### PR TITLE
reworked EventMessage pointers to shared pointers

### DIFF
--- a/src/logic/Controller.h
+++ b/src/logic/Controller.h
@@ -55,7 +55,7 @@ namespace Logic
         /**
          * Called when this vob recieved a message
          */
-        virtual void onMessage(EventMessages::EventMessage& message, Handle::EntityHandle sourceVob = Handle::EntityHandle::makeInvalidHandle()){}
+        virtual void onMessage(std::shared_ptr<EventMessages::EventMessage> message, Handle::EntityHandle sourceVob = Handle::EntityHandle::makeInvalidHandle()){}
 
         /**
          * Sets the transform of the underlaying entity

--- a/src/logic/DialogManager.h
+++ b/src/logic/DialogManager.h
@@ -125,7 +125,7 @@ namespace Logic
         /**
          * Sets the current Dialog Message. To be able to cancel it
          */
-        void setCurrentMessage(EventMessages::ConversationMessage* message) { m_CurrentDialogMessage = message; }
+        void setCurrentMessage(std::shared_ptr<EventMessages::ConversationMessage> message) { m_CurrentDialogMessage = message; }
 
         /**
          * Sorts registered choices depending on their sort index
@@ -244,7 +244,7 @@ namespace Logic
         /**
          * Can be used to cancel the current Dialog Sound, when IA_Close occurs.
          */
-        EventMessages::ConversationMessage* m_CurrentDialogMessage;
+        std::shared_ptr<EventMessages::ConversationMessage> m_CurrentDialogMessage;
 
         /**
          * Remember all already chosen important infos, for the current Dialog

--- a/src/logic/MobController.cpp
+++ b/src/logic/MobController.cpp
@@ -268,12 +268,12 @@ void MobController::initFromJSONDescriptor(const json& j)
     // since it is derived from the visual-name
 }
 
-void MobController::onMessage(EventMessages::EventMessage& message, Handle::EntityHandle sourceVob)
+void MobController::onMessage(std::shared_ptr<EventMessages::EventMessage> message, Handle::EntityHandle sourceVob)
 {
     Controller::onMessage(message, sourceVob);
-    assert(message.messageType == EventMessages::EventMessageType::Mob);
+    assert(message->messageType == EventMessages::EventMessageType::Mob);
 
-    EventMessages::MobMessage& msg = (EventMessages::MobMessage&)message;
+    EventMessages::MobMessage& msg = *std::dynamic_pointer_cast<EventMessages::MobMessage>(message);
     switch((EventMessages::MobMessage::MobSubType)msg.subType)
     {
         case EventMessages::MobMessage::ST_STARTINTERACTION: startInteraction(msg.npc); break;
@@ -344,7 +344,7 @@ void MobController::startInteraction(Handle::EntityHandle npc)
 
     // This is save, because mobs generally won't be deleted from the map.
     // If not, this will just do nothing
-    sm.addDoneCallback(m_Entity, [=](Handle::EntityHandle hostVob, EventMessages::EventMessage*){
+    sm.addDoneCallback(m_Entity, [=](Handle::EntityHandle hostVob, std::shared_ptr<EventMessages::EventMessage>){
 
 	LogInfo() << "lock camera";
     	m_lockCamera = true;
@@ -387,7 +387,7 @@ void MobController::startStateChange(Handle::EntityHandle npc, int from, int to)
 
     // This is save, because vobs generally won't be deleted from the map.
     // If not, this will just do nothing
-    sm.addDoneCallback(m_Entity, [=](Handle::EntityHandle hostVob, EventMessages::EventMessage*){
+    sm.addDoneCallback(m_Entity, [=](Handle::EntityHandle hostVob, std::shared_ptr<EventMessages::EventMessage>){
 
         // Re-get everything to make sure it is still there
         VobTypes::NpcVobInformation nv = VobTypes::asNpcVob(m_World, npc);

--- a/src/logic/MobController.h
+++ b/src/logic/MobController.h
@@ -196,7 +196,7 @@ namespace Logic
          */
         void setIdealPosition(Handle::EntityHandle npc);
 
