### PR TITLE
Added Console command tp <npc name>. Improved name matching for kill/knockout/tp

### DIFF
--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -167,6 +167,14 @@ namespace Logic
         void setDirection(const Math::float3& direction);
 
         /**
+         * @return The direction the player is facing
+         */
+        Math::float3 getDirection()
+        {
+            return m_MoveState.direction;
+        }
+
+        /**
          * @return The inventory of this player
          */
         Inventory& getInventory()
@@ -376,7 +384,7 @@ namespace Logic
         Materials::MaterialGroup getSurfaceMaterial();
 
         /**
-         * Returns material data of give triangle index 
+         * Returns material data of give triangle index
          */
         Materials::MaterialGroup getMaterial(uint32_t triangleIdx);
         /**
@@ -588,7 +596,7 @@ namespace Logic
         size_t m_LastAniRootPosUpdatedAniHash;
 
         /**
-         * Contstants 
+         * Contstants
          */
         static constexpr float m_swimThreshold = 1.3;  // TODO Adjust the value to reflect original game experiece
         static constexpr float m_wadeThreshold = 0.5;  // TODO Adjust the value to reflect original game experiece

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -384,7 +384,7 @@ namespace Logic
         Materials::MaterialGroup getSurfaceMaterial();
 
         /**
-         * Returns material data of give triangle index
+         * Returns material data of give triangle index 
          */
         Materials::MaterialGroup getMaterial(uint32_t triangleIdx);
         /**
@@ -596,7 +596,7 @@ namespace Logic
         size_t m_LastAniRootPosUpdatedAniHash;
 
         /**
-         * Contstants
+         * Contstants 
          */
         static constexpr float m_swimThreshold = 1.3;  // TODO Adjust the value to reflect original game experiece
         static constexpr float m_wadeThreshold = 0.5;  // TODO Adjust the value to reflect original game experiece

