### PR TITLE
Gathered all externals from Zenlib into Externals.cpp

### DIFF
--- a/src/audio/AudioWorld.cpp
+++ b/src/audio/AudioWorld.cpp
@@ -311,7 +311,6 @@ namespace World
         }
 
         m_VM = new Daedalus::DaedalusVM(datFile);
-        Daedalus::registerDaedalusStdLib(*m_VM);
         Daedalus::registerGothicEngineClasses(*m_VM);
 
         size_t count = 0;

--- a/src/logic/DialogManager.h
+++ b/src/logic/DialogManager.h
@@ -43,6 +43,8 @@ namespace Logic
 
             // Indicates whether choice should be auto played
             bool important;
+
+            static bool comparator(const ChoiceEntry& a, const ChoiceEntry& b){ return a.nr < b.nr; };
         };
 
         /**
@@ -111,11 +113,9 @@ namespace Logic
         void addChoice(ChoiceEntry& entry);
 
         /**
-         * Adds a single choice to the box.
-         * The entry will get a new nr to be guaranteed to be on top.
-         * @param entry Choice entry.
+         * @return new choice number guaranteed to be smaller than all existing ones
          */
-        void addChoiceFront(ChoiceEntry& entry);
+        int beforeFrontIndex();
 
         /**
          * Sets whether the DialogManager is in in the SubDialog state
@@ -139,8 +139,9 @@ namespace Logic
 
         /**
          * Updates the choices from script-side. Restores the original set.
+         * @param target conversation partner
          */
-        void updateChoices();
+        void updateChoices(Daedalus::GameState::NpcHandle target);
 
         /**
          * Called by the script when the interaction will end
@@ -166,6 +167,14 @@ namespace Logic
          */
         UI::SubtitleBox& getSubtitleBox() { return *m_ActiveSubtitleBox; }
 
+        /**
+         * Called when an NPC is about to say something
+         * @param self NPC talking
+         * @param target NPC talking to
+         * @param msg Message to say
+         */
+        void onAIOutput(Daedalus::GameState::NpcHandle self, Daedalus::GameState::NpcHandle target, const ZenLoad::oCMsgConversationData& msg);
+
     protected:
 
         /**
@@ -181,14 +190,6 @@ namespace Logic
          * @param infos List of choices the player has to select
          */
         void onAIProcessInfos(Daedalus::GameState::NpcHandle self, std::vector<Daedalus::GameState::InfoHandle> infos);
-
-        /**
-         * Called when an NPC is about to say something
-         * @param self NPC talking
-         * @param target NPC talking to
-         * @param msg Message to say
-         */
-        void onAIOutput(Daedalus::GameState::NpcHandle self, Daedalus::GameState::NpcHandle target, const ZenLoad::oCMsgConversationData& msg);
 
         /**
          * Currently active subtitle box

--- a/src/logic/PfxManager.cpp
+++ b/src/logic/PfxManager.cpp
@@ -36,7 +36,6 @@ bool Logic::PfxManager::loadParticleFXDAT()
 
     // Load DAT-File...
     m_pVM = new Daedalus::DaedalusVM(datFile);
-    Daedalus::registerDaedalusStdLib(*m_pVM);
     Daedalus::registerGothicEngineClasses(*m_pVM);
 
     m_DefaultEmitter = {0};

--- a/src/logic/ScriptEngine.cpp
+++ b/src/logic/ScriptEngine.cpp
@@ -41,7 +41,6 @@ bool ScriptEngine::loadDAT(const std::string& file)
     const bool verbose = false;
     Logic::ScriptExternals::registerStubs(*m_pVM, verbose);
     Logic::ScriptExternals::registerStdLib(*m_pVM, verbose);
-    m_pVM->getGameState().registerExternals();
     Logic::ScriptExternals::registerEngineExternals(m_World, m_pVM, verbose);
 
     // Register our externals
@@ -49,7 +48,6 @@ bool ScriptEngine::loadDAT(const std::string& file)
     ext.wld_insertnpc = [this](Daedalus::GameState::NpcHandle npc, std::string spawnpoint){ onNPCInserted(npc, spawnpoint); };
     ext.post_wld_insertnpc = [this](Daedalus::GameState::NpcHandle npc){ onNPCInitialized(npc); };
     ext.createinvitem = [this](Daedalus::GameState::ItemHandle item, Daedalus::GameState::NpcHandle npc){ onInventoryItemInserted(item, npc); };
-    ext.log_addentry = [this](std::string topic, std::string entry){ onLogEntryAdded(topic, entry); };
 
     m_pVM->getGameState().setGameExternals(ext);
 

--- a/src/logic/ScriptEngine.h
+++ b/src/logic/ScriptEngine.h
@@ -183,6 +183,11 @@ namespace Logic
          */
         void resetProfilingData();
 