-        void onMessage(EventMessages::EventMessage& message, Handle::EntityHandle sourceVob) override;
+        void onMessage(std::shared_ptr<EventMessages::EventMessage> message, Handle::EntityHandle sourceVob) override;
 
         /**
          * Called when the models visual changed

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -27,6 +27,7 @@
 
 using json = nlohmann::json;
 using namespace Logic;
+using SharedEMessage = std::shared_ptr<Logic::EventMessages::EventMessage>;
 
 /**
  * Standard node-names
@@ -1124,45 +1125,45 @@ void PlayerController::attackRight()
         getModelVisual()->playAnimation(type);
 }
 
-void PlayerController::onMessage(EventMessages::EventMessage& message, Handle::EntityHandle sourceVob)
+void PlayerController::onMessage(SharedEMessage message, Handle::EntityHandle sourceVob)
 {
     Controller::onMessage(message, sourceVob);
 
     bool done = false;
-    switch (message.messageType)
+    switch (message->messageType)
     {
         case EventMessages::EventMessageType::Event:
             done = EV_Event(message, sourceVob);
             break;
         case EventMessages::EventMessageType::Npc:
-            done = EV_Npc(reinterpret_cast<EventMessages::NpcMessage&>(message), sourceVob);
+            done = EV_Npc(std::dynamic_pointer_cast<EventMessages::NpcMessage>(message), sourceVob);
             break;
         case EventMessages::EventMessageType::Damage:
-            done = EV_Damage(reinterpret_cast<EventMessages::DamageMessage&>(message), sourceVob);
+            done = EV_Damage(std::dynamic_pointer_cast<EventMessages::DamageMessage>(message), sourceVob);
             break;
         case EventMessages::EventMessageType::Weapon:
-            done = EV_Weapon(reinterpret_cast<EventMessages::WeaponMessage&>(message), sourceVob);
+            done = EV_Weapon(std::dynamic_pointer_cast<EventMessages::WeaponMessage>(message), sourceVob);
             break;
         case EventMessages::EventMessageType::Movement:
-            done = EV_Movement(reinterpret_cast<EventMessages::MovementMessage&>(message), sourceVob);
+            done = EV_Movement(std::dynamic_pointer_cast<EventMessages::MovementMessage>(message), sourceVob);
             break;
         case EventMessages::EventMessageType::Attack:
-            done = EV_Attack(reinterpret_cast<EventMessages::AttackMessage&>(message), sourceVob);
+            done = EV_Attack(std::dynamic_pointer_cast<EventMessages::AttackMessage>(message), sourceVob);
             break;
         case EventMessages::EventMessageType::UseItem:
-            done = EV_UseItem(reinterpret_cast<EventMessages::UseItemMessage&>(message), sourceVob);
+            done = EV_UseItem(std::dynamic_pointer_cast<EventMessages::UseItemMessage>(message), sourceVob);
             break;
         case EventMessages::EventMessageType::State:
-            done = EV_State(reinterpret_cast<EventMessages::StateMessage&>(message), sourceVob);
+            done = EV_State(std::dynamic_pointer_cast<EventMessages::StateMessage>(message), sourceVob);
             break;
         case EventMessages::EventMessageType::Manipulate:
-            done = EV_Manipulate(reinterpret_cast<EventMessages::ManipulateMessage&>(message), sourceVob);
+            done = EV_Manipulate(std::dynamic_pointer_cast<EventMessages::ManipulateMessage>(message), sourceVob);
             break;
         case EventMessages::EventMessageType::Conversation:
-            done = EV_Conversation(reinterpret_cast<EventMessages::ConversationMessage&>(message), sourceVob);
+            done = EV_Conversation(std::dynamic_pointer_cast<EventMessages::ConversationMessage>(message), sourceVob);
             break;
         case EventMessages::EventMessageType::Magic:
-            done = EV_Magic(reinterpret_cast<EventMessages::MagicMessage&>(message), sourceVob);
+            done = EV_Magic(std::dynamic_pointer_cast<EventMessages::MagicMessage>(message), sourceVob);
             break;
         case EventMessages::EventMessageType::Mob:
             //TODO handle this somehow?
@@ -1170,32 +1171,33 @@ void PlayerController::onMessage(EventMessages::EventMessage& message, Handle::E
     }
 
     // Flag as deleted if this is done
-    message.deleted = done;
+    message->deleted = done;
 }
 
-bool PlayerController::EV_Event(EventMessages::EventMessage& message, Handle::EntityHandle sourceVob)
+bool PlayerController::EV_Event(SharedEMessage message, Handle::EntityHandle sourceVob)
 {
     return false;
 }
 
-bool PlayerController::EV_Npc(EventMessages::NpcMessage& message, Handle::EntityHandle sourceVob)
+bool PlayerController::EV_Npc(std::shared_ptr<EventMessages::NpcMessage> message, Handle::EntityHandle sourceVob)
 {
     return false;
 }
 
-bool PlayerController::EV_Damage(EventMessages::DamageMessage& message, Handle::EntityHandle sourceVob)
+bool PlayerController::EV_Damage(std::shared_ptr<EventMessages::DamageMessage> message, Handle::EntityHandle sourceVob)
 {
     return false;
 }
 
-bool PlayerController::EV_Weapon(EventMessages::WeaponMessage& message, Handle::EntityHandle sourceVob)
+bool PlayerController::EV_Weapon(std::shared_ptr<EventMessages::WeaponMessage> message, Handle::EntityHandle sourceVob)
 {
     return false;
 }
 
 bool
-PlayerController::EV_Movement(EventMessages::MovementMessage& message, Handle::EntityHandle sourceVob)
+PlayerController::EV_Movement(std::shared_ptr<EventMessages::MovementMessage> sharedMessage, Handle::EntityHandle sourceVob)
 {
+    auto& message = *sharedMessage;
     switch (static_cast<EventMessages::MovementMessage::MovementSubType>(message.subType))
     {
         case EventMessages::MovementMessage::ST_RobustTrace:
@@ -1365,18 +1367,19 @@ PlayerController::EV_Movement(EventMessages::MovementMessage& message, Handle::E
     return false;
 }
 
-bool PlayerController::EV_Attack(EventMessages::AttackMessage& message, Handle::EntityHandle sourceVob)
+bool PlayerController::EV_Attack(std::shared_ptr<EventMessages::AttackMessage> message, Handle::EntityHandle sourceVob)
 {
     return false;
 }
 
-bool PlayerController::EV_UseItem(EventMessages::UseItemMessage& message, Handle::EntityHandle sourceVob)
+bool PlayerController::EV_UseItem(std::shared_ptr<EventMessages::UseItemMessage> message, Handle::EntityHandle sourceVob)
 {
     return false;
 }
 
-bool PlayerController::EV_State(EventMessages::StateMessage& message, Handle::EntityHandle sourceVob)
+bool PlayerController::EV_State(std::shared_ptr<EventMessages::StateMessage> sharedMessage, Handle::EntityHandle sourceVob)
 {
+    auto& message = *sharedMessage;
     switch (message.subType)
     {
         case EventMessages::StateMessage::EV_StartState:
@@ -1426,8 +1429,9 @@ bool PlayerController::EV_State(EventMessages::StateMessage& message, Handle::En
 }
 
 bool
-PlayerController::EV_Manipulate(EventMessages::ManipulateMessage& message, Handle::EntityHandle sourceVob)
+PlayerController::EV_Manipulate(std::shared_ptr<EventMessages::ManipulateMessage> sharedMessage, Handle::EntityHandle sourceVob)
 {
+    auto& message = *sharedMessage;
     switch (static_cast<EventMessages::ManipulateMessage::ManipulateSubType>(message.subType))
     {
         case EventMessages::ManipulateMessage::ST_TakeVob:break;
@@ -1487,9 +1491,10 @@ PlayerController::EV_Manipulate(EventMessages::ManipulateMessage& message, Handl
     return false;
 }
 
-bool PlayerController::EV_Conversation(EventMessages::ConversationMessage& message,
+bool PlayerController::EV_Conversation(std::shared_ptr<EventMessages::ConversationMessage> sharedMessage,
                                        Handle::EntityHandle sourceVob)
 {
+    auto& message = *sharedMessage;
     switch (static_cast<EventMessages::ConversationMessage::ConversationSubType>(message.subType))
     {
 
@@ -1544,7 +1549,7 @@ bool PlayerController::EV_Conversation(EventMessages::ConversationMessage& messa
                 message.internInProgress = true;
                 // Play sound of this conv-message
                 message.soundTicket = m_World.getAudioWorld().playSound(message.name);
-                m_World.getDialogManager().setCurrentMessage(&message);
+                m_World.getDialogManager().setCurrentMessage(sharedMessage);
                 //m_World.getDialogManager().setCurrentTalker(this->m_Entity);
 
             } else
@@ -1613,7 +1618,7 @@ bool PlayerController::EV_Conversation(EventMessages::ConversationMessage& messa
     return false;
 }
 
-bool PlayerController::EV_Magic(EventMessages::MagicMessage& message, Handle::EntityHandle sourceVob)
+bool PlayerController::EV_Magic(std::shared_ptr<EventMessages::MagicMessage> message, Handle::EntityHandle sourceVob)
 {
     return false;
 }

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -110,7 +110,7 @@ namespace Logic
          * @param message Message to handle
          * @param sourceVob Instigator vob. Can be invalid.
          */
