### PR TITLE
Subtitle box small adjustments

### DIFF
--- a/src/ui/SubtitleBox.cpp
+++ b/src/ui/SubtitleBox.cpp
@@ -71,17 +71,32 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
     {
         // split so that each line is not longer than wrapAroundWidth pixel
         std::vector<std::string> lines = fnt->layoutText(m_Text.text, wrapAroundWidth);
-        lines.insert(lines.begin(), m_Text.speaker);
         const char * speakerFont = DEFAULT_FONT_HI;
         const char * dialogTextFont = DEFAULT_FONT;
-
-        for (unsigned i = 0; i < lines.size(); ++i)
+        // TODO read alignment from config
+        SubtitleAlign alignment = center;
+        switch (alignment)
         {
-            const char* font = i == 0 ? speakerFont : dialogTextFont;
-            unsigned before = i;
-            unsigned long after = lines.size() - i - 1;
-            std::string line = std::string(before, '\n') + lines[i] + std::string(after, '\n');
-            drawText(line, px + (sx / 2), py + (sy / 2), A_Center, config, font);
+            case center:
+                lines.insert(lines.begin(), m_Text.speaker);
+                for (unsigned i = 0; i < lines.size(); ++i)
+                {
+                    const char* font = i == 0 ? speakerFont : dialogTextFont;
+                    unsigned before = i;
+                    unsigned long after = lines.size() - i - 1;
+                    std::string line = std::string(before, '\n') + lines[i] + std::string(after, '\n');
+                    drawText(line, px + (sx / 2), py + (sy / 2), A_Center, config, font);
+                }
+                break;
+            case left:
+                std::stringstream ss;
+                for (const auto& line : lines)
+                {
+                    ss << '\n' << line;
+                }
+                drawText(m_Text.speaker + std::string(lines.size(), '\n'), px + (sx / 2), py + (sy / 2), A_Center, config, speakerFont);
+                drawText(ss.str(), px + (sx / 2), py + (sy / 2), A_Center, config, dialogTextFont);
+                break;
         }
     }
 }

--- a/src/ui/SubtitleBox.cpp
+++ b/src/ui/SubtitleBox.cpp
@@ -48,11 +48,13 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
 
     // Un-normalize transforms
     Math::float2 absTranslation = getAbsoluteTranslation();
-    int px = (int) (absTranslation.x * config.state.viewWidth + 0.5f);
-    int py = (int) (absTranslation.y * config.state.viewHeight + 0.5f);
 
-    int sx = (int) (0.50f * config.state.viewWidth + 0.5f);
+    int px = Math::iround(absTranslation.x * config.state.viewWidth);
+    int py = Math::iround((absTranslation.y + 0.02f) * config.state.viewHeight);
+
+    int sx = Math::iround(0.5f * config.state.viewWidth);
     int sy = 13 * 6; // 6 lines of dialog
+    int wrapAroundWidth = Math::iround(0.95f * sx);
 
     // Draw background image
     {
@@ -67,7 +69,6 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
     }
     // Draw text
     {
-        const int wrapAroundWidth = 485;
         // split so that each line is not longer than wrapAroundWidth pixel
         std::vector<std::string> lines = fnt->layoutText(m_Text.text, wrapAroundWidth);
         lines.insert(lines.begin(), m_Text.speaker);

--- a/src/ui/SubtitleBox.cpp
+++ b/src/ui/SubtitleBox.cpp
@@ -74,10 +74,10 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
         const char * speakerFont = DEFAULT_FONT_HI;
         const char * dialogTextFont = DEFAULT_FONT;
         // TODO read alignment from config
-        SubtitleAlignments::Alignment alignment = SubtitleAlignments::center;
+        SubtitleBox::TextAlignment alignment = SubtitleBox::TextAlignment::center;
         switch (alignment)
         {
-            case SubtitleAlignments::center:
+            case SubtitleBox::TextAlignment::center:
                 lines.insert(lines.begin(), m_Text.speaker);
                 for (unsigned i = 0; i < lines.size(); ++i)
                 {
@@ -88,7 +88,7 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
                     drawText(line, px + (sx / 2), py + (sy / 2), A_Center, config, font);
                 }
                 break;
-            case SubtitleAlignments::left:
+            case SubtitleBox::TextAlignment::left:
                 std::stringstream ss;
                 for (const auto& line : lines)
                 {

--- a/src/ui/SubtitleBox.cpp
+++ b/src/ui/SubtitleBox.cpp
@@ -65,28 +65,23 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
                     config.uniforms.diffuseTexture);
 
     }
-
-
     // Draw text
     {
-        // Insert linebreaks if the text is too long to fit
-        std::string layouted = fnt->layoutText(m_Text.text, (int)(sx * 0.95f));
+        const int wrapAroundWidth = 485;
+        // split so that each line is not longer than wrapAroundWidth pixel
+        std::vector<std::string> lines = fnt->layoutText(m_Text.text, wrapAroundWidth);
+        lines.insert(lines.begin(), m_Text.speaker);
+        const char * speakerFont = DEFAULT_FONT_HI;
+        const char * dialogTextFont = DEFAULT_FONT;
 
-        // Draw dialog text
-        // First newline is for the speaker, later
-        drawText("\n" + layouted, px + (sx / 2), py + (sy / 2), A_Center, config);
-
-        // Count number of newlines in text
-        unsigned ncnt = 0;
-        for(unsigned i=0;i<layouted.size();i++)
-            ncnt += layouted[i] == '\n' ? 1 : 0;
-
-        // Put the speaker, followed by ncnt newlines, to align it right above the actual text
-        std::string speaker = m_Text.speaker + "\n";
-        for(unsigned i=0;i<ncnt;i++)
-            speaker.push_back('\n');
-
-        drawText(speaker, px + (sx / 2), py + (sy / 2), A_Center, config, DEFAULT_FONT_HI);
+        for (unsigned i = 0; i < lines.size(); ++i)
+        {
+            const char* font = i == 0 ? speakerFont : dialogTextFont;
+            unsigned before = i;
+            unsigned long after = lines.size() - i - 1;
+            std::string line = std::string(before, '\n') + lines[i] + std::string(after, '\n');
+            drawText(line, px + (sx / 2), py + (sy / 2), A_Center, config, font);
+        }
     }
 }
 

