### PR TITLE
Small fixes

### DIFF
--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -31,6 +31,7 @@ DialogManager::DialogManager(World::WorldInstance& world) :
     m_ScriptDialogMananger = nullptr;
     m_ActiveSubtitleBox = nullptr;
     m_DialogActive = false;
+    m_Talking = false;
 }
 
 DialogManager::~DialogManager()
@@ -370,11 +371,13 @@ void DialogManager::displaySubtitle(const std::string& subtitle, const std::stri
 {
     m_ActiveSubtitleBox->setHidden(false);
     m_ActiveSubtitleBox->setText(self, subtitle);
+    m_Talking = true;
 }
 
 void DialogManager::stopDisplaySubtitle()
 {
     m_ActiveSubtitleBox->setHidden(true);
+    m_Talking = false;
 }
 
 void DialogManager::clearChoices()

--- a/src/logic/DialogManager.h
+++ b/src/logic/DialogManager.h
@@ -78,6 +78,11 @@ namespace Logic
          */
         bool isDialogActive() { return m_DialogActive; }
 
+	/**
+         * @return Whether a someone is currently talking
+         */
+        bool isTalking() { return m_Talking; }
+
         /**
          * Removes all choices currently in the dialogbox
          */
@@ -179,5 +184,10 @@ namespace Logic
          * Whether a dialog is currently active
          */
         bool m_DialogActive;
+
+	/**
+         * Whether a subtitlebox is currently shown
+         */
+        bool m_Talking;
     };
 }

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1973,17 +1973,21 @@ void PlayerController::setupKeyBindings()
         m_MoveSpeed2 = m_MoveSpeed2 || triggered;
     });
 
+    Engine::Input::RegisterAction(Engine::ActionType::UI_Close, [this](bool triggered, float intensity) {
+        s_action_triggered = false;
+
+        if (triggered)
+            s_action_triggered = true; // Set true for one frame
+    });
+
     Engine::Input::RegisterAction(Engine::ActionType::PlayerAction, [this](bool triggered, float intensity) {
         static bool s_triggered = false;
-
-        s_action_triggered = false;
 
         if (s_triggered && !triggered)
             s_triggered = false;
         else if (!s_triggered && triggered)
         {
             s_triggered = true;
-            s_action_triggered = true; // Set true for one frame
 
             if(m_World.getDialogManager().isDialogActive())
                 return;

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -142,8 +142,11 @@ void UI::Hud::onInputAction(UI::EInputAction action)
     if(!m_MenuChain.empty())
     {
         m_MenuChain.back()->onInputAction(action);
+        return;
     }else if(!m_pDialogBox->isHidden()){
-        m_pDialogBox->onInputAction(action);
+        if(action != IA_Close) // IA_Close would automatically quit the dialog
+            m_pDialogBox->onInputAction(action);
+        return;
     }
     
     // Close console or last menu, in case it's open

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -138,6 +138,9 @@ void UI::Hud::setTimeOfDay(const std::string& timeStr)
 
 void UI::Hud::onInputAction(UI::EInputAction action)
 {
+    // Don't you know it's rude to open a menu while talking to somebody?
+    if(m_Engine.getMainWorld().get().getDialogManager().isTalking()) return;
+
     // Notify last menu in chain
     if(!m_MenuChain.empty())
     {


### PR DESCRIPTION
I tried to read through the code-base a bit and fix some tiny issues along the way.
- pressing ESC in the main-menu was closing the menu but instantly spawning a new main-menu right after - now it only closes the existing menu
- regardless which option in a dialogue was highlighted, ESC would instantly end the dialogue
- menus can no longer be opened during a dialogue
- use ESC instead of Ctrl to advance a dialogue

I have a few questions regarding my changes though:
- Did Ctrl & ESC advance the dialog in vanilla gothic? As far as I can remember only ESC was used to jump through dialogues quickly
- will displaySubtitle() and stopDisplaySubtitle() also be called as soon as there is an option to disable subtitles in the game and will the setting be handled inside these functions? If not I have to come up with something new ^^