### PR TITLE
Added Day support, Day display, external wld_getday

### DIFF
--- a/src/audio/AudioWorld.cpp
+++ b/src/audio/AudioWorld.cpp
@@ -165,6 +165,7 @@ namespace World
 
         // TODO: pitch?
         //alSourcef(source, AL_PITCH, snd.sfx.);
+        alSourcef(s.m_Handle, AL_PITCH, m_Engine.getGameEngineSpeedFactor());
         alSourcef(s.m_Handle, AL_GAIN, snd.sfx.vol / 127.0f);
         alSource3f(s.m_Handle, AL_POSITION, 0, 0, 0);
         alSource3f(s.m_Handle, AL_VELOCITY, 0, 0, 0);

--- a/src/content/Sky.cpp
+++ b/src/content/Sky.cpp
@@ -38,6 +38,8 @@ Sky::Sky(World::WorldInstance& world) :
 
     // Both games start at 8:00 in the morning
     setTimeOfDay(8,00);
+    // Start with day one
+    m_MasterState.day = 1;
 
     fillSkyStates();
 
@@ -99,8 +101,17 @@ void Sky::interpolate(double deltaTime)
 //    if(inputGetKeyState(entry::Key::KeyO))
 //        deltaTime *= 10.0;
 
-    m_MasterState.time += deltaTime / (60.0 * 60.0 * 24.0);
-    m_MasterState.time = fmod(m_MasterState.time, 1.0f);
+    // update time
+    float& oldTime = m_MasterState.time;
+    float newTime = oldTime + static_cast<float>(deltaTime) / (60 * 60 * 24);
+    m_MasterState.time = newTime;
+
+    // check for change of day
+    constexpr float midNight = 0.5;
+    if (oldTime < midNight && newTime >= midNight)
+    {
+        m_MasterState.day++;
+    }
 
     size_t si0 = 0, si1 = 1;
 
@@ -411,10 +422,11 @@ void Sky::getTimeOfDay(int& hours, int& minutes) const
     minutes = (int)((fh - hours) * 60.0f);
 }
 
-std::string Sky::getTimeOfDayFormated() const
+std::string Sky::getDateTimeFormatted() const
 {
     int h, m;
     getTimeOfDay(h, m);
-
-    return std::to_string(h) + ":" + (m < 10 ? "0" : "") + std::to_string(m);
+    std::string clockString = std::to_string(h) + ":" + (m < 10 ? "0" : "") + std::to_string(m);
+    std::string dayString = "Day " + std::to_string(m_MasterState.day);
+    return dayString + ", " + clockString;
 }

--- a/src/content/Sky.cpp
+++ b/src/content/Sky.cpp
@@ -78,13 +78,13 @@ void Sky::calculateLUT_ZenGin(const Math::float3& col0, const Math::float3& col1
     }
 }
 