+        /**
+         * Called when a log-entry was inserted
+         */
+        void onLogEntryAdded(const std::string& topic, const std::string& entry);
+
     protected:
 
         /**
@@ -205,11 +210,6 @@ namespace Logic
          * Called when an item got inserted into some NPCs inventory
          */
         void onInventoryItemInserted(Daedalus::GameState::ItemHandle item, Daedalus::GameState::NpcHandle npc);
-
-        /**
-         * Called when a log-entry was inserted
-         */
-        void onLogEntryAdded(const std::string& topic, const std::string& entry);
 
         /**
          * Script-VM

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -15,7 +15,8 @@
 
 void ::Logic::ScriptExternals::registerStdLib(Daedalus::DaedalusVM& vm, bool verbose)
 {
-    Daedalus::registerDaedalusStdLib(vm, verbose);
+    // don't use ZenLib externals
+    // Daedalus::registerDaedalusStdLib(vm, verbose);
     Daedalus::registerGothicEngineClasses(vm);
 }
 
@@ -1254,6 +1255,44 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         playerLog[topicName].entries.push_back(entry);
 
         pWorld->getScriptEngine().onLogEntryAdded(topicName, entry);
+    });
+
+    vm->registerExternalFunction("inttostring", [](Daedalus::DaedalusVM& vm){
+        int32_t x = vm.popDataValue();
+
+        vm.setReturn(std::to_string(x));
+    });
+
+    vm->registerExternalFunction("floattoint", [](Daedalus::DaedalusVM& vm){
+        int32_t x = vm.popDataValue();
+        float f = reinterpret_cast<float&>(x);
+        vm.setReturn(static_cast<int32_t>(f));
+    });
+
+    vm->registerExternalFunction("inttofloat", [](Daedalus::DaedalusVM& vm){
+        int32_t x = vm.popDataValue();
+        float f = static_cast<float>(x);
+        vm.setReturn(reinterpret_cast<int32_t&>(f));
+    });
+
+    vm->registerExternalFunction("concatstrings", [](Daedalus::DaedalusVM& vm){
+        std::string s2 = vm.popString();
+        std::string s1 = vm.popString();
+
+        vm.setReturn(s1 + s2);
+    });
+
+    vm->registerExternalFunction("hlp_strcmp", [](Daedalus::DaedalusVM& vm){
+        std::string s1 = vm.popString();
+        std::string s2 = vm.popString();
+
+        vm.setReturn(s1 == s2 ? 1 : 0);
+    });
+
+    vm->registerExternalFunction("hlp_random", [=](Daedalus::DaedalusVM& vm){
+        int32_t n0 = vm.popDataValue();
+
+        vm.setReturn(rand() % n0);
     });
 }
 

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -23,6 +23,8 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 {
     Engine::BaseEngine* engine = world.getEngine();
     World::WorldInstance* pWorld = &world;
+    using Daedalus::GameState::NpcHandle;
+    using Daedalus::GameState::ItemHandle;
 
     auto isSymInstanceValid = [vm](size_t instance)
     {
@@ -34,7 +36,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
     {
 		assert(vm->getDATFile().getSymbolByIndex(instance).instanceDataClass == Daedalus::EInstanceClass::IC_Npc);
 
-        Daedalus::GameState::NpcHandle hnpc = ZMemory::handleCast<Daedalus::GameState::NpcHandle>
+        NpcHandle hnpc = ZMemory::handleCast<NpcHandle>
                 (vm->getDATFile().getSymbolByIndex(instance).instanceDataHandle);
 
         if(!hnpc.isValid())
@@ -109,7 +111,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         int32_t self = vm.popVar(arr_self); if(verbose) LogInfo() << "self: " << self;
 
         // TODO: Need a better API for this
-        Daedalus::GameState::NpcHandle hnpc = ZMemory::handleCast<Daedalus::GameState::NpcHandle>
+        NpcHandle hnpc = ZMemory::handleCast<NpcHandle>
                 (vm.getDATFile().getSymbolByIndex(self).instanceDataHandle);
         Daedalus::GEngineClasses::C_Npc& npcData = vm.getGameState().getNpc(hnpc);
 
@@ -145,7 +147,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 
 
         // TODO: Need a better API for this
-        Daedalus::GameState::NpcHandle hnpc = ZMemory::handleCast<Daedalus::GameState::NpcHandle>
+        NpcHandle hnpc = ZMemory::handleCast<NpcHandle>
                 (vm.getDATFile().getSymbolByIndex(self).instanceDataHandle);
         Daedalus::GEngineClasses::C_Npc& npcData = vm.getGameState().getNpc(hnpc);
 
@@ -810,7 +812,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 
             // Don't schedule random animations when the npc is the target of the dialog manager
             // Should not be necessary since npc should be in ZS_TALK state. Remove when state issue is resolved
-            Daedalus::GameState::NpcHandle npcHandle = npc.playerController->getScriptHandle();
+            NpcHandle npcHandle = npc.playerController->getScriptHandle();
             auto& dialogManager = pWorld->getDialogManager();
             if (dialogManager.isDialogActive() && dialogManager.getTarget() == npcHandle){
                 //LogInfo() << "Animation got canceled (DialogActive): npc = " << npc.playerController->getScriptInstance().name[0] << ", ani = " << ani;
@@ -954,7 +956,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
     vm->registerExternalFunction("ai_stopprocessinfos", [=](Daedalus::DaedalusVM& vm){
         // the self argument is the NPC, the player is talking with
         uint32_t self = vm.popVar();
-        Daedalus::GameState::NpcHandle hself = ZMemory::handleCast<Daedalus::GameState::NpcHandle>
+        NpcHandle hself = ZMemory::handleCast<NpcHandle>
             (vm.getDATFile().getSymbolByIndex(self).instanceDataHandle);
 
         // Notify DialogManager
@@ -1134,8 +1136,8 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         uint32_t target = vm.popVar();
         uint32_t self = vm.popVar();
 
-        Daedalus::GameState::NpcHandle hself = ZMemory::handleCast<Daedalus::GameState::NpcHandle>(vm.getDATFile().getSymbolByIndex(self).instanceDataHandle);
-        Daedalus::GameState::NpcHandle htarget = ZMemory::handleCast<Daedalus::GameState::NpcHandle>(vm.getDATFile().getSymbolByIndex(target).instanceDataHandle);
+        NpcHandle hself = ZMemory::handleCast<NpcHandle>(vm.getDATFile().getSymbolByIndex(self).instanceDataHandle);
+        NpcHandle htarget = ZMemory::handleCast<NpcHandle>(vm.getDATFile().getSymbolByIndex(target).instanceDataHandle);
 
         auto& dialogManager = pWorld->getDialogManager();
         auto& message = dialogManager.getScriptDialogManager()->getMessageLib().getMessageByName(outputname);
@@ -1145,7 +1147,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
     vm->registerExternalFunction("AI_ProcessInfos", [=](Daedalus::DaedalusVM& vm){
         uint32_t self = vm.popVar();
 
-        Daedalus::GameState::NpcHandle hself = ZMemory::handleCast<Daedalus::GameState::NpcHandle>(vm.getDATFile().getSymbolByIndex(self).instanceDataHandle);
+        NpcHandle hself = ZMemory::handleCast<NpcHandle>(vm.getDATFile().getSymbolByIndex(self).instanceDataHandle);
 
         pWorld->getDialogManager().updateChoices(hself);
     });
@@ -1155,7 +1157,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         int32_t infoinstance = vm.popDataValue();
         int32_t self = vm.popVar();
 
-        Daedalus::GameState::NpcHandle hself = ZMemory::handleCast<Daedalus::GameState::NpcHandle>(vm.getDATFile().getSymbolByIndex(self).instanceDataHandle);
+        NpcHandle hself = ZMemory::handleCast<NpcHandle>(vm.getDATFile().getSymbolByIndex(self).instanceDataHandle);
         Daedalus::GEngineClasses::C_Npc& npc = vm.getGameState().getNpc(hself);
 
         auto& scriptDialogManager = *pWorld->getDialogManager().getScriptDialogManager();
@@ -1164,6 +1166,94 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         //LogInfo() << "Does he kow? (" << vm.getDATFile().getSymbolByIndex(npc.instanceSymbol).name << " -> " << vm.getDATFile().getSymbolByIndex(infoinstance).name << "): " << knows;
 
         vm.setReturn(knows);
+    });
+    
+    vm->registerExternalFunction("createinvitem", [=](Daedalus::DaedalusVM& vm){
+        uint32_t itemInstance = (uint32_t)vm.popDataValue(); if(verbose) LogInfo() << "itemInstance: " << itemInstance;
+        uint32_t arr_n0;
+        int32_t npc = vm.popVar(arr_n0);
+
+        NpcHandle hnpc = ZMemory::handleCast<NpcHandle>(vm.getDATFile().getSymbolByIndex(npc).instanceDataHandle);
+
+        vm.getGameState().createInventoryItem(itemInstance, hnpc);
+
+        /*
+        Daedalus::GEngineClasses::C_Npc& npcData = vm.getGameState().getNpc(hnpc);
+        auto& parsym = vm.getDATFile().getSymbolByIndex(itemInstance);
+        LogInfo() << "1: " << parsym.name;
+        LogInfo() << "2. " << npcData.name[0];
+        LogInfo() << " ##### Created Inventory-Item '" << parsym.name << "' for NPC: " << npcData.name[0];
+         */
+    });
+
+    vm->registerExternalFunction("createinvitems", [=](Daedalus::DaedalusVM& vm){
+        uint32_t num = (uint32_t)vm.popDataValue();
+        uint32_t itemInstance = (uint32_t)vm.popDataValue(); if(verbose) LogInfo() << "itemInstance: " << itemInstance;
+        uint32_t arr_n0;
+        int32_t npc = vm.popVar(arr_n0);
+
+        NpcHandle hnpc = ZMemory::handleCast<NpcHandle>(vm.getDATFile().getSymbolByIndex(npc).instanceDataHandle);
+
+        vm.getGameState().createInventoryItem(itemInstance, hnpc, num);
+    });
+
+    vm->registerExternalFunction("hlp_getnpc", [=](Daedalus::DaedalusVM& vm){
+        int32_t instancename = vm.popDataValue(); if(verbose) LogInfo() << "instancename: " << instancename;
+
+        /*if(!vm.getDATFile().getSymbolByIndex(instancename).instanceDataHandle.isValid())
+        {
+
+        }else
+        {
+            GEngineClasses::C_Npc& npcData = getNpc(ZMemory::handleCast<NpcHandle>(vm.getDATFile().getSymbolByIndex(instancename).instanceDataHandle));
+            if(l) LogInfo() << " [HLP_GETNPC] Name: "
+                  << npcData.name[0];
+        }*/
+
+        vm.setReturnVar(instancename);
+    });
+
+    vm->registerExternalFunction("hlp_isvalidnpc", [=](Daedalus::DaedalusVM& vm){
+        int32_t self = vm.popVar();
+
+        if(vm.getDATFile().getSymbolByIndex(self).instanceDataHandle.isValid())
+        {
+            vm.setReturn(1);
+        }else
+        {
+            vm.setReturn(0);
+        }
+    });
+
+    vm->registerExternalFunction("log_createtopic", [=](Daedalus::DaedalusVM& vm){
+        int32_t section = vm.popDataValue();
+        std::string topicName = vm.popString();
+
+        auto& playerLog = vm.getGameState().getPlayerLog();
+        playerLog[topicName].section = static_cast<Daedalus::GameState::LogTopic::ESection>(section);
+    });
+
+    vm->registerExternalFunction("log_settopicstatus", [=](Daedalus::DaedalusVM& vm){
+        int32_t status = vm.popDataValue();
+        std::string topicName = vm.popString();
+
+        auto& playerLog = vm.getGameState().getPlayerLog();
+        playerLog[topicName].status = static_cast<Daedalus::GameState::LogTopic::ELogStatus>(status);
+    });
+
+    vm->registerExternalFunction("log_addentry", [=](Daedalus::DaedalusVM& vm){
+        std::string entry = vm.popString();
+        std::string topicName = vm.popString();
+
+        LogInfo() << "";
+        LogInfo() << " ########### New Log Entry: " << topicName << " ########### ";
+        LogInfo() << entry;
+        LogInfo() << "";
+
+        auto& playerLog = vm.getGameState().getPlayerLog();
+        playerLog[topicName].entries.push_back(entry);
+
+        pWorld->getScriptEngine().onLogEntryAdded(topicName, entry);
     });
 }
 

