### PR TITLE
fixed target run away, when player has farewell message. 

### DIFF
--- a/src/logic/messages/EventManager.cpp
+++ b/src/logic/messages/EventManager.cpp
@@ -132,10 +132,10 @@ void EventManager::waitForMessage(SharedEMessage other)
     wait.waitIdentifier = other;
 
     // Let the EM wait for this talking-action to complete
-    SharedEMessage queuedWait = onMessage(wait);
+    std::shared_ptr<EventMessages::ConversationMessage> queuedWait = onMessage(wait);
 
     other->onMessageDone.push_back(std::make_pair(m_HostVob, [=](Handle::EntityHandle hostVob, SharedEMessage hostMessage) {
-        queuedWait->deleted = true;
+        queuedWait->canceled = true;
     }));
 }
 

--- a/src/logic/messages/EventMessage.h
+++ b/src/logic/messages/EventMessage.h
@@ -532,6 +532,7 @@ namespace Logic
             {
                 messageType = EventMessageType::Conversation;
                 internInProgress = false;
+                canceled = false;
                 waitIdentifier = nullptr;
             }
 
@@ -551,8 +552,6 @@ namespace Logic
              * Export as JSON-String
              */
             virtual std::string exportPart();
-
-
 
             /**
              * Text to be displayed in the subtitle box
@@ -593,6 +592,11 @@ namespace Logic
              * Whether this is currently in progress. Set by the PlayerController.
              */
             bool internInProgress;
+
+            /**
+             * Whether this message has been kindly canceled by the ouside (i.e. DialogManager).
+             */
+            bool canceled;
 
             /**
              * Ticket. Can be used to ask AudioWorld if sound is playing.

--- a/src/ui/SubtitleBox.cpp
+++ b/src/ui/SubtitleBox.cpp
@@ -48,11 +48,13 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
 
     // Un-normalize transforms
     Math::float2 absTranslation = getAbsoluteTranslation();
-    int px = (int) (absTranslation.x * config.state.viewWidth + 0.5f);
-    int py = (int) (absTranslation.y * config.state.viewHeight + 0.5f);
 
-    int sx = (int) (0.50f * config.state.viewWidth + 0.5f);
+    int px = Math::iround(absTranslation.x * config.state.viewWidth);
+    int py = Math::iround((absTranslation.y + 0.02f) * config.state.viewHeight);
+
+    int sx = Math::iround(0.5f * config.state.viewWidth);
     int sy = 13 * 6; // 6 lines of dialog
+    int wrapAroundWidth = Math::iround(0.95f * sx);
 
     // Draw background image
     {
@@ -65,28 +67,37 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
                     config.uniforms.diffuseTexture);
 
     }
-
-
     // Draw text
     {
-        // Insert linebreaks if the text is too long to fit
-        std::string layouted = fnt->layoutText(m_Text.text, (int)(sx * 0.95f));
-
-        // Draw dialog text
-        // First newline is for the speaker, later
-        drawText("\n" + layouted, px + (sx / 2), py + (sy / 2), A_Center, config);
-
-        // Count number of newlines in text
-        unsigned ncnt = 0;
-        for(unsigned i=0;i<layouted.size();i++)
-            ncnt += layouted[i] == '\n' ? 1 : 0;
-
-        // Put the speaker, followed by ncnt newlines, to align it right above the actual text
-        std::string speaker = m_Text.speaker + "\n";
-        for(unsigned i=0;i<ncnt;i++)
-            speaker.push_back('\n');
-
-        drawText(speaker, px + (sx / 2), py + (sy / 2), A_Center, config, DEFAULT_FONT_HI);
+        // split so that each line is not longer than wrapAroundWidth pixel
+        std::vector<std::string> lines = fnt->layoutText(m_Text.text, wrapAroundWidth);
+        const char * speakerFont = DEFAULT_FONT_HI;
+        const char * dialogTextFont = DEFAULT_FONT;
+        // TODO read alignment from config
+        SubtitleBox::TextAlignment alignment = SubtitleBox::TextAlignment::center;
+        switch (alignment)
+        {
+            case SubtitleBox::TextAlignment::center:
+                lines.insert(lines.begin(), m_Text.speaker);
+                for (unsigned i = 0; i < lines.size(); ++i)
+                {
+                    const char* font = i == 0 ? speakerFont : dialogTextFont;
+                    unsigned before = i;
+                    unsigned long after = lines.size() - i - 1;
+                    std::string line = std::string(before, '\n') + lines[i] + std::string(after, '\n');
+                    drawText(line, px + (sx / 2), py + (sy / 2), A_Center, config, font);
+                }
+                break;
+            case SubtitleBox::TextAlignment::left:
+                std::stringstream ss;
+                for (const auto& line : lines)
+                {
+                    ss << '\n' << line;
+                }
+                drawText(m_Text.speaker + std::string(lines.size(), '\n'), px + (sx / 2), py + (sy / 2), A_Center, config, speakerFont);
+                drawText(ss.str(), px + (sx / 2), py + (sy / 2), A_Center, config, dialogTextFont);
+                break;
+        }
     }
 }
 

--- a/src/ui/SubtitleBox.h
+++ b/src/ui/SubtitleBox.h
@@ -11,6 +11,12 @@ namespace UI
         SubtitleBox(Engine::BaseEngine& e);
         ~SubtitleBox();
 
+        enum class TextAlignment
+        {
+            center,
+            left
+        };
+
         /**
          * Updates/draws the UI-Views
          * @param dt time since last frame

--- a/src/ui/zFont.h
+++ b/src/ui/zFont.h
@@ -65,12 +65,12 @@ namespace UI
         int getFontHeight() const { return m_Font.fontHeight; };
 
         /**
-         * Tries to fit the given text into the specified width. Inserts linebreaks to do so
+         * Returns lines where each is no wider than maxWidth
          * @param text Text to fit
          * @param maxWidth Max width of the text before a linebreak
-         * @return Layouted text
+         * @return vector of lines
          */
-        std::string layoutText(const std::string& text, int maxWidth) const;
+        std::vector<std::string> layoutText(const std::string& text, int maxWidth) const;
 
         /**
          * Calculates the width and height of the given piece of text


### PR DESCRIPTION
for each `ai_output` both dialog partners will get a wait event which blocks the event queue.
Also moved the callback (conversation message) into the playercontroller.