### PR TITLE
More small fixes

### DIFF
--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1888,7 +1888,7 @@ void PlayerController::setupKeyBindings()
 
     Engine::Input::RegisterAction(Engine::ActionType::OpenStatusMenu, [this](bool triggered, float) {
 
-        if(triggered)
+        if(triggered && !m_World.getDialogManager().isDialogActive())
         {
             UI::Hud &hud = m_World.getEngine()->getHud();
             if (!hud.isTopMenu<UI::Menu_Status>())

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -774,7 +774,7 @@ public:
             {
                 if (m_stopWatch.getTimeDiffFromStartToNow() > 400)
                 {
-                    if (m_stopWatch.DelayedByArgMS(150))
+                    if (m_stopWatch.DelayedByArgMS(150) && keyMap.find(i) != keyMap.end())
                     {
                         m_pEngine->getHud().onInputAction(keyMap[i]);
                     }

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -142,7 +142,7 @@ void UI::Hud::onInputAction(UI::EInputAction action)
     if(m_Engine.getMainWorld().get().getDialogManager().isTalking()) return;
 
     // Notify last menu in chain
-    if(!m_MenuChain.empty())
+    if(!m_MenuChain.empty() && action != IA_Close)
     {
         m_MenuChain.back()->onInputAction(action);
         return;


### PR DESCRIPTION
Every key was triggering UI::IA_Up. This means every key could be used to move up the choices in a dialogue-box.
Also the stat-screen could be shown even during dialogues.