-void Sky::interpolate(double gameTimeSeconds)
+void Sky::interpolate()
 {
     // time since 12:00 in days
-    double skyTime = std::fmod(gameTimeSeconds / (60 * 60 * 24) + 0.5, 1.0);
+    float skyTime = std::fmod(m_World.getWorldInfo().getTimeOfDay() + 0.5f, 1.0f);
 
     if(!m_World.getEngine()->getEngineArgs().cmdline.hasArg('d'))
-        m_MasterState.time = static_cast<float>(skyTime);
+        m_MasterState.time = skyTime;
 
     // init with values for case: time >= TIME_KEY_7 (= 0.75f)
     size_t si0 = ESPT_NUM_PRESETS - 1, si1 = 0;

--- a/src/content/Sky.cpp
+++ b/src/content/Sky.cpp
@@ -102,8 +102,8 @@ void Sky::interpolate(double deltaTime)
 //        deltaTime *= 10.0;
 
     // update time
-    float& oldTime = m_MasterState.time;
-    float newTime = oldTime + static_cast<float>(deltaTime) / (60 * 60 * 24);
+    float oldTime = m_MasterState.time;
+    float newTime = std::fmod(oldTime + static_cast<float>(deltaTime) / (60 * 60 * 24), 1.0f);
     m_MasterState.time = newTime;
 
     // check for change of day

--- a/src/content/Sky.h
+++ b/src/content/Sky.h
@@ -51,8 +51,8 @@ namespace Content
         struct SkyState
         {
             // Time when this state becomes active
+            // time in days since last 12:00
             float			time;
-            int             day;
 
             // Color values
             Math::float3	baseColor;
@@ -74,9 +74,9 @@ namespace Content
 
         /**
          * Updates the sky and the colors
-         * @param deltaTime Time since last frame
+         * @param gameTime in seconds
          */
-        void interpolate(double deltaTime);
+        void interpolate(double gameTime);
 
         /**
          * Initializes the given skystate to the given type
@@ -96,45 +96,6 @@ namespace Content
          * @return Pointer to the LUT
          */
         const Math::float4* getLUTPtr() const { return m_LUT; }
-
-        /**
-         * @return Day.
-         */
-        int getDay() const { return m_MasterState.day; }
-
-        /**
-         * @param sets the current day
-         */
-        void setDay(int newDay) { m_MasterState.day = newDay; }
-
-        /**
-         * @return Time of day.
-         */
-        float getTimeOfDay() const { return m_MasterState.time; }
-
-        /**
-         * @param t New time to set. Float value in range (0..1), where 0 is 12:00.
-         */
-        void setTimeOfDay(float t);
-
-        /**
-         * Set time to hours/minutes (24h format)
-         * @param hours
-         * @param minutes
-         */
-        void setTimeOfDay(int hours, int minutes);
-
-        /**
-         * Converts time to hours/minutes (24h format)
-         * @param hours
-         * @param minutes
-         */
-        void getTimeOfDay(int& hours, int& minutes) const;
-
-        /**
-         * @return Time of day as string
-         */
-        std::string getDateTimeFormatted() const;
 
         /**
          * @return current interpolated sky-state
@@ -183,11 +144,6 @@ namespace Content
          * World this sky belongs to
          */
         World::WorldInstance& m_World;
-
-        /**
-         * Debug only
-         */
-        float m_skySpeedMultiplier;
 
         /**
          * Global Farplane

--- a/src/content/Sky.h
+++ b/src/content/Sky.h
@@ -52,6 +52,7 @@ namespace Content
         {
             // Time when this state becomes active
             float			time;
+            int             day;
 
             // Color values
             Math::float3	baseColor;
@@ -97,6 +98,16 @@ namespace Content
         const Math::float4* getLUTPtr() const { return m_LUT; }
 
         /**
+         * @return Day.
+         */
+        int getDay() const { return m_MasterState.day; }
+
+        /**
+         * @param sets the current day
+         */
+        void setDay(int newDay) { m_MasterState.day = newDay; }
+
+        /**
          * @return Time of day.
          */
         float getTimeOfDay() const { return m_MasterState.time; }
@@ -109,21 +120,21 @@ namespace Content
         /**
          * Set time to hours/minutes (24h format)
          * @param hours
-         * @param minues
+         * @param minutes
          */
         void setTimeOfDay(int hours, int minutes);
 
         /**
          * Converts time to hours/minutes (24h format)
          * @param hours
-         * @param minues
+         * @param minutes
          */
         void getTimeOfDay(int& hours, int& minutes) const;
 
         /**
          * @return Time of day as string
          */
-        std::string getTimeOfDayFormated() const;
+        std::string getDateTimeFormatted() const;
 
         /**
          * @return current interpolated sky-state

--- a/src/content/Sky.h
+++ b/src/content/Sky.h
@@ -74,9 +74,8 @@ namespace Content
 
         /**
          * Updates the sky and the colors
-         * @param gameTime in seconds
          */
-        void interpolate(double gameTime);
+        void interpolate();
 
         /**
          * Initializes the given skystate to the given type

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -161,8 +161,7 @@ void BaseEngine::removeWorld(Handle::WorldHandle world)
 
 void BaseEngine::frameUpdate(double dt, uint16_t width, uint16_t height)
 {
-	onFrameUpdate(dt, width, height);
-
+	onFrameUpdate(dt * getGameEngineSpeedFactor(), width, height);
 }
 
 void BaseEngine::loadArchives()

--- a/src/engine/BaseEngine.h
+++ b/src/engine/BaseEngine.h
@@ -141,6 +141,25 @@ namespace Engine
          * @return Whether the operation was successful
          */
         bool saveWorld(Handle::WorldHandle world, const std::string& file);
+
+		/**
+         * sets the speed factor for EVERYTHING the game for updating world instances
+         * i.e. world (ergo animations), in game clock (ergo sky) even the camera
+         * only for fun / debug purpose (default = 1.0)
+         * @param factor
+         */
+		void setGameEngineSpeedFactor(float factor)
+		{
+			m_GameEngineSpeedFactor = factor;
+		}
+
+		/**
+         * @return m_GameEngineSpeedFactor
+         */
+		float getGameEngineSpeedFactor() const
+		{
+			return m_GameEngineSpeedFactor;
+		}
 	protected:
 
 		/**
@@ -203,5 +222,10 @@ namespace Engine
 		 * Folder where the content is
 		 */
 		std::string m_ContentBasePath;
+
+		/**
+         * Global speed factor. affects all instances (world (ergo animations), ingame clock (ergo sky))
+         */
+		float m_GameEngineSpeedFactor;
 	};
 }

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -73,7 +73,6 @@ void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
 //        lastLogicDisableKeyState = inputGetKeyState(entry::Key::Key2);
 //    }
 