--- a/src/ui/SubtitleBox.cpp
+++ b/src/ui/SubtitleBox.cpp
@@ -74,10 +74,10 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
         const char * speakerFont = DEFAULT_FONT_HI;
         const char * dialogTextFont = DEFAULT_FONT;
         // TODO read alignment from config
-        SubtitleAlign alignment = center;
+        SubtitleAlignments::Alignment alignment = SubtitleAlignments::center;
         switch (alignment)
         {
-            case center:
+            case SubtitleAlignments::center:
                 lines.insert(lines.begin(), m_Text.speaker);
                 for (unsigned i = 0; i < lines.size(); ++i)
                 {
@@ -88,7 +88,7 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
                     drawText(line, px + (sx / 2), py + (sy / 2), A_Center, config, font);
                 }
                 break;
-            case left:
+            case SubtitleAlignments::left:
                 std::stringstream ss;
                 for (const auto& line : lines)
                 {

--- a/src/ui/SubtitleBox.h
+++ b/src/ui/SubtitleBox.h
@@ -5,20 +5,17 @@
 
 namespace UI
 {
-    namespace SubtitleAlignments
-    {
-        enum Alignment
-        {
-            center,
-            left
-        };
-    }
-
     class SubtitleBox : public View
     {
     public:
         SubtitleBox(Engine::BaseEngine& e);
         ~SubtitleBox();
+
+        enum class TextAlignment
+        {
+            center,
+            left
+        };
 
         /**
          * Updates/draws the UI-Views

--- a/src/ui/SubtitleBox.h
+++ b/src/ui/SubtitleBox.h
@@ -5,6 +5,12 @@
 
 namespace UI
 {
+    enum SubtitleAlign
+    {
+        center,
+        left
+    };
+
     class SubtitleBox : public View
     {
     public:

--- a/src/ui/SubtitleBox.h
+++ b/src/ui/SubtitleBox.h
@@ -5,11 +5,14 @@
 
 namespace UI
 {
-    enum SubtitleAlign
+    namespace SubtitleAlignments
     {
-        center,
-        left
-    };
+        enum Alignment
+        {
+            center,
+            left
+        };
+    }
 
     class SubtitleBox : public View
     {

--- a/src/ui/zFont.h
+++ b/src/ui/zFont.h
@@ -65,12 +65,12 @@ namespace UI
         int getFontHeight() const { return m_Font.fontHeight; };
 
         /**
-         * Tries to fit the given text into the specified width. Inserts linebreaks to do so
+         * Returns lines where each is no wider than maxWidth
          * @param text Text to fit
          * @param maxWidth Max width of the text before a linebreak
-         * @return Layouted text
+         * @return vector of lines
          */
-        std::string layoutText(const std::string& text, int maxWidth) const;
+        std::vector<std::string> layoutText(const std::string& text, int maxWidth) const;
 
         /**
          * Calculates the width and height of the given piece of text


### PR DESCRIPTION
- text longer no longer out of box
- all lines are centered
- added small space above box
- added (hardcoded) flag to toggle between center/left (=previous) alignment