### PR TITLE
Configfiles

### DIFF
--- a/src/content/Sky.cpp
+++ b/src/content/Sky.cpp
@@ -26,7 +26,7 @@ const float TIME_KEY_7	= 0.75f;
 
 namespace Flags
 {
-    Cli::Flag skyType("s", "sky", 1, "Selects the sky to render. Possible options: g1, g2");
+    Cli::Flag skyType("s", "sky", 1, "Selects the sky to render. Possible options: auto, g1, g2", {"auto"}, "Game");
 }
 
 Sky::Sky(World::WorldInstance& world) :
@@ -145,7 +145,7 @@ void Sky::initSkyState(World::WorldInstance& world, ESkyPresetType type, Sky::Sk
 
     Math::float3 skyColor = skyColor_g2;
 
-    if(!Flags::skyType.isSet())
+    if(Flags::skyType.getArgs().empty() || Flags::skyType.getArgs()[0] == "auto")
     {
         if (world.getBasicGameType() == World::GT_Gothic2)
             skyColor = skyColor_g2;

--- a/src/content/Sky.cpp
+++ b/src/content/Sky.cpp
@@ -145,20 +145,24 @@ void Sky::initSkyState(World::WorldInstance& world, ESkyPresetType type, Sky::Sk
 
     Math::float3 skyColor = skyColor_g2;
 
-    if(Flags::skyType.getArgs().empty() || Flags::skyType.getArgs()[0] == "auto")
+    if(Flags::skyType.isSet())
     {
-        if (world.getBasicGameType() == World::GT_Gothic2)
-            skyColor = skyColor_g2;
-        else
-            skyColor = skyColor_g1;
-    } else
-    {
-        if(Flags::skyType.getArgs()[0] == "g1")
-            skyColor = skyColor_g1;
-        else if(Flags::skyType.getArgs()[0] == "g2")
-            skyColor = skyColor_g2;
-        else
-            LogWarn() << "Invalid sky-type supplied on commandline: " << Flags::skyType.getArgs()[0];
+        if (Flags::skyType.getArgs(0).empty()
+            || Flags::skyType.getArgs(0) == "auto")
+        {
+            if (world.getBasicGameType() == World::GT_Gothic2)
+                skyColor = skyColor_g2;
+            else
+                skyColor = skyColor_g1;
+        } else
+        {
+            if (Flags::skyType.getArgs(0) == "g1")
+                skyColor = skyColor_g1;
+            else if (Flags::skyType.getArgs(0) == "g2")
+                skyColor = skyColor_g2;
+            else
+                LogWarn() << "Invalid sky-type supplied on commandline: " << Flags::skyType.getArgs(0);
+        }
     }
 
     switch(type)

--- a/src/content/Sky.cpp
+++ b/src/content/Sky.cpp
@@ -147,8 +147,8 @@ void Sky::initSkyState(World::WorldInstance& world, ESkyPresetType type, Sky::Sk
 
     if(Flags::skyType.isSet())
     {
-        if (Flags::skyType.getArgs(0).empty()
-            || Flags::skyType.getArgs(0) == "auto")
+        if (Flags::skyType.getParam(0).empty()
+            || Flags::skyType.getParam(0) == "auto")
         {
             if (world.getBasicGameType() == World::GT_Gothic2)
                 skyColor = skyColor_g2;
@@ -156,12 +156,12 @@ void Sky::initSkyState(World::WorldInstance& world, ESkyPresetType type, Sky::Sk
                 skyColor = skyColor_g1;
         } else
         {
-            if (Flags::skyType.getArgs(0) == "g1")
+            if (Flags::skyType.getParam(0) == "g1")
                 skyColor = skyColor_g1;
-            else if (Flags::skyType.getArgs(0) == "g2")
+            else if (Flags::skyType.getParam(0) == "g2")
                 skyColor = skyColor_g2;
             else
-                LogWarn() << "Invalid sky-type supplied on commandline: " << Flags::skyType.getArgs(0);
+                LogWarn() << "Invalid sky-type supplied on commandline: " << Flags::skyType.getParam(0);
         }
     }
 

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -50,16 +50,16 @@ void BaseEngine::initEngine(int argc, char** argv)
     m_Args.gameBaseDirectory = ".";
     //m_Args.startupZEN = "addonworld.zen";
 
-    if(!Flags::gameDirectory.getArgs().empty())
-        m_Args.gameBaseDirectory = Flags::gameDirectory.getArgs()[0];
+    if(Flags::gameDirectory.isSet())
+        m_Args.gameBaseDirectory = Flags::gameDirectory.getArgs(0);
     else
         LogInfo() << "No game-root specified! Using the current working-directory as game root. Use the '-g' flag to specify this!";
 
     if(Flags::modFile.isSet())
-        m_Args.modfile = Flags::modFile.getArgs()[0];
+        m_Args.modfile = Flags::modFile.getArgs(0);
 
     if(Flags::world.isSet())
-        m_Args.startupZEN = Flags::world.getArgs()[0];
+        m_Args.startupZEN = Flags::world.getArgs(0);
 
 
     loadArchives();
@@ -77,7 +77,7 @@ void BaseEngine::initEngine(int argc, char** argv)
 
     std::string snd_device;
     if(Flags::sndDevice.isSet())
-        snd_device = Flags::sndDevice.getArgs()[0];
+        snd_device = Flags::sndDevice.getArgs(0);
 
     m_AudioEngine = new Audio::AudioEngine(snd_device);
 

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -20,10 +20,10 @@ using namespace Engine;
 
 namespace Flags
 {
-    Cli::Flag gameDirectory("g", "game-dir", 1, "Root-folder of your Gothic installation");
-    Cli::Flag modFile("m", "mod-file", 1, "Additional .mod-file to load");
-    Cli::Flag world("w", "world", 1, ".ZEN-file to load out of one of the vdf-archives");
-    Cli::Flag sndDevice("snd", "sound-device", 1, "OpenAL sound device");
+    Cli::Flag gameDirectory("g", "game-dir", 1, "Root-folder of your Gothic installation", {"."}, "Data");
+    Cli::Flag modFile("m", "mod-file", 1, "Additional .mod-file to load", {""}, "Data");
+    Cli::Flag world("w", "world", 1, ".ZEN-file to load out of one of the vdf-archives", {""}, "Data");
+    Cli::Flag sndDevice("snd", "sound-device", 1, "OpenAL sound device", {""}, "Sound");
 }
 
 BaseEngine::BaseEngine() : m_RootUIView(*this)
@@ -50,7 +50,7 @@ void BaseEngine::initEngine(int argc, char** argv)
     m_Args.gameBaseDirectory = ".";
     //m_Args.startupZEN = "addonworld.zen";
 
-    if(Flags::gameDirectory.isSet())
+    if(!Flags::gameDirectory.getArgs().empty())
         m_Args.gameBaseDirectory = Flags::gameDirectory.getArgs()[0];
     else
         LogInfo() << "No game-root specified! Using the current working-directory as game root. Use the '-g' flag to specify this!";

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -51,15 +51,15 @@ void BaseEngine::initEngine(int argc, char** argv)
     //m_Args.startupZEN = "addonworld.zen";
 
     if(Flags::gameDirectory.isSet())
-        m_Args.gameBaseDirectory = Flags::gameDirectory.getArgs(0);
+        m_Args.gameBaseDirectory = Flags::gameDirectory.getParam(0);
     else
         LogInfo() << "No game-root specified! Using the current working-directory as game root. Use the '-g' flag to specify this!";
 
     if(Flags::modFile.isSet())
-        m_Args.modfile = Flags::modFile.getArgs(0);
+        m_Args.modfile = Flags::modFile.getParam(0);
 
     if(Flags::world.isSet())
-        m_Args.startupZEN = Flags::world.getArgs(0);
+        m_Args.startupZEN = Flags::world.getParam(0);
 
 
     loadArchives();
@@ -77,7 +77,7 @@ void BaseEngine::initEngine(int argc, char** argv)
 
     std::string snd_device;
     if(Flags::sndDevice.isSet())
-        snd_device = Flags::sndDevice.getArgs(0);
+        snd_device = Flags::sndDevice.getParam(0);
 
     m_AudioEngine = new Audio::AudioEngine(snd_device);
 

--- a/src/engine/Input.cpp
+++ b/src/engine/Input.cpp
@@ -111,6 +111,9 @@ void Input::bindMouseAxis(MouseAxis mouseAxis, ActionType actionType, bool isCon
 
 void Input::keyEvent(int key, int scancode, int action, int mods)
 {
+	if(key < 0 || key > Input::NUM_KEYS)
+		return;
+
     if(KEY_ACTION_PRESS == action)
     {
         keyState[key] = true;

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -11,8 +11,12 @@ using namespace Engine;
 void ensureSavegameFolders(int idx)
 {
     std::string userdata = Utils::getUserDataLocation();
-    Utils::mkdir(userdata);
-    Utils::mkdir(SavegameManager::buildSavegamePath(idx));
+
+	if(!Utils::mkdir(userdata))
+		LogError() << "Failed to create userdata-directory at: " << userdata;
+
+    if(Utils::mkdir(SavegameManager::buildSavegamePath(idx)))
+		LogError() << "Failed to create savegame-directory at: " << SavegameManager::buildSavegamePath(idx);
 }
 
 std::string SavegameManager::buildSavegamePath(int idx)

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -914,6 +914,10 @@ int main(int argc, char** argv)
 {
     int ret = 0;
 
+    // Load config values for flags
+    Cli::loadConfigFile();
+
+    // Overwrite flags set from config using the commandline
     Cli::setCommandlineArgs(argc, argv);
 
     // Check if the user just wanted to see the list of commands
@@ -945,6 +949,9 @@ int main(int argc, char** argv)
         std::cerr << "Caught unknown exception in main loop" << std::endl;
         ret = 1;
     }
+
+    // Write current config-values
+    Cli::writeConfigFile();
 
     return ret;
 }

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -51,7 +51,7 @@ using json = nlohmann::json;
 namespace Flags
 {
     Cli::Flag help("h", "help", 0, "Prints this message");
-    Cli::Flag vsync("vsync", "vertical-sync", 0, "Enables vertical sync");
+    Cli::Flag vsync("vsync", "vertical-sync", 0, "Enables vertical sync", {"0"}, "Rendering");
 }
 
 struct PosColorVertex

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -322,7 +322,7 @@ bool Utils::mkdir(const std::string& dir)
     mode_t nMode = 0733; // UNIX style permissions
     nError = ::mkdir(dir.c_str(),nMode); // can be used on non-Windows
 #endif
-	return nError == 0;
+	return nError == 0 || (nError == -1 && errno == EEXIST);
 }
     
 std::string Utils::getUserDataLocation()

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -371,6 +371,22 @@ bool ::Utils::writeFile(const std::string& name, const std::string& path, const 
     return true;
 }
 
+bool ::Utils::writeFile(const std::string& name, const std::string& path, const std::string& text)
+{
+    std::string sep = (path.back() == '/' || path.back() == '\\') ? "" : "/";
+    std::string target = path + sep + name;
+
+    std::ofstream s(target);
+
+    if(!s.good())
+        return false;
+
+    s << text;
+
+    return true;
+}
+
+
 std::string Utils::stripFilePath(const std::string& file)
 {
     if(file.find_last_of("\\/") == std::string::npos)

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -394,3 +394,21 @@ std::string Utils::stripFilePath(const std::string& file)
 
     return file.substr(file.find_last_of("\\/") + 1);
 }
+
+std::string Utils::stripJsonComments(const std::string& json, const std::string& commentStart)
+{
+    // Split into lines
+    std::vector<std::string> lines = Utils::split(json, '\n');
+
+    std::string r;
+    for(std::string& l : lines)
+    {
+        // Find a // and cut it off there
+        l = l.substr(0, l.find(commentStart));
+
+        r += l + "\n";
+    }
+
+    return r;
+}
+

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -19,7 +19,7 @@
 #include <Shlobj.h>
 #endif
 
-const std::string USERDATA_FOLDER = ".REGoth";
+const std::string USERDATA_FOLDER = "REGoth";
 
 static bx::FileReaderI* fileReader = nullptr;
 static bx::FileWriterI* fileWriter = nullptr;
@@ -340,9 +340,9 @@ std::string Utils::getUserDataLocation()
     struct passwd *pw = getpwuid(getuid());
 
     const char *homedir = pw->pw_dir;
-    return std::string(homedir) + "/" + USERDATA_FOLDER;
+    return std::string(homedir) + "/." + USERDATA_FOLDER;
 #else
-    return "./" + USERDATA_FOLDER;
+    return "./." + USERDATA_FOLDER;
 #endif
 }
 

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -24,6 +24,14 @@ namespace Utils
     };
 
     /**
+     * Strips all text starting with commentStart from the given text
+     * @param json Json-text to modify
+     * @param commentStart String which starts a comment
+     * @return json-string without said comments
+     */
+    std::string stripJsonComments(const std::string& json, const std::string& commentStart = "#");
+
+    /**
      * Checks on which side of the plane the given point is.
      * @param point Point to check
      * @param plane Plane to check against

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -310,6 +310,7 @@ namespace Utils
      * @return Whether the file could be written
      */
     bool writeFile(const std::string& name, const std::string& path, const std::vector<uint8_t>& data);
+    bool writeFile(const std::string& name, const std::string& path, const std::string& text);
 
     /**
      * Reads the whole contents of a text-file into a buffer 

--- a/src/utils/cli.cpp
+++ b/src/utils/cli.cpp
@@ -4,9 +4,14 @@
 #include <iostream>
 #include <stdlib.h>
 #include "cli.h"
+#include "Utils.h"
 #include <iomanip>
+#include <ZenLib/utils/logger.h>
 
 using namespace Cli;
+
+const std::string CONFIG_FILE = "config.json";
+const int JSON_DUMP_INDENTATION = 4; // How many spaces to make the json pretty
 
 namespace Global
 {
@@ -25,17 +30,28 @@ namespace Global
     std::vector<std::string> commandline;
 }
 
-Flag::Flag(const std::string& flag, const std::string& verboseFlag, int nparams, const std::string& desc)
-        : m_Flag(flag), m_VerboseFlag(verboseFlag), m_nParams(nparams), m_Desc(desc)
+Flag::Flag(const std::string& flag,
+           const std::string& verboseFlag,
+           int nparams,
+           const std::string& desc,
+           const std::vector<std::string>& defaultValues,
+           std::string configSection)
+        : m_Flag(flag),
+          m_VerboseFlag(verboseFlag),
+          m_nParams(nparams),
+          m_Desc(desc),
+          m_DefaultValues(defaultValues),
+          m_ParsedArgs(defaultValues), // Initialize with default values
+          m_ConfigSection(configSection)
 {
     if(!flag.empty())
     {
-        assert(!flag.find_first_not_of(' ') != std::string::npos);
+        assert(flag.find_first_not_of(' ') != std::string::npos);
     }
 
     if(!verboseFlag.empty())
     {
-        assert(!flag.find_first_not_of(' ') != std::string::npos);
+        assert(verboseFlag.find_first_not_of(' ') != std::string::npos);
     }
 
     // Add this flag to the global list
@@ -105,6 +121,88 @@ void Flag::printUsage()
     std::cout << std::left << (m_nParams > 1 ? ("[" + std::to_string(m_nParams) + " args] ") : "") << m_Desc << std::endl;
 }
 
+void Flag::readFromConfig(const json& contents)
+{
+    // Choose the verbose version over the smaller one
+    std::string flag = m_VerboseFlag.empty() ? m_Flag : m_VerboseFlag;
+
+    if(contents.find(m_ConfigSection) == contents.end()
+       || contents[m_ConfigSection].find(flag) == contents[m_ConfigSection].end())
+    {
+        // It's not there, use the default
+        m_ParsedArgs = m_DefaultValues;
+        return;
+    }
+
+    const json& jf = contents[m_ConfigSection][flag];
+
+    LogInfo() << "Reading Flag '" << flag << " = " << jf.dump() << "' from config";
+
+    // Flags can be either arrays or single entries
+    if(!jf.is_array())
+    {
+        m_ParsedArgs.clear();
+        m_ParsedArgs.push_back(contents[m_ConfigSection][flag]);
+    } else
+    {
+        m_ParsedArgs = contents[m_ConfigSection][flag].get<std::vector<std::string>>();
+    }
+}
+
+void Flag::writeToConfig(json& conf)
+{
+    // Choose the verbose version over the smaller one
+    std::string flag = m_VerboseFlag.empty() ? m_Flag : m_VerboseFlag;
+
+    if(m_DefaultValues.empty() || m_ConfigSection.empty())
+        return; // Don't write these into the config, they don't want to be there
+
+    if(conf.find(m_ConfigSection) == conf.end())
+        conf[m_ConfigSection] = json::object();
+
+
+    if(m_nParams == 0)
+        conf[m_ConfigSection][flag] = isSet();
+    else if(m_nParams == 1)
+        conf[m_ConfigSection][flag] = m_ParsedArgs[0];
+    else
+        conf[m_ConfigSection][flag] = m_ParsedArgs;
+}
+
+std::string Flag::documentConfigText(const std::string& configText)
+{
+    std::vector<std::string> lines = Utils::split(configText, '\n');
+    std::vector<std::string> docLines = Utils::split(m_Desc, '\n');
+    std::vector<std::string> actualLines;
+    std::string flag = m_VerboseFlag.empty() ? m_Flag : m_VerboseFlag;
+
+    // Find a line with our flag
+    for(size_t i=0; i<lines.size(); i++)
+    {
+        if(lines[i].find("\"" + flag + "\": ") != std::string::npos)
+        {
+            // This is our line! Add our desc above it
+            for(const std::string& d : docLines)
+            {
+                // Indent and prefix with #
+                std::string c = "\n"; // Add one free line between the comment and the previous line
+                c.insert(1, JSON_DUMP_INDENTATION * 2, ' '); // 2 indents because of section
+                c += "# " + d;
+                actualLines.push_back(c);
+            }
+        }
+
+        actualLines.push_back(lines[i]);
+    }
+
+    // Merge lines to text again
+    std::string r;
+    for(const std::string& l : actualLines)
+        r += l + "\n";
+
+    return r;
+}
+
 void ::Cli::setCommandlineArgs(int argc, char** argv)
 {
     for(int i = 0; i < argc; i++)
@@ -123,4 +221,50 @@ void ::Cli::printHelp()
     {
         f->printUsage();
     }
+}
+
+void ::Cli::loadConfigFile()
+{
+    std::string conf = Utils::getUserDataLocation() + "/" + CONFIG_FILE;
+
+    // Have we even written one yet?
+    if(Utils::fileExists(conf))
+    {
+        std::string contents = Utils::readFileContents(conf);
+
+        // Strip all comments since the json-parser doesn't support them
+        std::string cleaned = Utils::stripJsonComments(contents);
+
+        if(cleaned.empty())
+            return; // Guess that's not valid
+
+        json j = json::parse(cleaned);
+
+        for (Flag* f : Global::getFlagList())
+            f->readFromConfig(j);
+    }
+}
+
+void ::Cli::writeConfigFile()
+{
+    json j = json::object();
+
+    // Write each flag
+    for (Flag* f : Global::getFlagList())
+        f->writeToConfig(j);
+
+    // Dump using specified indentation. This is important for comments, since they use the same indentation!
+    std::string dumped = j.dump(JSON_DUMP_INDENTATION);
+
+    // Another pass, to insert the comments
+    for (Flag* f : Global::getFlagList())
+        dumped = f->documentConfigText(dumped);
+
+    // Write that one to disk now. Ensure the userdata-folder exists first, though
+    std::string userdata = Utils::getUserDataLocation();
+    Utils::mkdir(userdata);
+
+    // Now create the file
+    if(!Utils::writeFile("config.json", userdata, dumped))
+        LogError() << "Failed to write config-file to: " << userdata << "/config.json";
 }

--- a/src/utils/cli.cpp
+++ b/src/utils/cli.cpp
@@ -285,7 +285,8 @@ void ::Cli::writeConfigFile()
 
     // Write that one to disk now. Ensure the userdata-folder exists first, though
     std::string userdata = Utils::getUserDataLocation();
-    Utils::mkdir(userdata);
+	if(!Utils::mkdir(userdata))
+		LogError() << "Failed to create userdata-directory at: " << userdata;
 
     // Now create the file
     if(!Utils::writeFile("config.json", userdata, dumped))

--- a/src/utils/cli.cpp
+++ b/src/utils/cli.cpp
@@ -218,7 +218,7 @@ std::string Flag::documentConfigText(const std::string& configText)
     return r;
 }
 
-const std::string& Flag::getArgs(size_t i)
+const std::string& Flag::getParam(unsigned i)
 {
     if(i >= m_ParsedArgs.size())
         return "";

--- a/src/utils/cli.h
+++ b/src/utils/cli.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <json.hpp>
+
+using json = nlohmann::json;
 
 /**
  * Simple interface to commandline flags and options
@@ -20,8 +23,16 @@ namespace Cli
          * @param verboseFlag Verbose version of the short-flag given beforehand, with eg. "./app --do-foo",
          *             this would have to be "do-foo".
          * @param nparams number of parameters of the flag
+         * @param defaultValue default values of this flag
+         * @param Config section this would end up. Note that a flag only gets put into the config if this is *not*
+         *        an empty string!
          */
-        Flag(const std::string& flag, const std::string& verboseFlag = "", int nparams = 0, const std::string& desc = "");
+        Flag(const std::string& flag,
+             const std::string& verboseFlag = "",
+             int nparams = 0,
+             const std::string& desc = "",
+             const std::vector<std::string>& defaultValues = std::vector<std::string>(),
+             std::string configSection = "");
 
         /**
          * @return Whether this flag was given on the commandline
@@ -43,11 +54,31 @@ namespace Cli
          * @return Arguments specified on the commandline of this flag
          */
         std::vector<std::string> getArgs(){ return m_ParsedArgs; }
+
+        /**
+         * Reads this flag from the config file. Will update m_ParsedArgs accordingly
+         * @param contents Actual contents of the config file
+         */
+        void readFromConfig(const json& contents);
+
+        /**
+         * Writes this flag to it's section in the config-file
+         * @param conf root node of the configs json data
+         */
+        void writeToConfig(json& conf);
+
+        /**
+         * Tries to put the desc-string into a done json-document, above this variable
+         * @param configText Dumped json-text
+         */
+        std::string documentConfigText(const std::string& configText);
     private:
 
         std::string m_Flag;
         std::string m_VerboseFlag;
         std::string m_Desc;
+        std::vector<std::string> m_DefaultValues;
+        std::string m_ConfigSection;
         int m_nParams;
 
         /**
@@ -68,4 +99,14 @@ namespace Cli
      * Prints a list of all available flags and their usage
      */
     void printHelp();
+
+    /**
+     * Loads the config-file and updates all flags accordingly
+     */
+    void loadConfigFile();
+
+    /**
+     * Writes flags currently set to config file
+     */
+    void writeConfigFile();
 }

--- a/src/utils/cli.h
+++ b/src/utils/cli.h
@@ -54,7 +54,7 @@ namespace Cli
          * @param Index of the argument to get
          * @return Arguments specified on the commandline of this flag. Empty string if invalid index.
          */
-        const std::string& getArgs(size_t i);
+        const std::string& getParam(unsigned i);
 
         /**
          * Reads this flag from the config file. Will update m_ParsedArgs accordingly

--- a/src/utils/cli.h
+++ b/src/utils/cli.h
@@ -23,13 +23,13 @@ namespace Cli
          * @param verboseFlag Verbose version of the short-flag given beforehand, with eg. "./app --do-foo",
          *             this would have to be "do-foo".
          * @param nparams number of parameters of the flag
-         * @param defaultValue default values of this flag
+         * @param defaultValue default values of this flag. For booleans (nparams==0), a "0" or "1" is used.
          * @param Config section this would end up. Note that a flag only gets put into the config if this is *not*
          *        an empty string!
          */
         Flag(const std::string& flag,
              const std::string& verboseFlag = "",
-             int nparams = 0,
+             unsigned nparams = 0,
              const std::string& desc = "",
              const std::vector<std::string>& defaultValues = std::vector<std::string>(),
              std::string configSection = "");
@@ -51,9 +51,10 @@ namespace Cli
         std::vector<std::string> extractFlag();
 
         /**
-         * @return Arguments specified on the commandline of this flag
+         * @param Index of the argument to get
+         * @return Arguments specified on the commandline of this flag. Empty string if invalid index.
          */
-        std::vector<std::string> getArgs(){ return m_ParsedArgs; }
+        const std::string& getArgs(size_t i);
 
         /**
          * Reads this flag from the config file. Will update m_ParsedArgs accordingly
@@ -79,7 +80,7 @@ namespace Cli
         std::string m_Desc;
         std::vector<std::string> m_DefaultValues;
         std::string m_ConfigSection;
-        int m_nParams;
+        unsigned m_nParams;
 
         /**
          * Location this flag is in the argv-array. If this is not 0, the flag is set!

--- a/src/utils/zTools.cpp
+++ b/src/utils/zTools.cpp
@@ -13,8 +13,8 @@ namespace Flags
 
 void unpackVdf()
 {
-    std::string vdf = Flags::unpackVdf.getArgs()[0];
-    std::string target = Flags::unpackVdf.getArgs()[1];
+    std::string vdf = Flags::unpackVdf.getArgs(0);
+    std::string target = Flags::unpackVdf.getArgs(1);
 
     std::string vdfname = Utils::stripFilePath(Utils::stripExtension(vdf));
     target = target + "/" + vdfname;

--- a/src/utils/zTools.cpp
+++ b/src/utils/zTools.cpp
@@ -13,8 +13,8 @@ namespace Flags
 
 void unpackVdf()
 {
-    std::string vdf = Flags::unpackVdf.getArgs(0);
-    std::string target = Flags::unpackVdf.getArgs(1);
+    std::string vdf = Flags::unpackVdf.getParam(0);
+    std::string target = Flags::unpackVdf.getParam(1);
 
     std::string vdfname = Utils::stripFilePath(Utils::stripExtension(vdf));
     target = target + "/" + vdfname;


### PR DESCRIPTION
Cli-flags can now be written to a config file. Currently, specifying an option on the CL has higher priority than the one in the config-file. 

If you want a flag to appear inside the config-file, you need to specify a default value and the regarding config-section. These have been added to the constructor of `Cli::Flag`.

Config-files are saved with the current settings from the CL-args at the end of `main`, so, when you close the game manually.