-        virtual void onMessage(EventMessages::EventMessage& message, Handle::EntityHandle sourceVob) override;
+        virtual void onMessage(std::shared_ptr<EventMessages::EventMessage> message, Handle::EntityHandle sourceVob) override;
 
         /**
          * Called on game-tick
@@ -445,17 +445,17 @@ namespace Logic
         /**
          * Events
          */
-        bool EV_Event(Logic::EventMessages::EventMessage& message, Handle::EntityHandle sourceVob);
-        bool EV_Npc(Logic::EventMessages::NpcMessage& message, Handle::EntityHandle sourceVob);
-        bool EV_Damage(Logic::EventMessages::DamageMessage& message, Handle::EntityHandle sourceVob);
-        bool EV_Weapon(Logic::EventMessages::WeaponMessage& message, Handle::EntityHandle sourceVob);
-        bool EV_Movement(Logic::EventMessages::MovementMessage& message, Handle::EntityHandle sourceVob);
-        bool EV_Attack(Logic::EventMessages::AttackMessage& message, Handle::EntityHandle sourceVob);
-        bool EV_UseItem(Logic::EventMessages::UseItemMessage& message, Handle::EntityHandle sourceVob);
-        bool EV_State(Logic::EventMessages::StateMessage& message, Handle::EntityHandle sourceVob);
-        bool EV_Manipulate(Logic::EventMessages::ManipulateMessage& message, Handle::EntityHandle sourceVob);
-        bool EV_Conversation(Logic::EventMessages::ConversationMessage& message, Handle::EntityHandle sourceVob);
-        bool EV_Magic(Logic::EventMessages::MagicMessage& message, Handle::EntityHandle sourceVob);
+        bool EV_Event(std::shared_ptr<Logic::EventMessages::EventMessage> message, Handle::EntityHandle sourceVob);
+        bool EV_Npc(std::shared_ptr<Logic::EventMessages::NpcMessage> message, Handle::EntityHandle sourceVob);
+        bool EV_Damage(std::shared_ptr<Logic::EventMessages::DamageMessage> message, Handle::EntityHandle sourceVob);
+        bool EV_Weapon(std::shared_ptr<Logic::EventMessages::WeaponMessage> message, Handle::EntityHandle sourceVob);
+        bool EV_Movement(std::shared_ptr<Logic::EventMessages::MovementMessage> message, Handle::EntityHandle sourceVob);
+        bool EV_Attack(std::shared_ptr<Logic::EventMessages::AttackMessage> message, Handle::EntityHandle sourceVob);
+        bool EV_UseItem(std::shared_ptr<Logic::EventMessages::UseItemMessage> message, Handle::EntityHandle sourceVob);
+        bool EV_State(std::shared_ptr<Logic::EventMessages::StateMessage> message, Handle::EntityHandle sourceVob);
+        bool EV_Manipulate(std::shared_ptr<Logic::EventMessages::ManipulateMessage> message, Handle::EntityHandle sourceVob);
+        bool EV_Conversation(std::shared_ptr<Logic::EventMessages::ConversationMessage> message, Handle::EntityHandle sourceVob);
+        bool EV_Magic(std::shared_ptr<Logic::EventMessages::MagicMessage> message, Handle::EntityHandle sourceVob);
 
         /**
          * Moves the NPC to the next waypoint of the current path

--- a/src/logic/messages/EventMessage.h
+++ b/src/logic/messages/EventMessage.h
@@ -32,7 +32,7 @@ namespace Logic
          */
         struct EventMessage
         {
-            typedef const void* MessageIdentifier;
+            using SharedEMessage = std::shared_ptr<EventMessage>;
 
             EventMessage()
             {
@@ -100,7 +100,7 @@ namespace Logic
              * @param hostVob Vob which the callback is set from
              * @param callback Callback function
              */
-            void addDoneCallback(Handle::EntityHandle hostVob, std::function<void(Handle::EntityHandle hostVob, EventMessage*)> callback)
+            void addDoneCallback(Handle::EntityHandle hostVob, std::function<void(Handle::EntityHandle hostVob, SharedEMessage)> callback)
             {
                 onMessageDone.push_back(std::make_pair(hostVob, callback));
             }
@@ -108,7 +108,7 @@ namespace Logic
             /**
              * External callbacks to trigger if this message gets processed. Must also store the waiting entity.
              */
-            std::list<std::pair<Handle::EntityHandle, std::function<void(Handle::EntityHandle, EventMessage*)>>> onMessageDone;
+            std::list<std::pair<Handle::EntityHandle, std::function<void(Handle::EntityHandle, SharedEMessage)>>> onMessageDone;
         };
 
         struct NpcMessage : public EventMessage
@@ -533,7 +533,6 @@ namespace Logic
                 messageType = EventMessageType::Conversation;
                 internInProgress = false;
                 waitIdentifier = nullptr;
-                waitTicket = 0;
             }
 
             /**
@@ -586,14 +585,9 @@ namespace Logic
             std::string animation;
 
             /**
-             * Pointer to the message we are waiting for
+             * SharedPointer to the message we are waiting for. Currently not used. Useful for debug purpose
              */
-            MessageIdentifier waitIdentifier;
-
-            /**
-             * Something to identify whatever we are waiting for at ST_WaitTillEnd
-             */
-            unsigned int waitTicket;
+            SharedEMessage waitIdentifier;
 
             /**
              * Whether this is currently in progress. Set by the PlayerController.


### PR DESCRIPTION
Refactored EventManager. Now stores` vector<shared_ptr<EventMessage>>` instead of `vector<EventMessage*>`.

That means it's now safe to use the newly added return value of `EventManager::onMessage` https://github.com/REGoth-project/REGoth/blob/SharedPointerMessages/src/logic/messages/EventManager.h#L22
The Message might not be in the queue any longer but it may still be referenced. So it's always safe to store shared pointers to the Messages outside of the Eventmanager class.

Also fixed some `reinterpret_cast` to `dynamic_pointer_cast`