--- a/src/ui/Menu.cpp
+++ b/src/ui/Menu.cpp
@@ -178,7 +178,6 @@ bool UI::Menu::loadMenuDAT()
 
     // Load DAT-File...
     m_pVM = new Daedalus::DaedalusVM(datFile);
-    Daedalus::registerDaedalusStdLib(*m_pVM);
     Daedalus::registerGothicEngineClasses(*m_pVM);
 
     return true;


### PR DESCRIPTION
- This is step 1 of a refactoring process of the externals.
- step 2 will be gathering all signatures for all 333 externals ([WoG](https://www.worldofgothic.de/dl/index.php?go=g2functions)) and merging the parameter names from the externals.d into it. -> **new externals specification file**
- step 3 might be flagging certain int variables in the specification file like npc symbol indices.
- step 4 auto generating externals similiar to the current stubs from the specification file. Each registered function (lambda) will call a c++ function with the same name as the external. Signatures of those c++ functions can differ (take handles instead of script-indices). For some variables like npc symbol indices the respective engine handles will be created (i.e. NpcHandle). The c++ function will take these Handles as arguments instead of the script symbols.
- Ideally there will be no need to touch the registering calls anymore. Actual implementation will be done in the c++ function. Paramenter names should be adjusted in the specification file. Registering can be auto generated again.