-    dt *= getGameEngineSpeedFactor();
     if(m_disableLogic)
     {
         getMainCamera<Components::LogicComponent>().m_pLogicController->onUpdate(dt);

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -20,6 +20,7 @@ const float DRAW_DISTANCE = 100.0f;
 GameEngine::GameEngine() : m_DefaultRenderSystem(*this)
 {
     m_disableLogic = false;
+    m_GameEngineSpeedFactor = 1.0;
 }
 
 GameEngine::~GameEngine()
@@ -72,6 +73,7 @@ void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
 //        lastLogicDisableKeyState = inputGetKeyState(entry::Key::Key2);
 //    }
 
+    dt *= m_GameEngineSpeedFactor;
     if(m_disableLogic)
     {
         getMainCamera<Components::LogicComponent>().m_pLogicController->onUpdate(dt);

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -73,7 +73,7 @@ void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
 //        lastLogicDisableKeyState = inputGetKeyState(entry::Key::Key2);
 //    }
 
-    dt *= m_GameEngineSpeedFactor;
+    dt *= getGameEngineSpeedFactor();
     if(m_disableLogic)
     {
         getMainCamera<Components::LogicComponent>().m_pLogicController->onUpdate(dt);

--- a/src/engine/GameEngine.h
+++ b/src/engine/GameEngine.h
@@ -47,17 +47,6 @@ namespace Engine
         {
             return m_DefaultRenderSystem;
         }
-
-        /**
-         * sets the speed factor for EVERYTHING the game for updating world instances
-         * i.e. world (ergo animations), in game clock (ergo sky) even the camera
-         * only for fun / debug purpose (default = 1.0)
-         * @param factor
-         */
-        void setGameEngineSpeedFactor(float factor)
-        {
-            m_GameEngineSpeedFactor = factor;
-        }
     protected:
 
         /**
@@ -91,10 +80,5 @@ namespace Engine
          * Debug only
          */
         bool m_disableLogic;
-
-        /**
-         * Global speed factor. affects all instances (world (ergo animations), ingame clock (ergo sky))
-         */
-         float m_GameEngineSpeedFactor;
     };
 }

--- a/src/engine/GameEngine.h
+++ b/src/engine/GameEngine.h
@@ -47,6 +47,17 @@ namespace Engine
         {
             return m_DefaultRenderSystem;
         }
+
+        /**
+         * sets the speed factor for EVERYTHING the game for updating world instances
+         * i.e. world (ergo animations), in game clock (ergo sky) even the camera
+         * only for fun / debug purpose (default = 1.0)
+         * @param factor
+         */
+        void setGameEngineSpeedFactor(float factor)
+        {
+            m_GameEngineSpeedFactor = factor;
+        }
     protected:
 
         /**
@@ -80,5 +91,10 @@ namespace Engine
          * Debug only
          */
         bool m_disableLogic;
+
+        /**
+         * Global speed factor. affects all instances (world (ergo animations), ingame clock (ergo sky))
+         */
+         float m_GameEngineSpeedFactor;
     };
 }

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -480,7 +480,6 @@ void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, co
 {
     // Set frametime in worldinfo
     m_WorldInfo.lastFrameDeltaTime = deltaTime;
-    m_WorldInfo.time += deltaTime;
     m_WorldInfo.update(deltaTime);
 
     // Tell script engine the frame started
@@ -628,7 +627,7 @@ WorldInstance::getFreepointsInRange(const Math::float3& center, float distance, 
             Components::SpotComponent& sp = getEntity<Components::SpotComponent>(fp);
             Components::PositionComponent& pos = getEntity<Components::PositionComponent>(fp);
 
-            if((!sp.m_UsingEntity.isValid() || sp.m_UseEndTime < m_WorldInfo.time)
+            if((!sp.m_UsingEntity.isValid() || sp.m_UseEndTime < m_WorldInfo.getTime())
                && (!inst.isValid() || sp.m_UsingEntity != inst))
             {
 

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -35,7 +35,8 @@ WorldInstance::WorldInstance()
       m_BspTree(*this),
       m_PfxManager(*this)
 {
-
+    // Both games start at 8:00 in the morning
+    m_WorldInfo.setTimeOfDay(8, 00);
 }
 
 WorldInstance::~WorldInstance()
@@ -480,6 +481,8 @@ void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, co
     // Set frametime in worldinfo
     m_WorldInfo.lastFrameDeltaTime = deltaTime;
     m_WorldInfo.time += deltaTime;
+    double deltaGameTime = deltaTime * m_WorldInfo.totalSpeedUp();
+    m_WorldInfo.gameTime += deltaGameTime;
 
     // Tell script engine the frame started
     m_ScriptEngine.onFrameStart();
@@ -488,7 +491,7 @@ void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, co
     m_PhysicsSystem.update(deltaTime);
 
     // Update sky
-    m_Sky.interpolate(deltaTime);
+    m_Sky.interpolate(m_WorldInfo.gameTime);
 
     size_t num = getComponentAllocator().getNumObtainedElements();
     const auto& ctuple = getComponentDataBundle().m_Data;
@@ -553,7 +556,7 @@ void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, co
     m_ScriptEngine.onFrameEnd();
 
     // Update hud
-    m_pEngine->getHud().setDateTimeDisplay(m_Sky.getDateTimeFormatted());
+    m_pEngine->getHud().setDateTimeDisplay(m_WorldInfo.getDateTimeFormatted());
 
     m_BspTree.debugDraw();
 }

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -481,8 +481,7 @@ void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, co
     // Set frametime in worldinfo
     m_WorldInfo.lastFrameDeltaTime = deltaTime;
     m_WorldInfo.time += deltaTime;
-    double deltaGameTime = deltaTime * m_WorldInfo.totalSpeedUp();
-    m_WorldInfo.gameTime += deltaGameTime;
+    m_WorldInfo.update(deltaTime);
 
     // Tell script engine the frame started
     m_ScriptEngine.onFrameStart();
@@ -491,7 +490,7 @@ void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, co
     m_PhysicsSystem.update(deltaTime);
 
     // Update sky
-    m_Sky.interpolate(m_WorldInfo.gameTime);
+    m_Sky.interpolate();
 
     size_t num = getComponentAllocator().getNumObtainedElements();
     const auto& ctuple = getComponentDataBundle().m_Data;

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -553,7 +553,7 @@ void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, co
     m_ScriptEngine.onFrameEnd();
 
     // Update hud
-    m_pEngine->getHud().setTimeOfDay(m_Sky.getTimeOfDayFormated());
+    m_pEngine->getHud().setDateTimeDisplay(m_Sky.getDateTimeFormatted());
 
     m_BspTree.debugDraw();
 }

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -93,6 +93,9 @@ namespace World
                 // start at day 1, 8:00 o'clock
                 day = 1;
                 setTimeOfDay(8, 0);
+
+                // for test purpose make the clock run 7 times faster than usual gameplay
+                setClockSpeedFactor(7);
             }
 
             // Last deltatime-value we have gotten here
@@ -107,10 +110,10 @@ namespace World
             int day;
 
             // Defines how much faster the ingame clock runs compared to the real time clock
-            float gameTimeRealTimeRatio = 100;
+            float gameTimeRealTimeRatio = 14.5;
 
             // define an extra speedup for the ingame clock for test purposes
-            float gameTimeSpeedFactor = 1.0;
+            float clockSpeedFactor = 1.0;
 
             /**
              * @return current day
@@ -187,8 +190,8 @@ namespace World
             /**
              * sets the extra speed factor for test purposes
              */
-            void setGameTimeSpeedFactor(float factor){
-                gameTimeSpeedFactor = factor;
+            void setClockSpeedFactor(float factor){
+                clockSpeedFactor = factor;
             }
 
             /**
@@ -196,7 +199,7 @@ namespace World
              */
             float totalSpeedUp() const
             {
-                return gameTimeRealTimeRatio * gameTimeSpeedFactor;
+                return gameTimeRealTimeRatio * clockSpeedFactor;
             }
 
             /**

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -82,25 +82,21 @@ namespace World
     {
     public:
 
-		/**
-          * Information about the state of the world
-          */
-		struct WorldInfo
-		{
-			WorldInfo()
-			{
-				lastFrameDeltaTime = 0.0;
-                time = 0.0;
+        /**
+         * Information about the state of the world
+         */
+        struct WorldInfo
+        {
+            WorldInfo()
+            {
+                lastFrameDeltaTime = 0.0;
                 // start at day 1, 8:00 o'clock
                 day = 1;
                 setTimeOfDay(8, 0);
-			}
+            }
 
-			// Last deltatime-value we have gotten here
-			double lastFrameDeltaTime;
-
-			// real time in seconds, which the game is running in the current session
-			double time;
+            // Last deltatime-value we have gotten here
+            double lastFrameDeltaTime;
 
             // Time elapsed in the game since last 00:00 in days (interval [0,1[)
             // TODO export/import this value in json for savegames
@@ -110,10 +106,10 @@ namespace World
             // TODO export/import this value in json for savegames
             int day;
 
-            // Defines how much faster the gothic clock runs compared to the real time clock
+            // Defines how much faster the ingame clock runs compared to the real time clock
             float gameTimeRealTimeRatio = 100;
 
-            // define an extra speedup for test purposes
+            // define an extra speedup for the ingame clock for test purposes
             float gameTimeSpeedFactor = 1.0;
 
             /**
@@ -201,6 +197,13 @@ namespace World
             float totalSpeedUp() const
             {
                 return gameTimeRealTimeRatio * gameTimeSpeedFactor;
+            }
+
+            /**
+             * @return time in days since "new game" started
+             */
+            float getTime(){
+                return day + timeOfDay;
             }
 
             /**

--- a/src/logic/NpcScriptState.cpp
+++ b/src/logic/NpcScriptState.cpp
@@ -175,7 +175,7 @@ bool NpcScriptState::doAIState(float deltaTime)
     if(m_Routine.hasRoutine && isInRoutine())
     {
         int h, m;
-        m_World.getSky().getTimeOfDay(h, m);
+        m_World.getWorldInfo().getTimeOfDay(h, m);
 
         if(!m_Routine.routine[m_Routine.routineActiveIdx].timeInRange(h, m))
         {

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -590,6 +590,7 @@ namespace Logic
         /**
          * refuse talk countdown
          */
+        // TODO export/import this value in json for savegames
         float m_RefuseTalkTime;
 
         /**

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -750,7 +750,6 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
     });
 
     vm->registerExternalFunction("wld_istime", [=](Daedalus::DaedalusVM& vm){
-
         int32_t min2 = vm.popDataValue();
         int32_t hour2 = vm.popDataValue();
         int32_t min1 = vm.popDataValue();
@@ -759,6 +758,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         int32_t hour, min;
         pWorld->getWorldInfo().getTimeOfDay(hour, min);
 
+        // TODO this isn't right. multiple errors...
         if (hour >= hour1 && hour <= hour2 &&
             min >= min1 && min >= min2)
         {

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -757,7 +757,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         int32_t hour1 = vm.popDataValue();
 
         int32_t hour, min;
-        pWorld->getSky().getTimeOfDay(hour, min);
+        pWorld->getWorldInfo().getTimeOfDay(hour, min);
 
         if (hour >= hour1 && hour <= hour2 &&
             min >= min1 && min >= min2)
@@ -1101,7 +1101,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 
     vm->registerExternalFunction("wld_getday", [=](Daedalus::DaedalusVM& vm) {
         if(verbose) LogInfo() << "wld_getday";
-        vm.setReturn(pWorld->getSky().getDay());
+        vm.setReturn(pWorld->getWorldInfo().getDay());
     });
 }
 

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -1098,6 +1098,11 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 
         vm.setReturn(v);
     });
+
+    vm->registerExternalFunction("wld_getday", [=](Daedalus::DaedalusVM& vm) {
+        if(verbose) LogInfo() << "wld_getday";
+        vm.setReturn(pWorld->getSky().getDay());
+    });
 }
 
 

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -381,7 +381,7 @@ public:
 
         console.registerCommand("set day", [this](const std::vector<std::string>& args) -> std::string {
             // modifies the world time
-            if(args.size() < 2)
+            if(args.size() < 3)
                 return "Missing argument. Usage: set day <day>";
 
             int day = std::stoi(args[2]);
@@ -410,18 +410,18 @@ public:
 
         console.registerCommand("set clockspeed", [this](const std::vector<std::string>& args) -> std::string {
             // adds an additional speed factor for the time of day
-            if(args.size() < 2)
-                return "Missing argument. Usage: set timespeed <factor:default=1>";
+            if(args.size() < 3)
+                return "Missing argument. Usage: set clockspeed <factor>";
 
             float factor = std::stof(args[2]);
-            m_pEngine->getMainWorld().get().getWorldInfo().setGameTimeSpeedFactor(factor);
+            m_pEngine->getMainWorld().get().getWorldInfo().setClockSpeedFactor(factor);
 
             return "Set clockspeed to " + std::to_string(factor);
         });
 
         console.registerCommand("set gamespeed", [this](const std::vector<std::string>& args) -> std::string {
             // adds an additional speed factor for the game time
-            if(args.size() < 2)
+            if(args.size() < 3)
                 return "Missing argument. Usage: set gamespeed <factor:default=1>";
 
             float factor = std::stof(args[2]);
@@ -681,14 +681,6 @@ public:
             }
             return "Could not find NPC " + requested;
         };
-
-        console.registerCommand("nextday", [this, tpToNameLike](const std::vector<std::string>& args) -> std::string {
-            auto& wInfo = m_pEngine->getMainWorld().get().getWorldInfo();
-            auto currentDay = wInfo.getDay();
-            auto nextDay = currentDay + 1;
-            wInfo.setDay(nextDay);
-            return "Changing day from " + std::to_string(currentDay) + " to " + std::to_string(nextDay);
-        });
 
         console.registerCommand("tp", [this, tpToNameLike](const std::vector<std::string>& args) -> std::string {
             if (args.size() < 2)

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -660,6 +660,13 @@ public:
             return "Could not find NPC " + requested;
         };
 
+        console.registerCommand("nextday", [this, tpToNameLike](const std::vector<std::string>& args) -> std::string {
+            auto currentDay = m_pEngine->getMainWorld().get().getSky().getDay();
+            auto nextDay = currentDay + 1;
+            m_pEngine->getMainWorld().get().getSky().setDay(nextDay);
+            return "Changing day from " + std::to_string(currentDay) + " to " + std::to_string(nextDay);
+        });
+
         console.registerCommand("tp", [this, tpToNameLike](const std::vector<std::string>& args) -> std::string {
             if (args.size() < 2)
                 return "Missing argument(s). Usage: tp <name>";

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -379,27 +379,15 @@ public:
             return "Hello World!";
         });
 
-        console.registerCommand("set time", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("set day", [this](const std::vector<std::string>& args) -> std::string {
             // modifies the world time
             if(args.size() < 2)
-                return "Missing argument. Usage: set time <days elapsed since Day 0, 0:00>";
+                return "Missing argument. Usage: set day <day>";
 
-            float timeInDays = std::stof(args[2]);
-            float timeInSeconds = timeInDays * 60 * 60 * 24;
-            m_pEngine->getMainWorld().get().getWorldInfo().setGameTime(timeInSeconds);
+            int day = std::stoi(args[2]);
+            m_pEngine->getMainWorld().get().getWorldInfo().setDay(day);
 
-            return "Set game time to " + m_pEngine->getMainWorld().get().getWorldInfo().getDateTimeFormatted();
-        });
-
-        console.registerCommand("set timespeed", [this](const std::vector<std::string>& args) -> std::string {
-            // adds an additional speed factor for the game time
-            if(args.size() < 2)
-                return "Missing argument. Usage: set timespeed <factor>";
-
-            float factor = std::stof(args[2]);
-            m_pEngine->getMainWorld().get().getWorldInfo().setGameTimeSpeedFactor(factor);
-
-            return "Set timespeed time to " + std::to_string(factor);
+            return "Set day to " + std::to_string(m_pEngine->getMainWorld().get().getWorldInfo().getDay());
         });
 
         console.registerCommand("set clock", [this](const std::vector<std::string>& args) -> std::string {
@@ -417,7 +405,29 @@ public:
 
             m_pEngine->getMainWorld().get().getWorldInfo().setTimeOfDay(hh, mm);
 
-            return "Set clock to " + args[2] + ":" + args[3];
+            return "Set clock to " + m_pEngine->getMainWorld().get().getWorldInfo().getTimeOfDayFormatted();
+        });
+
+        console.registerCommand("set clockspeed", [this](const std::vector<std::string>& args) -> std::string {
+            // adds an additional speed factor for the time of day
+            if(args.size() < 2)
+                return "Missing argument. Usage: set timespeed <factor:default=1>";
+
+            float factor = std::stof(args[2]);
+            m_pEngine->getMainWorld().get().getWorldInfo().setGameTimeSpeedFactor(factor);
+
+            return "Set clockspeed to " + std::to_string(factor);
+        });
+
+        console.registerCommand("set gamespeed", [this](const std::vector<std::string>& args) -> std::string {
+            // adds an additional speed factor for the game time
+            if(args.size() < 2)
+                return "Missing argument. Usage: set gamespeed <factor:default=1>";
+
+            float factor = std::stof(args[2]);
+            m_pEngine->setGameEngineSpeedFactor(factor);
+
+            return "Set gamespeed to " + std::to_string(factor);
         });
 
         console.registerCommand("heroexport", [this](const std::vector<std::string>& args) -> std::string {

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -633,21 +633,11 @@ public:
             return "Experience points successfully given";
         });
 
-        console.registerCommand("goto npc", [this](const std::vector<std::string>& args) -> std::string {
-            if(args.size() < 3)
-                return "Missing argument(s). Usage: goto npc <name>";
-
+        std::function<std::string(std::string)> tpToNameLike = [this](std::string requested) -> std::string {
             auto& worldInstance = m_pEngine->getMainWorld().get();
             auto& scriptEngine = worldInstance.getScriptEngine();
             auto& datFile = scriptEngine.getVM().getDATFile();
 
-            std::stringstream joinedArgs;
-            for (auto it = args.begin() + 2; it != args.end(); ++it)
-            {
-                joinedArgs << *it;
-            }
-
-            std::string requested = joinedArgs.str();
             auto matches = scriptEngine.findWorldNPCsNameLike(requested);
             for (auto& npc : matches)
             {
@@ -668,6 +658,30 @@ public:
                 return "Teleported to " + npcDisplayName + " (" + npcDatFileName + ")";
             }
             return "Could not find NPC " + requested;
+        };
+
+        console.registerCommand("tp", [this, tpToNameLike](const std::vector<std::string>& args) -> std::string {
+            if (args.size() < 2)
+                return "Missing argument(s). Usage: tp <name>";
+
+            std::stringstream joinedArgs;
+            for (auto it = args.begin() + 1; it != args.end(); ++it)
+            {
+                joinedArgs << *it;
+            }
+            return tpToNameLike(joinedArgs.str());
+        });
+
+        console.registerCommand("goto npc", [this, tpToNameLike](const std::vector<std::string>& args) -> std::string {
+            if(args.size() < 3)
+                return "Missing argument(s). Usage: goto npc <name>";
+
+            std::stringstream joinedArgs;
+            for (auto it = args.begin() + 2; it != args.end(); ++it)
+            {
+                joinedArgs << *it;
+            }
+            return tpToNameLike(joinedArgs.str());
         });
 
         console.registerCommand("kill", [this](const std::vector<std::string>& args) -> std::string {

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -379,33 +379,45 @@ public:
             return "Hello World!";
         });
 
-
-        console.registerCommand("timeset", [this](const std::vector<std::string>& args) -> std::string {
-
+        console.registerCommand("set time", [this](const std::vector<std::string>& args) -> std::string {
+            // modifies the world time
             if(args.size() < 2)
-                return "Missing argument. Usage: timeset <time (0..1)>";
+                return "Missing argument. Usage: set time <days elapsed since Day 0, 0:00>";
 
-            float t = std::stof(args[1]);
-            m_pEngine->getMainWorld().get().getSky().setTimeOfDay(t);
+            float timeInDays = std::stof(args[2]);
+            float timeInSeconds = timeInDays * 60 * 60 * 24;
+            m_pEngine->getMainWorld().get().getWorldInfo().setGameTime(timeInSeconds);
 
-            return "Set time to " + std::to_string(t);
+            return "Set game time to " + m_pEngine->getMainWorld().get().getWorldInfo().getDateTimeFormatted();
         });
 
-        console.registerCommand("set time", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("set timespeed", [this](const std::vector<std::string>& args) -> std::string {
+            // adds an additional speed factor for the game time
+            if(args.size() < 2)
+                return "Missing argument. Usage: set timespeed <factor>";
+
+            float factor = std::stof(args[2]);
+            m_pEngine->getMainWorld().get().getWorldInfo().setGameTimeSpeedFactor(factor);
+
+            return "Set timespeed time to " + std::to_string(factor);
+        });
+
+        console.registerCommand("set clock", [this](const std::vector<std::string>& args) -> std::string {
+            // modifies the world time
             if(args.size() != 4)
-                return "Invalid arguments. Usage: set time [hh mm]";
+                return "Invalid arguments. Usage: set clock [hh mm]";
 
             const int hh = std::stoi(args[2]);
             const int mm = std::stoi(args[3]);
 
             if(hh < 0 || hh > 23)
-                return "Invalid argument. Hours must be in range from 00 to 23";
+                return "Invalid argument. Hours must be in range from 0 to 23";
             if(mm < 0 || mm > 59)
-                return "Invalid argument. Minutes must be in range from 00 to 59";
+                return "Invalid argument. Minutes must be in range from 0 to 59";
 
-            m_pEngine->getMainWorld().get().getSky().setTimeOfDay(hh, mm);
+            m_pEngine->getMainWorld().get().getWorldInfo().setTimeOfDay(hh, mm);
 
-            return "Set time to " + args[2] + ":" + args[3];
+            return "Set clock to " + args[2] + ":" + args[3];
         });
 
         console.registerCommand("heroexport", [this](const std::vector<std::string>& args) -> std::string {
@@ -661,9 +673,10 @@ public:
         };
 
         console.registerCommand("nextday", [this, tpToNameLike](const std::vector<std::string>& args) -> std::string {
-            auto currentDay = m_pEngine->getMainWorld().get().getSky().getDay();
+            auto& wInfo = m_pEngine->getMainWorld().get().getWorldInfo();
+            auto currentDay = wInfo.getDay();
             auto nextDay = currentDay + 1;
-            m_pEngine->getMainWorld().get().getSky().setDay(nextDay);
+            wInfo.setDay(nextDay);
             return "Changing day from " + std::to_string(currentDay) + " to " + std::to_string(nextDay);
         });
 

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -131,7 +131,7 @@ void UI::Hud::setEnemyHealth(float value)
     m_pEnemyHealthBar->setValue(value);
 }
 
-void UI::Hud::setTimeOfDay(const std::string& timeStr)
+void UI::Hud::setDateTimeDisplay(const std::string &timeStr)
 {
     m_pClock->setText(timeStr);
 }

--- a/src/ui/Hud.h
+++ b/src/ui/Hud.h
@@ -58,7 +58,7 @@ namespace UI
         /**
          * @param timeStr Current time of day to be shown on the hud
          */
-        void setTimeOfDay(const std::string& timeStr);
+        void setDateTimeDisplay(const std::string &timeStr);
 
         /**
          * To be called when one of the given actions were triggered


### PR DESCRIPTION
- Added day Indicator besides clock
- game time starts at Day 1 8:00
- Day adjusts when clock passes 24:00 through frameupdate (not via `set clock`)
- ~new command: `nextday` increments the day (maybe superfluous?)~ command got removed
- renamed `set time` to `set clock`
- new comand `set day`
- new command `set clockspeed` (default=7.0). Value of 1.0 would be normal gothic clock. Speeds up the ingame clock. (affects TA states, routines, sky)
- new awesome command `set gamespeed` (default=1.0). Modifies the updating of all world instances. I.e. Slow motion or super speed for EVERYTHING. Animations, movement, clock, sky, camera, sound (including pitch).
- sky uses World's gametime
- added missing sky transition (7->0)
- implemented external `wld_getday`. Whistler will now be very angry if you talk to him after 2 days or more and still haven't given him the sword.
- readded `tp` command: I'm tired of typing `goto npc` all the time. `tp` is additional alias now.
- fixed bug in `wld_istime` (min1 <= min <= min2)

TODO: add gametime to savegame. handle save/load