--- a/src/logic/ScriptEngine.cpp
+++ b/src/logic/ScriptEngine.cpp
@@ -364,6 +364,9 @@ std::set<Handle::EntityHandle> ScriptEngine::findWorldNPCsNameLike(std::string n
     for(const Handle::EntityHandle& npc : getWorldNPCs())
     {
         VobTypes::NpcVobInformation npcVobInfo = VobTypes::asNpcVob(m_World, npc);
+        if (!npcVobInfo.isValid())
+            continue;
+
         Daedalus::GEngineClasses::C_Npc& npcScripObject = VobTypes::getScriptObject(npcVobInfo);
         std::string npcDisplayName = npcVobInfo.playerController->getScriptInstance().name[0];
         std::string npcDatFileName = datFile.getSymbolByIndex(npcScripObject.instanceSymbol).name;

--- a/src/logic/ScriptEngine.cpp
+++ b/src/logic/ScriptEngine.cpp
@@ -346,6 +346,40 @@ std::set<Handle::EntityHandle> ScriptEngine::getNPCsInRadius(const Math::float3 
     return outSet;
 }
 
+std::set<Handle::EntityHandle> ScriptEngine::findWorldNPCsNameLike(std::string namePart)
+{
+    std::set<Handle::EntityHandle> outSet;
+    auto& datFile = getVM().getDATFile();
+
+    auto strippedAndLowered = [](const std::string& in){
+        std::function<bool(char)> isNotAlNum = [](char c){ return std::isalnum(c) == 0;};
+        std::string out = in;
+        std::transform(out.begin(), out.end(), out.begin(), ::tolower);
+        out.erase(std::remove_if(out.begin(), out.end(), isNotAlNum), out.end());
+        return out;
+    };
+
+    std::string requestedLower = strippedAndLowered(namePart);
+
+    for(const Handle::EntityHandle& npc : getWorldNPCs())
+    {
+        VobTypes::NpcVobInformation npcVobInfo = VobTypes::asNpcVob(m_World, npc);
+        Daedalus::GEngineClasses::C_Npc& npcScripObject = VobTypes::getScriptObject(npcVobInfo);
+        std::string npcDisplayName = npcVobInfo.playerController->getScriptInstance().name[0];
+        std::string npcDatFileName = datFile.getSymbolByIndex(npcScripObject.instanceSymbol).name;
+
+        for (const auto& npcName : {npcDisplayName, npcDatFileName})
+        {
+            std::string npcNameLower = strippedAndLowered(npcName);
+            if (npcNameLower.find(requestedLower) != std::string::npos)
+            {
+                outSet.insert(npc);
+            }
+        }
+    }
+    return outSet;
+}
+
 void ScriptEngine::onLogEntryAdded(const std::string& topic, const std::string& entry)
 {
     m_World.getPrintScreenManager().printMessage("Topic: " + topic);

--- a/src/logic/ScriptEngine.h
+++ b/src/logic/ScriptEngine.h
@@ -129,8 +129,8 @@ namespace Logic
         const std::set<Handle::EntityHandle>& getWorldNPCs(){ return m_WorldNPCs; }
 
         /**
-         * Searches the current world for NPCs whose display-name or DATFile-name contain the given string
-         * comparison is case insensitive and strips off all non-alphanumeric characters first
+         * Searches the current world for NPCs whose display-name or DATFile-name contain the given string.
+         * Comparison is case insensitive and strips off all non-alphanumeric characters first
          * @param namePart full or partial name to be looked for
          * @return List of all NPCs whose names are similar to namePart
          */

--- a/src/logic/ScriptEngine.h
+++ b/src/logic/ScriptEngine.h
@@ -129,6 +129,14 @@ namespace Logic
         const std::set<Handle::EntityHandle>& getWorldNPCs(){ return m_WorldNPCs; }
 
         /**
+         * Searches the current world for NPCs whose display-name or DATFile-name contain the given string
+         * comparison is case insensitive and strips off all non-alphanumeric characters first
+         * @param namePart full or partial name to be looked for
+         * @return List of all NPCs whose names are similar to namePart
+         */
+        std::set<Handle::EntityHandle> findWorldNPCsNameLike(std::string namePart);
+
+        /**
          * Looks up the handle currently stored inside the given symbol. If it doesn't hold the right type or nothing
          * at all, an invalid handle is returned
          * @param symName Symbol to look up

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -374,7 +374,7 @@ public:
             return "Cameramode changed to " + std::to_string(idx);
         });
 
-
+            
         console.registerCommand("test", [](const std::vector<std::string>& args) -> std::string {
             return "Hello World!";
         });
@@ -501,7 +501,7 @@ public:
             using namespace Engine;
 
             int idx = std::stoi(args[1]);
-
+           
             if(!SavegameManager::isSavegameAvailable(idx))
                 return "Savegame in slot " + std::to_string(idx) + " no available!";
 
@@ -513,7 +513,7 @@ public:
             // Sanity check, if we really got a safe for this world. Otherwise we would end up in the fresh version
             // if it was missing. Also, IF the player saved there, there should be a save for this.
             if(!Utils::getFileSize(worldPath))
-                return "Target world invalid!";
+                return "Target world invalid!"; 
 
             clearActions();
             m_pEngine->removeWorld(m_pEngine->getMainWorld());
@@ -526,7 +526,7 @@ public:
                 return "Missing argument. Usage: save <savegame>";
 
             int idx = std::stoi(args[1]);
-
+    
             if(idx < 1)
                 return "Invalid index. Must be greater than 0!";
 
@@ -547,7 +547,7 @@ public:
             // Save
             Engine::SavegameManager::writeWorld(idx, info.world, Utils::iso_8859_1_to_utf8(j.dump(4)));
 
-            return "World saved to slot: " + std::to_string(idx);
+            return "World saved to slot: " + std::to_string(idx); 
         });
 
         console.registerCommand("knockout", [this](const std::vector<std::string>& args) -> std::string {

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -608,16 +608,16 @@ public:
             return "Experience points successfully given";
         });
 
-        console.registerCommand("tp", [this](const std::vector<std::string>& args) -> std::string {
-            if(args.size() < 2)
-                return "Missing argument(s). Usage: tp <npc name>";
+        console.registerCommand("goto npc", [this](const std::vector<std::string>& args) -> std::string {
+            if(args.size() < 3)
+                return "Missing argument(s). Usage: goto npc <name>";
 
             auto& worldInstance = m_pEngine->getMainWorld().get();
             auto& scriptEngine = worldInstance.getScriptEngine();
             auto& datFile = scriptEngine.getVM().getDATFile();
 
             std::stringstream joinedArgs;
-            for (auto it = args.begin() + 1; it != args.end(); ++it)
+            for (auto it = args.begin() + 2; it != args.end(); ++it)
             {
                 joinedArgs << *it;
             }


### PR DESCRIPTION
Added new console command `tp <npc name>`.
The Player will be teleported to the location of the target (if any match is found). The Player will be placed in front of the target and rotated to look towards it.

The npc name given is checked to be part of either the DisplayName or the DATFileName of all NPCs in the current World. The Comparison is case insensitive and all non alpha-numeric character are stripped of all strings beforehand.

Examples: 
- Diego (PC_THIEF); valid names: diego, dieg, iEgo, DIEGO

- Cor Kalom (GUR_1201_CORKALOM); valid names: cor kalom, orka, COR K, GUR1201, 1201cork

I have integrated this name matching also into `knockout` and kill `command`.
