### PR TITLE
Console auto complete + tp, kill, knockout, giveitem, removeitem rework

### DIFF
--- a/src/content/Sky.cpp
+++ b/src/content/Sky.cpp
@@ -81,8 +81,8 @@ void Sky::calculateLUT_ZenGin(const Math::float3& col0, const Math::float3& col1
 void Sky::interpolate()
 {
     // time since 12:00 in days
-    float skyTime = std::fmod(m_World.getEngine()->getGameClock().getTimeOfDay() + 0.5f, 1.0f);
-    m_MasterState.time = skyTime;
+    double skyTime = std::fmod(m_World.getEngine()->getGameClock().getTimeOfDay() + 0.5, 1.0);
+    m_MasterState.time = static_cast<float>(skyTime);
 
     // init with values for case: time >= TIME_KEY_7 (= 0.75f)
     size_t si0 = ESPT_NUM_PRESETS - 1, si1 = 0;

--- a/src/engine/GameClock.cpp
+++ b/src/engine/GameClock.cpp
@@ -1,27 +1,31 @@
 #include "GameClock.h"
 #include <cmath>
 #include <math/mathlib.h>
+#include <ZenLib/utils/logger.h>
 
 using namespace Engine;
 
 GameClock::GameClock()
 {
     m_ClockSpeedFactor = 1.0;
+    m_totalTimeInDays = 0;
+
     // day/clock init only necessary for test start world (not started via main menu)
     resetNewGame();
 }
 
 int GameClock::getDay() const
 {
-    return Math::ifloor(m_totalTimeInDays);
+    return lround(floor(m_totalTimeInDays));
 }
 
 void GameClock::setDay(int newDay) {
     m_totalTimeInDays += newDay - getDay();
 }
 
-void GameClock::update(float deltaRealTimeSeconds)
+void GameClock::update(double deltaRealTimeSeconds)
 {
+    LogInfo() << getTimeOfDay() / (totalSpeedUp() * deltaRealTimeSeconds / SECONDS_IN_A_DAY);
     m_totalTimeInDays += totalSpeedUp() * deltaRealTimeSeconds / SECONDS_IN_A_DAY;
 }
 
@@ -30,7 +34,7 @@ void GameClock::getTimeOfDay(int& hours, int& minutes) const
     dayTimeTohm(getTimeOfDay(), hours, minutes);
 }
 
-float GameClock::getTimeOfDay() const
+double GameClock::getTimeOfDay() const
 {
     return m_totalTimeInDays - getDay();
 }
@@ -47,7 +51,7 @@ void GameClock::setTimeOfDay(int hours, int minutes)
 
 void GameClock::setTotalSeconds(std::size_t s)
 {
-    m_totalTimeInDays = s / static_cast<float>(SECONDS_IN_A_DAY);
+    m_totalTimeInDays = s / static_cast<double>(SECONDS_IN_A_DAY);
 }
 
 std::size_t GameClock::getTotalSeconds()
@@ -64,7 +68,7 @@ float GameClock::totalSpeedUp() const
     return GAMETIME_REALTIME_RATIO * m_ClockSpeedFactor;
 }
 
-float GameClock::getTime(){
+double GameClock::getTime(){
     return m_totalTimeInDays;
 }
 
@@ -75,18 +79,19 @@ std::string GameClock::getTimeOfDayFormatted() const
     return std::to_string(h) + ":" + (m < 10 ? "0" : "") + std::to_string(m);
 }
 
-float GameClock::hmToDayTime(int hours, int minutes)
+double GameClock::hmToDayTime(int hours, int minutes)
 {
     return (hours + minutes / 60.0f) / 24.0f;
 }
 
-void GameClock::dayTimeTohm(float timeOfDay, int& hours, int& minutes)
+void GameClock::dayTimeTohm(double timeOfDay, int& hours, int& minutes)
 {
     hours = static_cast<int>(timeOfDay * 24);
     minutes = static_cast<int>((timeOfDay * 24 - hours) * 60);
 }
 
 void GameClock::resetNewGame() {
+    m_totalTimeInDays = 0;
     setDay(0);
     setTimeOfDay(8, 0);
 }

--- a/src/engine/GameClock.cpp
+++ b/src/engine/GameClock.cpp
@@ -1,5 +1,6 @@
 #include "GameClock.h"
 #include <cmath>
+#include <math/mathlib.h>
 
 using namespace Engine;
 
@@ -12,60 +13,46 @@ GameClock::GameClock()
 
 int GameClock::getDay() const
 {
-    return m_Day;
+    return Math::ifloor(m_totalTimeInDays);
 }
 
 void GameClock::setDay(int newDay) {
-    m_Day = newDay;
+    m_totalTimeInDays += newDay - getDay();
 }
 
 void GameClock::update(float deltaRealTimeSeconds)
 {
-    m_TimeOfDay += totalSpeedUp() * deltaRealTimeSeconds / SECONDS_IN_A_DAY;
-    if (m_TimeOfDay >= 1.0f)
-    {
-        float overFlowTimeOfDay = m_TimeOfDay;
-        m_TimeOfDay = std::fmod(m_TimeOfDay, 1.0f);
-        // handles also case where the ingame clock is updated by huge dt (> 1 day)
-        m_Day += std::lround(overFlowTimeOfDay - m_TimeOfDay);
-    }
+    m_totalTimeInDays += totalSpeedUp() * deltaRealTimeSeconds / SECONDS_IN_A_DAY;
 }
 
 void GameClock::getTimeOfDay(int& hours, int& minutes) const
 {
-    dayTimeTohm(m_TimeOfDay, hours, minutes);
+    dayTimeTohm(getTimeOfDay(), hours, minutes);
 }
 
 float GameClock::getTimeOfDay() const
 {
-    return m_TimeOfDay;
+    return m_totalTimeInDays - getDay();
 }
 
 std::string GameClock::getDateTimeFormatted() const
 {
-    return "Day " + std::to_string(m_Day) + ", " + getTimeOfDayFormatted();
+    return "Day " + std::to_string(getDay()) + ", " + getTimeOfDayFormatted();
 }
 
-void GameClock::setTimeOfDay(int hours, int minutes, bool onlyForward)
+void GameClock::setTimeOfDay(int hours, int minutes)
 {
-    float newTimeOfDay = hmToDayTime(hours, minutes);
-    if (onlyForward && newTimeOfDay < m_TimeOfDay)
-    {
-        m_Day++;
-    }
-    m_TimeOfDay = newTimeOfDay;
+    m_totalTimeInDays = getDay() + hmToDayTime(hours, minutes);
 }
 
 void GameClock::setTotalSeconds(std::size_t s)
 {
-    float inDays = s / static_cast<float>(SECONDS_IN_A_DAY);
-    m_Day = static_cast<int>(inDays);
-    m_TimeOfDay = inDays - m_Day;
+    m_totalTimeInDays = s / static_cast<float>(SECONDS_IN_A_DAY);
 }
 
 std::size_t GameClock::getTotalSeconds()
 {
-    return static_cast<std::size_t>((m_Day + m_TimeOfDay) * SECONDS_IN_A_DAY);
+    return static_cast<std::size_t>(m_totalTimeInDays * SECONDS_IN_A_DAY);
 }
 
 void GameClock::setClockSpeedFactor(float factor){
@@ -78,7 +65,7 @@ float GameClock::totalSpeedUp() const
 }
 
 float GameClock::getTime(){
-    return m_Day + m_TimeOfDay;
+    return m_totalTimeInDays;
 }
 
 std::string GameClock::getTimeOfDayFormatted() const

--- a/src/engine/GameClock.cpp
+++ b/src/engine/GameClock.cpp
@@ -25,7 +25,6 @@ void GameClock::setDay(int newDay) {
 
 void GameClock::update(double deltaRealTimeSeconds)
 {
-    LogInfo() << getTimeOfDay() / (totalSpeedUp() * deltaRealTimeSeconds / SECONDS_IN_A_DAY);
     m_totalTimeInDays += totalSpeedUp() * deltaRealTimeSeconds / SECONDS_IN_A_DAY;
 }
 

--- a/src/engine/GameClock.h
+++ b/src/engine/GameClock.h
@@ -51,11 +51,12 @@ namespace Engine
 
         /**
          * Set time to hours/minutes (24h format)
+         * hours + minutes / 60.0 may be greater than 24 or smaller than 0
+         * and the day will be adjusted in this case
          * @param hours
          * @param minutes
-         * @param onlyForward indicates whether the day should be incremented as well if given clock time is in past
          */
-        void setTimeOfDay(int hours, int minutes, bool onlyForward=false);
+        void setTimeOfDay(int hours, int minutes);
 
         /**
          * sets the total time directly
@@ -111,11 +112,14 @@ namespace Engine
         static constexpr float GAMETIME_REALTIME_RATIO = 14.5;
 
     private:
+        // Time elapsed since Day 0 00:00 in days
+        float m_totalTimeInDays;
+
         // Time elapsed in the game since last 00:00 in days (interval [0,1[)
-        float m_TimeOfDay;
+        float m_TimeOfDay2;
 
         // Number of full days elapsed in the game since "start new gothic game"
-        int m_Day;
+        int m_Day2;
 
         // define an extra speedup for the ingame clock
         float m_ClockSpeedFactor;

--- a/src/engine/GameClock.h
+++ b/src/engine/GameClock.h
@@ -30,7 +30,7 @@ namespace Engine
         /**
          * updates the game time with the given real time
          */
-        void update(float deltaRealTimeSeconds);
+        void update(double deltaRealTimeSeconds);
 
         /**
          * Converts time to hours/minutes (24h format)
@@ -42,7 +42,7 @@ namespace Engine
         /**
          * @return time elapsed in days since last midnight (0:00)
          */
-        float getTimeOfDay() const;
+        double getTimeOfDay() const;
 
         /**
          * @return Day + time of day as string
@@ -52,7 +52,7 @@ namespace Engine
         /**
          * Set time to hours/minutes (24h format)
          * hours + minutes / 60.0 may be greater than 24 or smaller than 0
-         * and the day will be adjusted in this case
+         * the day will be adjusted in this case
          * @param hours
          * @param minutes
          */
@@ -81,9 +81,9 @@ namespace Engine
         float totalSpeedUp() const;
 
         /**
-         * @return time in days since "new game" started
+         * @return time in days since day 0 0:00
          */
-        float getTime();
+        double getTime();
 
         /**
          * @return time of day as string in hh:mm format
@@ -94,17 +94,17 @@ namespace Engine
          * helper function for conversion
          * @param hours
          * @param minutes
-         * @return converts timespan in hours/minutes to days (float)
+         * @return converts timeOfDay in hours/minutes to days (double)
          */
-        static float hmToDayTime(int hours, int minutes);
+        static double hmToDayTime(int hours, int minutes);
 
         /**
          * helper function for conversion
          * @param hours
          * @param minutes
-         * @return converts timeOfDay in days (float) to hours/minutes
+         * @return converts timeOfDay in days (double) to hours/minutes
          */
-        static void dayTimeTohm(float timeOfDay, int& hours, int& minutes);
+        static void dayTimeTohm(double timeOfDay, int& hours, int& minutes);
 
         static constexpr unsigned int SECONDS_IN_A_DAY = 24 * 60 * 60;
 
@@ -113,7 +113,7 @@ namespace Engine
 
     private:
         // Time elapsed since Day 0 00:00 in days
-        float m_totalTimeInDays;
+        double m_totalTimeInDays;
 
         // define an extra speedup for the ingame clock
         float m_ClockSpeedFactor;

--- a/src/engine/GameClock.h
+++ b/src/engine/GameClock.h
@@ -115,12 +115,6 @@ namespace Engine
         // Time elapsed since Day 0 00:00 in days
         float m_totalTimeInDays;
 
-        // Time elapsed in the game since last 00:00 in days (interval [0,1[)
-        float m_TimeOfDay2;
-
-        // Number of full days elapsed in the game since "start new gothic game"
-        int m_Day2;
-
         // define an extra speedup for the ingame clock
         float m_ClockSpeedFactor;
     };

--- a/src/engine/PlatformGLFW.cpp
+++ b/src/engine/PlatformGLFW.cpp
@@ -216,7 +216,6 @@ int32_t PlatformGLFW::run(int argc, char** argv)
     bindKey(GLFW_KEY_P, ActionType::PauseGame, false);
 
     bindKey(GLFW_KEY_B, ActionType::OpenStatusMenu, false);
-    bindKey(GLFW_KEY_F10, ActionType::OpenConsole, false);
     bindKey(GLFW_KEY_ESCAPE, ActionType::UI_Close, false);
     bindKey(GLFW_KEY_UP, ActionType::UI_Up, false);
     bindKey(GLFW_KEY_DOWN, ActionType::UI_Down, false);

--- a/src/logic/Inventory.cpp
+++ b/src/logic/Inventory.cpp
@@ -117,7 +117,7 @@ unsigned int Inventory::getItemCount(Daedalus::GameState::ItemHandle item)
     Logic::ScriptEngine& vm = m_World.getScriptEngine();
 
     if(item.isValid())
-        return vm.getGameState().getItem(item).count[0];
+        return vm.getGameState().getItem(item).amount;
 
     return 0;
 }
@@ -133,7 +133,7 @@ void Inventory::exportInventory(json& j)
         std::string instanceName = vm.getVM().getDATFile().getSymbolByIndex(data.instanceSymbol).name;
 
         // Save instance and amount. Rest will be initialized by script on loading
-        j[instanceName] = data.count[0];
+        j[instanceName] = data.amount;
     }
 }
 
@@ -160,7 +160,7 @@ void Inventory::clear()
     {
         Daedalus::GEngineClasses::C_Item& data = vm.getGameState().getItem(item);
 
-        removeItem(item, (uint32_t)data.count[0]);
+        removeItem(item, data.amount);
     }
 
     assert(getItems().empty());

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -363,8 +363,8 @@ void PlayerController::onDebugDraw()
             {
                 Daedalus::GEngineClasses::C_Item idata = m_World.getScriptEngine().getGameState().getItem(i);
 
-                if(idata.count[0] > 1)
-                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s [%d]" , idata.getInventoryName().c_str(), idata.count[0]);
+                if(idata.amount > 1)
+                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s [%d]" , idata.getInventoryName().c_str(), idata.amount);
                 else
                     bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s", idata.getInventoryName().c_str());
 

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2026,13 +2026,6 @@ void PlayerController::setupKeyBindings()
         }
     });
 
-    Engine::Input::RegisterAction(Engine::ActionType::OpenConsole, [this](bool triggered, float) {
-        if(triggered && !m_World.getEngine()->getHud().isMenuActive())
-        {
-            m_World.getEngine()->getHud().getConsole().setOpen(true);
-        }
-    });
-
     Engine::Input::RegisterAction(Engine::ActionType::PlayerDrawWeaponMelee, [this](bool triggered, float) {
         m_isDrawWeaponMelee = triggered;
     });

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -356,6 +356,7 @@ void PlayerController::onDebugDraw()
         {
             // Print inventory
             const std::list<Daedalus::GameState::ItemHandle>& items = m_Inventory.getItems();
+            Daedalus::DATFile& datFile = m_World.getScriptEngine().getVM().getDATFile();
 
             uint16_t idx=20;
             bgfx::dbgTextPrintf(0, idx++, 0x0f, "Inventory:");
@@ -363,10 +364,23 @@ void PlayerController::onDebugDraw()
             {
                 Daedalus::GEngineClasses::C_Item idata = m_World.getScriptEngine().getGameState().getItem(i);
 
+                std::string displayName;
+                {
+                    if (!idata.description.empty())
+                    {
+                        displayName = idata.description;
+                    } else if (!idata.name.empty())
+                    {
+                        displayName = idata.name;
+                    } else {
+                        displayName = datFile.getSymbolByIndex(idata.instanceSymbol).name;
+                    }
+                }
+
                 if(idata.amount > 1)
-                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s [%d]" , idata.getInventoryName().c_str(), idata.amount);
+                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s [%d]" , displayName.c_str(), idata.amount);
                 else
-                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s", idata.getInventoryName().c_str());
+                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s", displayName.c_str());
 
             }
         }

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -358,7 +358,7 @@ void PlayerController::onDebugDraw()
             const std::list<Daedalus::GameState::ItemHandle>& items = m_Inventory.getItems();
             Daedalus::DATFile& datFile = m_World.getScriptEngine().getVM().getDATFile();
 
-            uint16_t idx=20;
+            uint16_t idx=27;
             bgfx::dbgTextPrintf(0, idx++, 0x0f, "Inventory:");
             for(Daedalus::GameState::ItemHandle i : items)
             {
@@ -2028,7 +2028,9 @@ void PlayerController::setupKeyBindings()
 
     Engine::Input::RegisterAction(Engine::ActionType::OpenConsole, [this](bool triggered, float) {
         if(triggered && !m_World.getEngine()->getHud().isMenuActive())
+        {
             m_World.getEngine()->getHud().getConsole().setOpen(true);
+        }
     });
 
     Engine::Input::RegisterAction(Engine::ActionType::PlayerDrawWeaponMelee, [this](bool triggered, float) {

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -364,9 +364,9 @@ void PlayerController::onDebugDraw()
                 Daedalus::GEngineClasses::C_Item idata = m_World.getScriptEngine().getGameState().getItem(i);
 
                 if(idata.count[0] > 1)
-                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s [%d]" , idata.description.c_str(), idata.count[0]);
+                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s [%d]" , idata.getInventoryName().c_str(), idata.count[0]);
                 else
-                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s", idata.description.c_str());
+                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s", idata.getInventoryName().c_str());
 
             }
         }

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -364,9 +364,9 @@ void PlayerController::onDebugDraw()
                 Daedalus::GEngineClasses::C_Item idata = m_World.getScriptEngine().getGameState().getItem(i);
 
                 if(idata.count[0] > 1)
-                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s [%d]" , idata.name.c_str(), idata.count[0]);
+                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s [%d]" , idata.description.c_str(), idata.count[0]);
                 else
-                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s", idata.name.c_str());
+                    bgfx::dbgTextPrintf(0, idx++, 0x0f, " %s", idata.description.c_str());
 
             }
         }

--- a/src/logic/ScriptEngine.cpp
+++ b/src/logic/ScriptEngine.cpp
@@ -338,9 +338,9 @@ std::set<Handle::EntityHandle> ScriptEngine::getNPCsInRadius(const Math::float3 
     return outSet;
 }
 
-std::set<Handle::EntityHandle> ScriptEngine::findWorldNPCsNameLike(std::string namePart)
+Handle::EntityHandle ScriptEngine::findWorldNPC(std::string name)
 {
-    std::set<Handle::EntityHandle> outSet;
+    std::string nameLower = Utils::lowered(name);
     auto& datFile = getVM().getDATFile();
 
     for(const Handle::EntityHandle& npc : getWorldNPCs())
@@ -353,15 +353,17 @@ std::set<Handle::EntityHandle> ScriptEngine::findWorldNPCsNameLike(std::string n
         std::string npcDisplayName = npcVobInfo.playerController->getScriptInstance().name[0];
         std::string npcDatFileName = datFile.getSymbolByIndex(npcScripObject.instanceSymbol).name;
 
-        for (const auto& npcName : {npcDisplayName, npcDatFileName})
+        for (auto npcName : {npcDisplayName, npcDatFileName})
         {
-            if (Utils::containsLike(npcName, namePart))
+            std::replace(npcName.begin(), npcName.end(), ' ', '_');
+            Utils::lower(npcName);
+            if (nameLower == npcName)
             {
-                outSet.insert(npc);
+                return npc;
             }
         }
     }
-    return outSet;
+    return Handle::EntityHandle();
 }
 
 void ScriptEngine::onLogEntryAdded(const std::string& topic, const std::string& entry)

--- a/src/logic/ScriptEngine.cpp
+++ b/src/logic/ScriptEngine.cpp
@@ -338,9 +338,8 @@ std::set<Handle::EntityHandle> ScriptEngine::getNPCsInRadius(const Math::float3 
     return outSet;
 }
 
-Handle::EntityHandle ScriptEngine::findWorldNPC(std::string name)
+Handle::EntityHandle ScriptEngine::findWorldNPC(const std::string& name)
 {
-    std::string nameLower = Utils::lowered(name);
     auto& datFile = getVM().getDATFile();
 
     for(const Handle::EntityHandle& npc : getWorldNPCs())
@@ -349,15 +348,14 @@ Handle::EntityHandle ScriptEngine::findWorldNPC(std::string name)
         if (!npcVobInfo.isValid())
             continue;
 
-        Daedalus::GEngineClasses::C_Npc& npcScripObject = VobTypes::getScriptObject(npcVobInfo);
-        std::string npcDisplayName = npcVobInfo.playerController->getScriptInstance().name[0];
-        std::string npcDatFileName = datFile.getSymbolByIndex(npcScripObject.instanceSymbol).name;
+        Daedalus::GEngineClasses::C_Npc& npcScriptObject = npcVobInfo.playerController->getScriptInstance();
+        std::string npcDisplayName = npcScriptObject.name[0];
+        std::string npcDatFileName = datFile.getSymbolByIndex(npcScriptObject.instanceSymbol).name;
 
         for (auto npcName : {npcDisplayName, npcDatFileName})
         {
             std::replace(npcName.begin(), npcName.end(), ' ', '_');
-            Utils::lower(npcName);
-            if (nameLower == npcName)
+            if (Utils::stringEqualIngoreCase(name, npcName))
             {
                 return npc;
             }

--- a/src/logic/ScriptEngine.h
+++ b/src/logic/ScriptEngine.h
@@ -134,7 +134,7 @@ namespace Logic
          * @param namePart full or partial name to be looked for
          * @return List of all NPCs whose names are similar to namePart
          */
-        Handle::EntityHandle findWorldNPC(std::string name);
+        Handle::EntityHandle findWorldNPC(const std::string& name);
 
         /**
          * Looks up the handle currently stored inside the given symbol. If it doesn't hold the right type or nothing

--- a/src/logic/ScriptEngine.h
+++ b/src/logic/ScriptEngine.h
@@ -129,12 +129,12 @@ namespace Logic
         const std::set<Handle::EntityHandle>& getWorldNPCs(){ return m_WorldNPCs; }
 
         /**
-         * Searches the current world for NPCs whose display-name or DATFile-name contain the given string.
-         * Comparison is case insensitive and strips off all non-alphanumeric characters first
+         * Searches the current world for NPCs with the given display-name or DATFile-name
+         * Comparison is case insensitive
          * @param namePart full or partial name to be looked for
          * @return List of all NPCs whose names are similar to namePart
          */
-        std::set<Handle::EntityHandle> findWorldNPCsNameLike(std::string namePart);
+        Handle::EntityHandle findWorldNPC(std::string name);
 
         /**
          * Looks up the handle currently stored inside the given symbol. If it doesn't hold the right type or nothing

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -765,9 +765,9 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         auto& clock = pWorld->getEngine()->getGameClock();
         int32_t hour, min;
         clock.getTimeOfDay(hour, min);
-        float timeOfDay = clock.getTimeOfDay();
-        float timeOfDay1 = clock.hmToDayTime(hour1, min1);
-        float timeOfDay2 = clock.hmToDayTime(hour2, min2);
+        double timeOfDay = clock.getTimeOfDay();
+        double timeOfDay1 = clock.hmToDayTime(hour1, min1);
+        double timeOfDay2 = clock.hmToDayTime(hour2, min2);
         bool inside;
         if (timeOfDay1 < timeOfDay2)
         {

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -816,7 +816,6 @@ public:
                 amount = static_cast<unsigned int>(std::stoul(args[2]));
 
             auto& se = m_pEngine->getMainWorld().get().getScriptEngine();
-            VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(), se.getPlayerEntity());
 
             std::vector<std::vector<std::string>> candidateLists;
             {
@@ -827,49 +826,46 @@ public:
                     cItem = Daedalus::GEngineClasses::C_Item();
                     // Run the script-constructor
                     se.getVM().initializeInstance(ZMemory::toBigHandle(dummyHandle), i, Daedalus::IC_Item);
-                    if (cItem.description == "")
-                    {
-                        cItem.description = cItem.name;
-                    }
-                    candidateLists.push_back({parSymbol.name, cItem.description, cItem.name});
+
+                    candidateLists.push_back({parSymbol.name, cItem.getInventoryName(), cItem.name});
                 });
                 se.getVM().getGameState().removeItem(dummyHandle);
             }
-
+            // std::vector<std::tuple<std::size_t, std::string>> matchCandidates;
             for (auto& candidateList : candidateLists)
             {
                 for (auto& candidate : candidateList)
                 {
-                    if (Utils::containsLike(candidate, partItemName)) {
+                    if (Utils::strippedAndLowered(candidate) == Utils::strippedAndLowered(partItemName)){
                         auto& parScriptName = candidateList[0];
+                        VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(), se.getPlayerEntity());
                         auto handle = player.playerController->getInventory().addItem(parScriptName, amount);
                         Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(handle);
-                        return std::string("Item(s) added to the inventory: ") + cItem.description + " (" + parScriptName + ")";
+                        return std::string("Item(s) added to the inventory: ") + cItem.getInventoryName() + " (" + parScriptName + ")";
                     }
                 }
             }
             return "Item not found!";
         });
 
-        console.registerCommand("ls", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("items", [this](const std::vector<std::string>& args) -> std::string {
             auto& se = m_pEngine->getMainWorld().get().getScriptEngine();
 
             Daedalus::GameState::ItemHandle dummyHandle = se.getVM().getGameState().createItem();
             Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(dummyHandle);
-            se.getVM().getDATFile().iterateSymbolsOfClass("C_ITEM", [&](size_t i, Daedalus::PARSymbol& parSymbol){
-                // reset to default values. especially name and description
-                cItem = Daedalus::GEngineClasses::C_Item();
-                // Run the script-constructor
-                se.getVM().initializeInstance(ZMemory::toBigHandle(dummyHandle), i, Daedalus::IC_Item);
-                if (cItem.description == "")
-                {
-                    cItem.description = cItem.name;
-                }
-                LogInfo() << parSymbol.name << " " << cItem.description << " " << cItem.name;
-            });
+            {
+                Utils::Profiler a("gather candidates");
+                se.getVM().getDATFile().iterateSymbolsOfClass("C_ITEM", [&](size_t i, Daedalus::PARSymbol& parSymbol){
+                    // reset to default values. especially name and description
+                    cItem = Daedalus::GEngineClasses::C_Item();
+                    // Run the script-constructor
+                    se.getVM().initializeInstance(ZMemory::toBigHandle(dummyHandle), i, Daedalus::IC_Item);
+                    LogInfo() << parSymbol.name << " " << cItem.getInventoryName() << " " << cItem.name;
+                });
+            }
             se.getVM().getGameState().removeItem(dummyHandle);
 
-            return "items listed";
+            return "items have been written to the terminal";
         });
 
         imguiCreate(nullptr, 0, fontSize);

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -1053,8 +1053,12 @@ public:
 
         if(!m_NoHUD)
         {
-            bgfx::dbgTextPrintf(0, 1, 0x4f, "REGoth-Engine (%s)", m_pEngine->getEngineArgs().startupZEN.c_str());
-            bgfx::dbgTextPrintf(0, 2, 0x0f, "Frame: % 7.3f[ms] %.1f[fps]", 1000.0 * dt, 1.0f / (double(dt)));
+            uint16_t xOffset = 0;
+
+            if (m_pEngine->getHud().getConsole().isOpen())
+                xOffset = 100;
+            bgfx::dbgTextPrintf(xOffset, 1, 0x4f, "REGoth-Engine (%s)", m_pEngine->getEngineArgs().startupZEN.c_str());
+            bgfx::dbgTextPrintf(xOffset, 2, 0x0f, "Frame: % 7.3f[ms] %.1f[fps]", 1000.0 * dt, 1.0f / (double(dt)));
         }
 
         // This dummy draw call is here to make sure that view 0 is cleared

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -445,16 +445,26 @@ public:
             return "Hero successfully exported to: hero.json";
         });
 
+        auto waypointNamesGen = [this]() -> std::vector<std::vector<std::string>> {
+            std::vector<std::vector<std::string>> groups;
+            auto& waypoints = m_pEngine->getMainWorld().get().getWaynet().waypoints;
+            for (auto& waypoint : waypoints)
+            {
+                groups.push_back({waypoint.name});
+            }
+            return groups;
+        };
+
         console.registerCommand("goto waypoint", [this](const std::vector<std::string>& args) -> std::string {
             if(args.size() != 3)
                 return "Invalid argument. Usage: goto waypoint [waypoint]";
 
-            const std::string &waypointArgument = args[2];
+            const std::string& waypointArgument = args[2];
             const World::Waynet::WaynetInstance& waynet = m_pEngine->getMainWorld().get().getWaynet();
             Logic::ScriptEngine &scriptEngine = m_pEngine->getMainWorld().get().getScriptEngine();
             const auto waypointIndex = World::Waynet::getWaypointIndex(waynet, waypointArgument);
             if(waypointIndex == World::Waynet::INVALID_WAYPOINT)
-                return "Error: Waypoint" + waypointArgument + "not found";
+                return "Error: Waypoint " + waypointArgument + " not found";
 
             VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(), scriptEngine.getPlayerEntity());
             if(!player.isValid())
@@ -462,7 +472,7 @@ public:
             player.playerController->teleportToWaypoint(waypointIndex);
 
             return "Player moved to waypoint " + waypointArgument;
-        });
+        }).registerAutoComplete(waypointNamesGen);
 
         console.registerCommand("heroimport", [this](const std::vector<std::string>& args) -> std::string {
             auto& s = m_pEngine->getMainWorld().get().getScriptEngine();

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -808,7 +808,7 @@ public:
         });
 
         auto dummy = [](const std::vector<std::string>& args) -> std::string{ return "";};
-        auto itemGen = []() -> std::vector<std::string> { return {"foo", "bar"}; };
+        auto itemGen = []() -> std::vector<std::string> { return {"Torch", "FACKEL"}; };
         console.registerCommand2({gen({"giveitem", "removeitem"}), itemGen}, dummy, 1);
         console.registerCommand2({gen({"set"}), gen({"clock", "clockspeed"})}, dummy, 2);
 

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -640,13 +640,23 @@ public:
             if(args.size() != 2)
                 return "Missing argument. Usage: givexp <experience points>";
 
-            if (!s1.getVM().getDATFile().hasSymbolName("B_GiveXP"))
-                return "B_GiveXP is undefined!";
+            std::string scriptName;
+            // B_GiveXP is called B_GivePlayerXP in Gothic II
+            for (auto scriptFunctionName : {"B_GiveXP", "B_GivePlayerXP"})
+            {
+                if (s1.getVM().getDATFile().hasSymbolName(scriptFunctionName))
+                {
+                    scriptName = scriptFunctionName;
+                    break;
+                }
+            }
+            if (scriptName.empty())
+                return "error: could not find script functions";
 
             int exp = std::stoi(args[1]);
             s1.prepareRunFunction();
             s1.pushInt(exp);
-            s1.runFunction("B_GiveXP");
+            s1.runFunction(scriptName);
 
             return "Experience points successfully given";
         });

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -336,6 +336,12 @@ public:
         fontSize = 23.0f;
 #endif
 
+        auto gen = [](std::vector<std::string> candidates){
+            return [candidates]() -> std::vector<std::string>{
+                return candidates;
+            };
+        };
+
         auto& console = m_pEngine->getHud().getConsole();
         console.registerCommand("stats", [](const std::vector<std::string>& args) -> std::string {
             static bool s_Stats = false;
@@ -800,6 +806,11 @@ public:
 
             return "Used " + std::to_string(dmg) + " mana";
         });
+
+        auto dummy = [](const std::vector<std::string>& args) -> std::string{ return "";};
+        auto itemGen = []() -> std::vector<std::string> { return {"foo", "bar"}; };
+        console.registerCommand2({gen({"giveitem", "removeitem"}), itemGen}, dummy, 1);
+        console.registerCommand2({gen({"set"}), gen({"clock", "clockspeed"})}, dummy, 2);
 
         console.registerCommand("quit", [](const std::vector<std::string>& args) -> std::string {
             setQuit(true);

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -344,7 +344,7 @@ public:
         };
 
         auto& console = m_pEngine->getHud().getConsole();
-        console.registerCommand2({gen({{"stats"}})}, 1, [](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("stats", [](const std::vector<std::string>& args) -> std::string {
             static bool s_Stats = false;
             s_Stats = !s_Stats;
 
@@ -352,7 +352,7 @@ public:
             return "Toggled stats";
         });
 
-        console.registerCommand2({gen({{"hud"}})}, 1, [&](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("hud", [&](const std::vector<std::string>& args) -> std::string {
             static bool s_Stats = false;
             s_Stats = !s_Stats;
 
@@ -361,7 +361,7 @@ public:
             return "Toggled hud";
         });
 
-        console.registerCommand2({gen({{"camera"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("camera", [this](const std::vector<std::string>& args) -> std::string {
 
             if(args.size() < 2)
                 return "Missing argument. Usage: camera <mode> | (0=Free, 1=Static, 2=FirstPerson, 3=ThirdPerson)";
@@ -373,11 +373,11 @@ public:
             return "Cameramode changed to " + std::to_string(idx);
         });
 
-        console.registerCommand2({gen({{"test"}})}, 1, [](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("test", [](const std::vector<std::string>& args) -> std::string {
             return "Hello World!";
         });
 
-        console.registerCommand2({gen({{"set"}}), gen({{"day"}})}, 2, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("set day", [this](const std::vector<std::string>& args) -> std::string {
             // modifies the day
             if(args.size() < 3)
                 return "Missing argument. Usage: set day <day>";
@@ -389,7 +389,7 @@ public:
             return "Set day to " + std::to_string(clock.getDay());
         });
 
-        console.registerCommand2({gen({{"set"}}), gen({{"clock"}})}, 2, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("set clock", [this](const std::vector<std::string>& args) -> std::string {
             // modifies the world time
             if(args.size() != 4)
                 return "Invalid arguments. Usage: set clock [hh mm]";
@@ -408,7 +408,7 @@ public:
             return "Set clock to " + clock.getTimeOfDayFormatted();
         });
 
-        console.registerCommand2({gen({{"set"}}), gen({{"clockspeed"}})}, 2, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("set clockspeed", [this](const std::vector<std::string>& args) -> std::string {
             // adds an additional speed factor for the time of day
             if(args.size() < 3)
                 return "Missing argument. Usage: set clockspeed <factor>";
@@ -419,7 +419,7 @@ public:
             return "Set clockspeed to " + std::to_string(factor);
         });
 
-        console.registerCommand2({gen({{"set"}}), gen({{"gamespeed"}})}, 2, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("set gamespeed", [this](const std::vector<std::string>& args) -> std::string {
             // adds an additional speed factor for the game time
             if(args.size() < 3)
                 return "Missing argument. Usage: set gamespeed <factor:default=1>";
@@ -430,7 +430,7 @@ public:
             return "Set gamespeed to " + std::to_string(factor);
         });
 
-        console.registerCommand2({gen({{"camera"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("heroexport", [this](const std::vector<std::string>& args) -> std::string {
             auto& s = m_pEngine->getMainWorld().get().getScriptEngine();
 
             VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(), s.getPlayerEntity());
@@ -445,7 +445,7 @@ public:
             return "Hero successfully exported to: hero.json";
         });
 
-        console.registerCommand2({gen({{"goto"}}), gen({{"waypoint"}})}, 2, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("goto waypoint", [this](const std::vector<std::string>& args) -> std::string {
             if(args.size() != 3)
                 return "Invalid argument. Usage: goto waypoint [waypoint]";
 
@@ -464,7 +464,7 @@ public:
             return "Player moved to waypoint " + waypointArgument;
         });
 
-        console.registerCommand2({gen({{"heroimport"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("heroimport", [this](const std::vector<std::string>& args) -> std::string {
             auto& s = m_pEngine->getMainWorld().get().getScriptEngine();
 
             std::ifstream f("hero.json");
@@ -479,7 +479,7 @@ public:
             return "Hero successfully imported from: hero.json";
         });
 
-        console.registerCommand2({gen({{"switchlevel"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("switchlevel", [this](const std::vector<std::string>& args) -> std::string {
 
             auto& s1 = m_pEngine->getMainWorld().get().getScriptEngine();
 
@@ -540,7 +540,7 @@ public:
             return "Successfully switched world to: " + file;
         });
 
-        console.registerCommand2({gen({{"load"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("load", [this](const std::vector<std::string>& args) -> std::string {
 
             if(args.size() != 2)
                 return "Missing argument. Usage: load <savegame>";
@@ -567,7 +567,7 @@ public:
             m_pEngine->addWorld("", worldPath);
         });
 
-        console.registerCommand2({gen({{"save"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("save", [this](const std::vector<std::string>& args) -> std::string {
 
             if(args.size() < 2)
                 return "Missing argument. Usage: save <savegame>";
@@ -624,7 +624,7 @@ public:
             return aliasGroups;
         };
 
-        console.registerCommand2({gen({{"knockout"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("knockout", [this](const std::vector<std::string>& args) -> std::string {
 
             VobTypes::NpcVobInformation npc;
             auto& scriptEngine = m_pEngine->getMainWorld().get().getScriptEngine();
@@ -661,7 +661,7 @@ public:
             return npc.playerController->getScriptInstance().name[0] + " is now in UNCONSCIOUS state";
         });
 
-        console.registerCommand2({gen({{"givexp"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("givexp", [this](const std::vector<std::string>& args) -> std::string {
             auto& s1 = m_pEngine->getMainWorld().get().getScriptEngine();
 
             if(args.size() != 2)
@@ -713,7 +713,7 @@ public:
             return "Could not find NPC " + requested;
         };
 
-        console.registerCommand2({gen({{"tp"}}), npcNamesGen}, 1, tpCallback);
+        console.registerCommand("tp", tpCallback).registerAutoComplete(npcNamesGen);
 
         auto killCallback = [this](const std::vector<std::string>& args) -> std::string {
 
@@ -764,9 +764,9 @@ public:
             return npc.playerController->getScriptInstance().name[0] + " is now in DEAD state";
         };
 
-        console.registerCommand2({gen({{"kill"}}), npcNamesGen}, 1, killCallback);
+        console.registerCommand("kill", killCallback).registerAutoComplete(npcNamesGen);
 
-        console.registerCommand2({gen({{"interrupt"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("interrupt", [this](const std::vector<std::string>& args) -> std::string {
 
             VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(),
                                                                     m_pEngine->getMainWorld().get().getScriptEngine().getPlayerEntity());
@@ -776,7 +776,7 @@ public:
             return "Interrupted player, cleared EM";
         });
 
-        console.registerCommand2({gen({{"hurtself"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("hurtself", [this](const std::vector<std::string>& args) -> std::string {
 
             VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(),
                                                                     m_pEngine->getMainWorld().get().getScriptEngine().getPlayerEntity());
@@ -790,7 +790,7 @@ public:
             return "Hurt player by " + std::to_string(dmg) + " HP";
         });
 
-        console.registerCommand2({gen({{"usemana"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("usemana", [this](const std::vector<std::string>& args) -> std::string {
 
             VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(),
                                                                     m_pEngine->getMainWorld().get().getScriptEngine().getPlayerEntity());
@@ -830,7 +830,7 @@ public:
             return aliasGroups;
         };
 
-        console.registerCommand2({gen({{"quit"}})}, 1, [](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("quit", [](const std::vector<std::string>& args) -> std::string {
             setQuit(true);
             return std::string("Exiting ...");
         });
@@ -901,7 +901,7 @@ public:
             return "Item not found!";
         };
 
-        console.registerCommand2({gen({{"giveitem"}, {"removeitem"}}), itemNamesGen}, 1, giveOrRemoveItemCallback);
+        console.registerCommand("giveitem", giveOrRemoveItemCallback).registerAutoComplete(itemNamesGen);
 
         imguiCreate(nullptr, 0, fontSize);
         m_ImgUiCreated = true;

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -985,7 +985,7 @@ public:
             {
                 m_stopWatch.start();
 
-                if(m_pEngine->getHud().getConsole().isOpen())
+                if(m_pEngine->getHud().getConsole().isOpen() || i == GLFW_KEY_F10)
                     m_pEngine->getHud().getConsole().onKeyDown(i);
                 else if (keyMap.find(i) != keyMap.end())
                 {
@@ -998,7 +998,7 @@ public:
                 {
                     if (m_stopWatch.DelayedByArgMS(70))
                     {
-                        if(m_pEngine->getHud().getConsole().isOpen())
+                        if(m_pEngine->getHud().getConsole().isOpen() || i == GLFW_KEY_F10)
                             m_pEngine->getHud().getConsole().onKeyDown(i);
                         else if (keyMap.find(i) != keyMap.end())
                         {

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -344,7 +344,7 @@ public:
         };
 
         auto& console = m_pEngine->getHud().getConsole();
-        console.registerCommand("stats", [](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"stats"}})}, 1, [](const std::vector<std::string>& args) -> std::string {
             static bool s_Stats = false;
             s_Stats = !s_Stats;
 
@@ -352,7 +352,7 @@ public:
             return "Toggled stats";
         });
 
-        console.registerCommand("hud", [&](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"hud"}})}, 1, [&](const std::vector<std::string>& args) -> std::string {
             static bool s_Stats = false;
             s_Stats = !s_Stats;
 
@@ -361,15 +361,7 @@ public:
             return "Toggled hud";
         });
 
-        console.registerCommand("stats", [](const std::vector<std::string>& args) -> std::string {
-            static bool s_Stats = false;
-            s_Stats = !s_Stats;
-
-            bgfx::setDebug(s_Stats ? BGFX_DEBUG_STATS : 0);
-            return "Toggled stats";
-        });
-
-        console.registerCommand("camera", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"camera"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
 
             if(args.size() < 2)
                 return "Missing argument. Usage: camera <mode> | (0=Free, 1=Static, 2=FirstPerson, 3=ThirdPerson)";
@@ -381,13 +373,12 @@ public:
             return "Cameramode changed to " + std::to_string(idx);
         });
 
-
-        console.registerCommand("test", [](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"test"}})}, 1, [](const std::vector<std::string>& args) -> std::string {
             return "Hello World!";
         });
 
-        console.registerCommand("set day", [this](const std::vector<std::string>& args) -> std::string {
-            // modifies the world time
+        console.registerCommand2({gen({{"set"}}), gen({{"day"}})}, 2, [this](const std::vector<std::string>& args) -> std::string {
+            // modifies the day
             if(args.size() < 3)
                 return "Missing argument. Usage: set day <day>";
 
@@ -398,7 +389,7 @@ public:
             return "Set day to " + std::to_string(clock.getDay());
         });
 
-        console.registerCommand("set clock", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"set"}}), gen({{"clock"}})}, 2, [this](const std::vector<std::string>& args) -> std::string {
             // modifies the world time
             if(args.size() != 4)
                 return "Invalid arguments. Usage: set clock [hh mm]";
@@ -417,7 +408,7 @@ public:
             return "Set clock to " + clock.getTimeOfDayFormatted();
         });
 
-        console.registerCommand("set clockspeed", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"set"}}), gen({{"clockspeed"}})}, 2, [this](const std::vector<std::string>& args) -> std::string {
             // adds an additional speed factor for the time of day
             if(args.size() < 3)
                 return "Missing argument. Usage: set clockspeed <factor>";
@@ -428,7 +419,7 @@ public:
             return "Set clockspeed to " + std::to_string(factor);
         });
 
-        console.registerCommand("set gamespeed", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"set"}}), gen({{"gamespeed"}})}, 2, [this](const std::vector<std::string>& args) -> std::string {
             // adds an additional speed factor for the game time
             if(args.size() < 3)
                 return "Missing argument. Usage: set gamespeed <factor:default=1>";
@@ -439,7 +430,7 @@ public:
             return "Set gamespeed to " + std::to_string(factor);
         });
 
-        console.registerCommand("heroexport", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"camera"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
             auto& s = m_pEngine->getMainWorld().get().getScriptEngine();
 
             VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(), s.getPlayerEntity());
@@ -454,7 +445,7 @@ public:
             return "Hero successfully exported to: hero.json";
         });
 
-        console.registerCommand("goto waypoint", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"goto"}}), gen({{"waypoint"}})}, 2, [this](const std::vector<std::string>& args) -> std::string {
             if(args.size() != 3)
                 return "Invalid argument. Usage: goto waypoint [waypoint]";
 
@@ -473,7 +464,7 @@ public:
             return "Player moved to waypoint " + waypointArgument;
         });
 
-        console.registerCommand("heroimport", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"heroimport"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
             auto& s = m_pEngine->getMainWorld().get().getScriptEngine();
 
             std::ifstream f("hero.json");
@@ -488,7 +479,7 @@ public:
             return "Hero successfully imported from: hero.json";
         });
 
-        console.registerCommand("switchlevel", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"switchlevel"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
 
             auto& s1 = m_pEngine->getMainWorld().get().getScriptEngine();
 
@@ -549,7 +540,7 @@ public:
             return "Successfully switched world to: " + file;
         });
 
-        console.registerCommand("load", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"load"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
 
             if(args.size() != 2)
                 return "Missing argument. Usage: load <savegame>";
@@ -576,7 +567,7 @@ public:
             m_pEngine->addWorld("", worldPath);
         });
 
-        console.registerCommand("save", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"save"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
 
             if(args.size() < 2)
                 return "Missing argument. Usage: save <savegame>";
@@ -633,21 +624,7 @@ public:
             return aliasGroups;
         };
 
-        auto findNameInGroups = [](std::vector<std::vector<std::string>> groups, std::string name) -> std::vector<std::string>{
-            Utils::lower(name);
-            for (auto& aliasGroup : groups)
-            {
-                for (auto& alias : aliasGroup) {
-                    if (Utils::lowered(alias) == name)
-                    {
-                        return aliasGroup;
-                    }
-                }
-            }
-            return {};
-        };
-
-        console.registerCommand("knockout", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"knockout"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
 
             VobTypes::NpcVobInformation npc;
             auto& scriptEngine = m_pEngine->getMainWorld().get().getScriptEngine();
@@ -684,7 +661,7 @@ public:
             return npc.playerController->getScriptInstance().name[0] + " is now in UNCONSCIOUS state";
         });
 
-        console.registerCommand("givexp", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"givexp"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
             auto& s1 = m_pEngine->getMainWorld().get().getScriptEngine();
 
             if(args.size() != 2)
@@ -701,7 +678,7 @@ public:
             return "Experience points successfully given";
         });
 
-        auto tpCallback = [this, npcNamesGen, findNameInGroups](const std::vector<std::string>& args) -> std::string {
+        auto tpCallback = [this, npcNamesGen](const std::vector<std::string>& args) -> std::string {
             if (args.size() < 2)
                 return "Missing argument(s). Usage: tp <name>";
 
@@ -711,7 +688,7 @@ public:
             auto& datFile = scriptEngine.getVM().getDATFile();
 
             auto aliasGroups = npcNamesGen();
-            auto group = findNameInGroups(aliasGroups, requested);
+            auto group = Utils::findNameInGroups(aliasGroups, requested);
 
             if (group.size() >= 2)
             {
@@ -736,8 +713,7 @@ public:
             return "Could not find NPC " + requested;
         };
 
-        console.registerCommand2({gen({{"tp"}}), npcNamesGen}, tpCallback, 1);
-        console.registerCommand("tp", tpCallback);
+        console.registerCommand2({gen({{"tp"}}), npcNamesGen}, 1, tpCallback);
 
         auto killCallback = [this](const std::vector<std::string>& args) -> std::string {
 
@@ -788,10 +764,9 @@ public:
             return npc.playerController->getScriptInstance().name[0] + " is now in DEAD state";
         };
 
-        console.registerCommand("kill", killCallback);
-        // console.registerCommand2({gen({"kill"}), npcNamesGen}, killCallback, 1);
+        console.registerCommand2({gen({{"kill"}}), npcNamesGen}, 1, killCallback);
 
-        console.registerCommand("interrupt", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"interrupt"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
 
             VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(),
                                                                     m_pEngine->getMainWorld().get().getScriptEngine().getPlayerEntity());
@@ -801,7 +776,7 @@ public:
             return "Interrupted player, cleared EM";
         });
 
-        console.registerCommand("hurtself", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"hurtself"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
 
             VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(),
                                                                     m_pEngine->getMainWorld().get().getScriptEngine().getPlayerEntity());
@@ -815,7 +790,7 @@ public:
             return "Hurt player by " + std::to_string(dmg) + " HP";
         });
 
-        console.registerCommand("usemana", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"usemana"}})}, 1, [this](const std::vector<std::string>& args) -> std::string {
 
             VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(),
                                                                     m_pEngine->getMainWorld().get().getScriptEngine().getPlayerEntity());
@@ -855,7 +830,7 @@ public:
             return aliasGroups;
         };
 
-        console.registerCommand("quit", [](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand2({gen({{"quit"}})}, 1, [](const std::vector<std::string>& args) -> std::string {
             setQuit(true);
             return std::string("Exiting ...");
         });
@@ -893,64 +868,40 @@ public:
 
             std::size_t index = 0;
             auto aliasGroups = itemNamesGen();
-            for (auto& aliasGroup : aliasGroups)
+            auto group = Utils::findNameInGroups(aliasGroups, itemName);
+            if (group.size() == 3)
             {
-                for (auto& alias : aliasGroup)
+                auto& parScriptName = group[0];
+                VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(), se.getPlayerEntity());
+                std::string description;
+                std::string action;
+                if (cmdType == give)
                 {
-                    if (Utils::lowered(alias) == Utils::lowered(itemName)){
-                        auto& parScriptName = aliasGroup[0];
-                        VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(), se.getPlayerEntity());
-                        std::string description;
-                        std::string action;
-                        if (cmdType == give)
-                        {
-                            auto handle = player.playerController->getInventory().addItem(parScriptName, amount);
-                            Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(handle);
-                            description = cItem.description;
-                            action = "added to";
-                        } else if (cmdType == remove) {
-                            auto handle = player.playerController->getInventory().getItem(parScriptName);
-                            if (handle.isValid())
-                            {
-                                Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(handle);
-                                description =  cItem.description;
-                                action = "removed from";
-                                amount = std::min(static_cast<u_int32_t >(amount), cItem.amount);
-                                player.playerController->getInventory().removeItem(parScriptName, amount);
-                            } else {
-                                return "error: could not remove item. item " + parScriptName + " is not in inventory";
-                            }
-                        }
-                        return std::string("Item(s) " + action + " the inventory: ")
-                               + std::to_string(amount) + " x " + description + " (" + parScriptName + ")";
+                    auto handle = player.playerController->getInventory().addItem(parScriptName, amount);
+                    Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(handle);
+                    description = cItem.description;
+                    action = "added to";
+                } else if (cmdType == remove) {
+                    auto handle = player.playerController->getInventory().getItem(parScriptName);
+                    if (handle.isValid())
+                    {
+                        Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(handle);
+                        description =  cItem.description;
+                        action = "removed from";
+                        amount = std::min(static_cast<u_int32_t >(amount), cItem.amount);
+                        player.playerController->getInventory().removeItem(parScriptName, amount);
+                    } else {
+                        return "error: could not remove item. item " + parScriptName + " is not in inventory";
                     }
                 }
+                return std::string("Item(s) " + action + " the inventory: ")
+                       + std::to_string(amount) + " x " + description + " (" + parScriptName + ")";
+
             }
             return "Item not found!";
         };
 
-        console.registerCommand2({gen({{"giveitem"}, {"removeitem"}}), itemNamesGen}, giveOrRemoveItemCallback, 1);
-        console.registerCommand("giveitem", giveOrRemoveItemCallback);
-
-        console.registerCommand("items", [this](const std::vector<std::string>& args) -> std::string {
-            auto& se = m_pEngine->getMainWorld().get().getScriptEngine();
-
-            Daedalus::GameState::ItemHandle dummyHandle = se.getVM().getGameState().createItem();
-            Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(dummyHandle);
-            {
-                Utils::Profiler a("gather candidates");
-                se.getVM().getDATFile().iterateSymbolsOfClass("C_ITEM", [&](size_t i, Daedalus::PARSymbol& parSymbol){
-                    // reset to default values. especially name and description
-                    cItem = Daedalus::GEngineClasses::C_Item();
-                    // Run the script-constructor
-                    se.getVM().initializeInstance(ZMemory::toBigHandle(dummyHandle), i, Daedalus::IC_Item);
-                    LogInfo() << parSymbol.name << " " << cItem.name << " " << cItem.description;
-                });
-            }
-            se.getVM().getGameState().removeItem(dummyHandle);
-
-            return "items have been written to the terminal";
-        });
+        console.registerCommand2({gen({{"giveitem"}, {"removeitem"}}), itemNamesGen}, 1, giveOrRemoveItemCallback);
 
         imguiCreate(nullptr, 0, fontSize);
         m_ImgUiCreated = true;

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -852,6 +852,11 @@ public:
                         std::replace(name.begin(), name.end(), ' ', '_');
                         aliasGroup.push_back(name);
                     }
+                    if (aliasGroup[1] == aliasGroup[2])
+                    {
+                        // most of the items have description equal to name, so remove one of them
+                        aliasGroup.pop_back();
+                    }
                     aliasGroups.push_back(aliasGroup);
                 });
                 se.getVM().getGameState().removeItem(dummyHandle);
@@ -881,7 +886,7 @@ public:
             std::size_t index = 0;
             auto aliasGroups = itemNamesGen();
             auto group = Utils::findNameInGroups(aliasGroups, itemName);
-            if (group.size() == 3)
+            if (group.size() >= 1)
             {
                 auto& parScriptName = group[0];
                 VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(), se.getPlayerEntity());

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -336,13 +336,6 @@ public:
         fontSize = 23.0f;
 #endif
 
-        std::function<UI::ConsoleCommand::CandidateListGenerator(std::vector<std::vector<std::string>>)> gen =
-                [](std::vector<std::vector<std::string>> candidates) {
-            return [candidates]() {
-                return candidates;
-            };
-        };
-
         auto& console = m_pEngine->getHud().getConsole();
         console.registerCommand("stats", [](const std::vector<std::string>& args) -> std::string {
             static bool s_Stats = false;

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -877,7 +877,7 @@ public:
                     {
                         Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(handle);
                         description =  cItem.description;
-                        amount = std::min(static_cast<u_int32_t >(amount), cItem.amount);
+                        amount = std::min(static_cast<uint32_t>(amount), cItem.amount);
                         player.playerController->getInventory().removeItem(parScriptName, amount);
                     } else {
                         return "error: could not remove item. item " + parScriptName + " is not in inventory";

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -787,19 +787,19 @@ public:
             return "Hurt player by " + std::to_string(dmg) + " HP";
         });
 
-		console.registerCommand("usemana", [this](const std::vector<std::string>& args) -> std::string {
+        console.registerCommand("usemana", [this](const std::vector<std::string>& args) -> std::string {
 
-			VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(),
-				m_pEngine->getMainWorld().get().getScriptEngine().getPlayerEntity());
+            VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_pEngine->getMainWorld().get(),
+                                                                    m_pEngine->getMainWorld().get().getScriptEngine().getPlayerEntity());
 
-			if(args.size() < 2)
-				return "Missing argument. Usage: usemana <mana>";
+            if(args.size() < 2)
+                return "Missing argument. Usage: usemana <mana>";
 
-			int dmg = std::stoi(args[1]);
-			player.playerController->changeAttribute(Daedalus::GEngineClasses::C_Npc::EATR_MANA, -dmg);
+            int dmg = std::stoi(args[1]);
+            player.playerController->changeAttribute(Daedalus::GEngineClasses::C_Npc::EATR_MANA, -dmg);
 
-			return "Used " + std::to_string(dmg) + " mana";
-		});
+            return "Used " + std::to_string(dmg) + " mana";
+        });
 
         console.registerCommand("quit", [](const std::vector<std::string>& args) -> std::string {
             setQuit(true);
@@ -851,10 +851,11 @@ public:
                             auto handle = player.playerController->getInventory().getItem(parScriptName);
                             if (handle.isValid())
                             {
+                                uint32_t removeAmount = static_cast<uint32_t >(-amount);
                                 Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(handle);
                                 description = cItem.getInventoryName();
                                 action = "removed from";
-                                amount = std::min(-amount, cItem.count[0]);
+                                amount = std::min(removeAmount, cItem.amount);
                                 player.playerController->getInventory().removeItem(parScriptName, amount);
                             } else {
                                 return "error: could not remove item. item " + parScriptName + " is not in inventory";

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -46,7 +46,6 @@ Console::Console(Engine::BaseEngine& e) :
     m_BaseEngine(e),
     m_ConsoleBox(e, *this)
 {
-    m_Config.height = 10;
     m_HistoryIndex = 0;
     m_IsOpen = false;
 
@@ -68,9 +67,6 @@ Console::~Console() {
 
 void Console::update()
 {
-    return;
-    bgfx::dbgTextPrintf(0, (uint16_t)(GLOBAL_Y + m_Config.height + 1), 0x4f, "> %s", m_TypedLine.c_str());
-    printOutput();
 }
 
 void Console::onKeyDown(int glfwKey)
@@ -192,20 +188,6 @@ ConsoleCommand& Console::registerCommand(const std::string& command, ConsoleComm
     auto sanitizedCommand = Utils::join(tokens.begin(), tokens.end(), " ");
     m_Commands.emplace_back(ConsoleCommand{sanitizedCommand, generators, callback, generators.size()});
     return m_Commands.back();
-}
-
-void Console::printOutput()
-{
-    int i=0;
-    for(const std::string& s : m_Output)
-    {
-        if(i == m_Config.height)
-            break;
-
-        bgfx::dbgTextPrintf(0, (uint16_t)(GLOBAL_Y + m_Config.height - i), 0x0f, "| %s", s.c_str());
-
-        i++;
-    }
 }
 
 void Console::outputAdd(const std::string& msg)

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -260,7 +260,7 @@ int Console::autoComplete(std::string& input, bool limitToFixed, bool showSugges
                 }
             }
         }
-        vector<MatchInfo> suggestions;
+        std::map<string, MatchInfo> suggestions;
         for (auto& matchInfos : {matchInfosStartsWith, matchInfosInMiddle})
         {
             if (matchInfos.empty())
@@ -271,7 +271,7 @@ int Console::autoComplete(std::string& input, bool limitToFixed, bool showSugges
             auto longestCandidateLen = reference.size();
             for (auto& matchInfo : matchInfos)
             {
-                suggestions.push_back(matchInfo);
+                suggestions[matchInfo.candidateLowered] = matchInfo;
                 commandIsAlive[matchInfo.commandID] = true;
                 commonLength = std::min(Utils::commonStartLength(reference, matchInfo.candidateLowered), commonLength);
                 longestCandidateLen = std::max(longestCandidateLen, matchInfo.candidateLowered.size());
@@ -290,8 +290,13 @@ int Console::autoComplete(std::string& input, bool limitToFixed, bool showSugges
             auto sorter = [](const MatchInfo& a, const MatchInfo& b) -> bool {
                 return a.notMatchingCharCount < b.notMatchingCharCount;
             };
-            std::sort(suggestions.begin(), suggestions.end(), sorter);
-            for (auto& matchInfo : suggestions)
+            vector<MatchInfo> suggestionsList;
+            for (const auto& pair : suggestions)
+            {
+                suggestionsList.push_back(pair.second);
+            }
+            std::sort(suggestionsList.begin(), suggestionsList.end(), sorter);
+            for (auto& matchInfo : suggestionsList)
             {
                 ss << matchInfo.candidate << " ";
             }

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -116,15 +116,14 @@ std::string Console::submitCommand(const std::string& command)
     m_HistoryIndex = -1;
     m_PendingLine.clear();
 
-    outputAdd(" >> " + command);
-
     if(command.empty())
         return "";
 
     auto commandAutoCompleted = command;
-    auto commID = autoComplete(commandAutoCompleted, false, false, true);
+    auto commID = autoComplete(commandAutoCompleted, true, false, true);
+    autoComplete(commandAutoCompleted, false, false, true);
 
-    outputAdd(" >> (Auto) " + commandAutoCompleted);
+    outputAdd(" >> " + commandAutoCompleted);
 
     size_t bestMatchSize = 0;
     int bestMatchIndex = -1;
@@ -136,10 +135,10 @@ std::string Console::submitCommand(const std::string& command)
             continue;
         }
 
-        if (command.size() == candidate.size() || (command.size() > candidate.size() && command.at(candidate.size()) == ' '))
+        if (commandAutoCompleted.size() == candidate.size() || (commandAutoCompleted.size() > candidate.size() && commandAutoCompleted.at(candidate.size()) == ' '))
         {
             // it makes sense to compare
-            if (candidate == command.substr(0, candidate.size()))
+            if (candidate == commandAutoCompleted.substr(0, candidate.size()))
             {
                 // Match!
                 bestMatchSize = candidate.size();
@@ -150,7 +149,7 @@ std::string Console::submitCommand(const std::string& command)
 
     if (bestMatchIndex >= 0)
     {
-        const std::vector<std::string> args = Utils::split(command, ' ');
+        const std::vector<std::string> args = Utils::split(commandAutoCompleted, ' ');
         std::string result;
         try {
             result = m_CommandCallbacks.at(bestMatchIndex)(args);
@@ -296,11 +295,11 @@ int Console::autoComplete(std::string& input, bool limitToFixed, bool showSugges
                 suggestionsList.push_back(pair.second);
             }
             std::sort(suggestionsList.begin(), suggestionsList.end(), sorter);
+            LogInfo() << "suggestions:";
             for (auto& matchInfo : suggestionsList)
             {
-                ss << matchInfo.candidate << " ";
+                LogInfo() << matchInfo.candidate;
             }
-            LogInfo() << "suggestions: " << ss.str();
         }
     }
     if (overwriteInput)

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -139,7 +139,16 @@ std::string Console::submitCommand(const std::string& command)
     if (bestMatchIndex >= 0)
     {
         const std::vector<std::string> args = Utils::split(command, ' ');
-        const std::string result = m_CommandCallbacks.at(bestMatchIndex)(args);
+        std::string result;
+        try {
+            result = m_CommandCallbacks.at(bestMatchIndex)(args);
+        } catch (const std::out_of_range& e)
+        {
+            result = "error: argument out of range";
+        } catch (const std::invalid_argument& e)
+        {
+            result = "error: invalid argument";
+        }
         outputAdd(result);
         return result;
     }

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -239,8 +239,14 @@ void Console::autoComplete(std::string& input, bool limitToFixed, bool showSugge
     using std::string;
 
     vector<string> tokens = Utils::splitAndRemoveEmpty(input, ' ');
-    if (tokens.empty())
-        return;
+
+    bool lookAhead = false;
+    if (tokens.empty() || isspace(input.back()))
+    {
+        // append empty pseudo token to trigger lookahead for the next token
+        tokens.push_back("");
+        lookAhead = true;
+    }
 
     vector<std::tuple<string, bool>> newTokens;
     for (auto& token : tokens)
@@ -347,6 +353,11 @@ void Console::autoComplete(std::string& input, bool limitToFixed, bool showSugge
                 LogInfo() << ss.str();
             }
         }
+    }
+    if (lookAhead && std::get<0>(newTokens.back()) == "")
+    {
+        tokens.pop_back();
+        newTokens.pop_back();
     }
     if (overwriteInput)
     {

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -133,7 +133,7 @@ void Console::onTextInput(const std::string& text)
     m_TypedLine += text;
 }
 
-std::string Console::submitCommand(const std::string& command)
+std::string Console::submitCommand(std::string command)
 {
     if((command.find_first_not_of(' ') != std::string::npos) && (m_History.empty() || m_History.back() != command))
         m_History.push_back(command);
@@ -144,16 +144,14 @@ std::string Console::submitCommand(const std::string& command)
     if(command.empty())
         return "";
 
-    auto commandAutoCompleted = command;
     // bool autoCompleteCommandTokensOnly = true;
-    // autoComplete(commandAutoCompleted, autoCompleteCommandTokensOnly, false, true);
+    // autoComplete(command, autoCompleteCommandTokensOnly, false, true);
 
-    outputAdd(" >> " + commandAutoCompleted);
+    outputAdd(" >> " + command);
 
-    std::vector<std::string> args = Utils::split(commandAutoCompleted, ' ');
+    std::vector<std::string> args = Utils::split(command, ' ');
     auto commID = determineCommand(args);
 
-    // new command system
     if (commID != -1)
     {
         std::string result;
@@ -170,55 +168,8 @@ std::string Console::submitCommand(const std::string& command)
         return result;
     }
 
-    // old command system
-    size_t bestMatchSize = 0;
-    int bestMatchIndex = -1;
-    for (size_t i = 0; i < m_Commands.size(); ++i)
-    {
-        const std::string &candidate = m_Commands.at(i);
-        if (candidate.size() < bestMatchSize) {
-            // We already found a better command candidate
-            continue;
-        }
-
-        if (commandAutoCompleted.size() == candidate.size() || (commandAutoCompleted.size() > candidate.size() && commandAutoCompleted.at(candidate.size()) == ' '))
-        {
-            // it makes sense to compare
-            if (candidate == commandAutoCompleted.substr(0, candidate.size()))
-            {
-                // Match!
-                bestMatchSize = candidate.size();
-                bestMatchIndex = i;
-            }
-        }
-    }
-
-    if (bestMatchIndex >= 0)
-    {
-        std::string result;
-        try {
-            result = m_CommandCallbacks.at(bestMatchIndex)(args);
-        } catch (const std::out_of_range& e)
-        {
-            result = "error: argument out of range";
-        } catch (const std::invalid_argument& e)
-        {
-            result = "error: invalid argument";
-        }
-        outputAdd(result);
-        return result;
-    }
-
     outputAdd(" -- Command not found -- ");
-
     return "NOTFOUND";
-}
-
-void Console::registerCommand(const std::string& command,
-                              ConsoleCommand::Callback callback)
-{
-    m_Commands.push_back(command);
-    m_CommandCallbacks.push_back(callback);
 }
 
 void Console::registerCommand2(std::vector<ConsoleCommand::CandidateListGenerator> generators,

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -153,7 +153,7 @@ std::string Console::submitCommand(std::string command)
     // bool autoCompleteCommandTokensOnly = true;
     // autoComplete(command, autoCompleteCommandTokensOnly, true);
 
-    outputAdd(" >> " + command);
+    outputAdd(">> " + command);
 
     auto commID = determineCommand(args);
 
@@ -173,7 +173,7 @@ std::string Console::submitCommand(std::string command)
         return result;
     }
 
-    outputAdd(" -- Command not found -- ");
+    outputAdd("-- Command not found --");
     return "NOTFOUND";
 }
 

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -61,8 +61,8 @@ namespace UI
          *
          */
         void registerCommand2(std::vector<ConsoleCommand::CandidateListGenerator> generators,
-                              ConsoleCommand::Callback callback,
-                              unsigned int numFixTokens);
+                              unsigned int numFixTokens,
+                              ConsoleCommand::Callback callback);
 
         /**
          * Trigger autocompletion
@@ -70,9 +70,13 @@ namespace UI
          * @param limitToFixed limit the number of tokens evaluated to numFixTokens for each command
          * @param showSuggestions show suggestions
          * @param overwriteTypedLine replace the console line with the suggested one
-         * @return returns the number of the command found. -1 if non matched
          */
-        int autoComplete(std::string& input, bool limitToFixed, bool showSuggestions, bool overwriteInput);
+        void autoComplete(std::string& input, bool limitToFixed, bool showSuggestions, bool overwriteInput);
+
+        /**
+         * searches for command which, could generate the given tokens and returns its index
+         */
+        int determineCommand(const std::vector<std::string>& tokens);
 
         /**
          * Executes a given command

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -52,14 +52,6 @@ namespace UI
          * @param Callback Function to be executed if the given command was typed.
          *
          */
-        void registerCommand(const std::string& command, ConsoleCommand::Callback callback);
-
-        /**
-         * Adds a command to the console
-         * @param Command Command to be added.
-         * @param Callback Function to be executed if the given command was typed.
-         *
-         */
         void registerCommand2(std::vector<ConsoleCommand::CandidateListGenerator> generators,
                               unsigned int numFixTokens,
                               ConsoleCommand::Callback callback);
@@ -84,7 +76,7 @@ namespace UI
          * @return Output of the command.
          *         - "NOTFOUND", if the command was not found
          */
-        std::string submitCommand(const std::string& command);
+        std::string submitCommand(std::string command);
 
         /**
          * Adds a message to the history
@@ -136,13 +128,7 @@ namespace UI
         /**
          * All registered commands
          */
-        std::vector<std::string> m_Commands;
         std::vector<ConsoleCommand> m_Commands2;
-
-        /**
-         * All registered callbacks
-         */
-        std::vector<ConsoleCommand::Callback> m_CommandCallbacks;
 
         /**
          * Currently typed line

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -16,7 +16,7 @@ namespace UI
         // Takes list of arguments as parameter, returns command result
         typedef std::function<std::string(const std::vector<std::string>&)> Callback;
         // generator, which returns vector of candidates
-        using CandidateListGenerator = std::function<std::vector<std::string>()>;
+        using CandidateListGenerator = std::function<std::vector<std::vector<std::string>>()>;
 
         std::vector<CandidateListGenerator> generators;
         Callback callback;

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -11,14 +11,21 @@
 
 namespace UI
 {
+    struct ConsoleCommand
+    {
+        // Takes list of arguments as parameter, returns command result
+        typedef std::function<std::string(const std::vector<std::string>&)> Callback;
+        // generator, which returns vector of candidates
+        using CandidateListGenerator = std::function<std::vector<std::string>()>;
+
+        std::vector<CandidateListGenerator> generators;
+        Callback callback;
+        unsigned int numFixTokens;
+    };
+
     class Console
     {
     public:
-
-        // Takes list of arguments as parameter, returns command result
-        typedef std::function<std::string(const std::vector<std::string>&)> CommandCallback;
-        // generator, which returns vector of candidates
-        using CandidateListGenerator = std::function<std::vector<std::string>()>;
 
         Console();
 
@@ -45,7 +52,7 @@ namespace UI
          * @param Callback Function to be executed if the given command was typed.
          *
          */
-        void registerCommand(const std::string& command, CommandCallback callback);
+        void registerCommand(const std::string& command, ConsoleCommand::Callback callback);
 
         /**
          * Adds a command to the console
@@ -53,21 +60,19 @@ namespace UI
          * @param Callback Function to be executed if the given command was typed.
          *
          */
-        void registerCommand2(std::vector<CandidateListGenerator> functions, CommandCallback callback);
-
-        /**
-         * Adds an autocomplete-function for an already registered command. Will get all arguments passed.
-         * The last one is most likely incomplete.
-         * @param command Command to add the autocomplete for
-         * @param callback Callback triggered on autocomplete
-         */
-        void registerAutocompleteFn(const std::string& command, CommandCallback callback);
-
+        void registerCommand2(std::vector<ConsoleCommand::CandidateListGenerator> generators,
+                              ConsoleCommand::Callback callback,
+                              unsigned int numFixTokens);
 
         /**
          * Trigger autocompletion
+         * @param line to work on
+         * @param limitToFixed limit the number of tokens evaluated to numFixTokens for each command
+         * @param showSuggestions show suggestions
+         * @param overwriteTypedLine replace the console line with the suggested one
+         * @return returns the number of the command found. -1 if non matched
          */
-        void autoComplete();
+        int autoComplete(std::string& input, bool limitToFixed, bool showSuggestions, bool overwriteInput);
 
         /**
          * Executes a given command
@@ -128,18 +133,12 @@ namespace UI
          * All registered commands
          */
         std::vector<std::string> m_Commands;
-        std::vector<std::vector<CandidateListGenerator>> m_Commands2;
+        std::vector<ConsoleCommand> m_Commands2;
 
         /**
          * All registered callbacks
          */
-        std::vector<CommandCallback> m_CommandCallbacks;
-        std::vector<CommandCallback> m_CommandCallbacks2;
-
-        /**
-         * Callbacks for when the user wants to autocomplete an argument
-         */
-        std::map<std::string, CommandCallback> m_AutocompleteCallbacks;
+        std::vector<ConsoleCommand::Callback> m_CommandCallbacks;
 
         /**
          * Currently typed line

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -17,6 +17,8 @@ namespace UI
 
         // Takes list of arguments as parameter, returns command result
         typedef std::function<std::string(const std::vector<std::string>&)> CommandCallback;
+        // generator, which returns vector of candidates
+        using CandidateListGenerator = std::function<std::vector<std::string>()>;
 
         Console();
 
@@ -46,6 +48,14 @@ namespace UI
         void registerCommand(const std::string& command, CommandCallback callback);
 
         /**
+         * Adds a command to the console
+         * @param Command Command to be added.
+         * @param Callback Function to be executed if the given command was typed.
+         *
+         */
+        void registerCommand2(std::vector<CandidateListGenerator> functions, CommandCallback callback);
+
+        /**
          * Adds an autocomplete-function for an already registered command. Will get all arguments passed.
          * The last one is most likely incomplete.
          * @param command Command to add the autocomplete for
@@ -53,6 +63,11 @@ namespace UI
          */
         void registerAutocompleteFn(const std::string& command, CommandCallback callback);
 
+
+        /**
+         * Trigger autocompletion
+         */
+        void autoComplete();
 
         /**
          * Executes a given command
@@ -113,11 +128,13 @@ namespace UI
          * All registered commands
          */
         std::vector<std::string> m_Commands;
+        std::vector<std::vector<CandidateListGenerator>> m_Commands2;
 
         /**
          * All registered callbacks
          */
         std::vector<CommandCallback> m_CommandCallbacks;
+        std::vector<CommandCallback> m_CommandCallbacks2;
 
         /**
          * Callbacks for when the user wants to autocomplete an argument

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -106,19 +106,6 @@ namespace UI
     private:
 
         /**
-         * Draws history over the commandline
-         */
-        void printOutput();
-
-        struct
-        {
-            /**
-             * Lines of history + current line
-             */
-            int height;
-        }m_Config;
-
-        /**
          * Last submitted commands
          */
         std::vector<std::string> m_History;

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <functional>
 #include <map>
+#include <ui/ConsoleBox.h>
 
 namespace UI
 {
@@ -34,7 +35,9 @@ namespace UI
     {
     public:
 
-        Console();
+        Console(Engine::BaseEngine& e);
+
+        ~Console();
 
         /**
          * Updates and draws the console
@@ -68,7 +71,8 @@ namespace UI
          * @param showSuggestions show suggestions
          * @param overwriteTypedLine replace the console line with the suggested one
          */
-        void autoComplete(std::string& input, bool limitToFixed, bool showSuggestions, bool overwriteInput);
+        using Suggestion = std::vector<std::string>;
+        std::vector<std::vector<Suggestion>> autoComplete(std::string& input, bool limitToFixed, bool overwriteInput);
 
         /**
          * searches for command which, could generate the given tokens and returns its index
@@ -94,6 +98,10 @@ namespace UI
          */
         bool isOpen(){ return m_IsOpen; }
         void setOpen(bool open){ m_IsOpen = open; }
+
+        const std::list<std::string>& getOutputLines() { return m_Output; }
+        const std::string& getTypedLine() { return m_TypedLine; }
+        const std::vector<std::vector<Suggestion>>& getSuggestions() { return m_SuggestionsList; }
 
     private:
 
@@ -136,6 +144,11 @@ namespace UI
         std::vector<ConsoleCommand> m_Commands;
 
         /**
+         * suggestions for each token
+         */
+        std::vector<std::vector<Suggestion>> m_SuggestionsList;
+
+        /**
          * Currently typed line
          */
         std::string m_TypedLine;
@@ -144,6 +157,14 @@ namespace UI
          * Whether the console is currently shown
          */
         bool m_IsOpen;
+
+        Engine::BaseEngine& m_BaseEngine;
+
+        /**
+         * console window
+         */
+        UI::ConsoleBox m_ConsoleBox;
+
     };
 }
 

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -21,6 +21,7 @@ namespace UI
         std::string commandName;
         std::vector<CandidateListGenerator> generators;
         Callback callback;
+        // number of tokens, that must match to identify this command
         std::size_t numFixTokens;
 
         ConsoleCommand& registerAutoComplete(CandidateListGenerator generator){

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -18,9 +18,14 @@ namespace UI
         // generator, which returns vector of candidates
         using CandidateListGenerator = std::function<std::vector<std::vector<std::string>>()>;
 
+        std::string commandName;
         std::vector<CandidateListGenerator> generators;
         Callback callback;
-        unsigned int numFixTokens;
+        std::size_t numFixTokens;
+
+        void registerAutoComplete(CandidateListGenerator generator){
+            generators.push_back(generator);
+        }
     };
 
     class Console
@@ -52,9 +57,7 @@ namespace UI
          * @param Callback Function to be executed if the given command was typed.
          *
          */
-        void registerCommand2(std::vector<ConsoleCommand::CandidateListGenerator> generators,
-                              unsigned int numFixTokens,
-                              ConsoleCommand::Callback callback);
+        ConsoleCommand& registerCommand(const std::string& command, ConsoleCommand::Callback callback);
 
         /**
          * Trigger autocompletion

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -23,8 +23,9 @@ namespace UI
         Callback callback;
         std::size_t numFixTokens;
 
-        void registerAutoComplete(CandidateListGenerator generator){
+        ConsoleCommand& registerAutoComplete(CandidateListGenerator generator){
             generators.push_back(generator);
+            return *this;
         }
     };
 
@@ -131,7 +132,7 @@ namespace UI
         /**
          * All registered commands
          */
-        std::vector<ConsoleCommand> m_Commands2;
+        std::vector<ConsoleCommand> m_Commands;
 
         /**
          * Currently typed line

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -63,7 +63,7 @@ namespace UI
 
         /**
          * Trigger autocompletion
-         * @param line to work on
+         * @param command to work on
          * @param limitToFixed limit the number of tokens evaluated to numFixTokens for each command
          * @param showSuggestions show suggestions
          * @param overwriteTypedLine replace the console line with the suggested one

--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -1,0 +1,103 @@
+#include <imgui/imgui.h>
+#include <render/RenderSystem.h>
+#include <utils/logger.h>
+#include "ConsoleBox.h"
+#include <engine/BaseEngine.h>
+#include "zFont.h"
+#include <ui/Console.h>
+
+UI::ConsoleBox::ConsoleBox(Engine::BaseEngine& e, UI::Console& console) :
+    View(e),
+    m_Console(console)
+{
+    m_Config.height = 10;
+    m_BackgroundTexture = e.getEngineTextureAlloc().loadTextureVDF("CONSOLE.TGA");
+    m_SuggestionsBackgroundTexture = e.getEngineTextureAlloc().loadTextureVDF("DLG_CHOICE.TGA");
+}
+
+UI::ConsoleBox::~ConsoleBox()
+{
+}
+
+void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render::RenderConfig& config)
+{
+    m_IsHidden = !m_Console.isOpen();
+    if (m_IsHidden)
+        return;
+
+    auto font = DEFAULT_FONT;
+    const UI::zFont* fnt = m_Engine.getFontCache().getFont(font);
+    if(!fnt)
+        return;
+
+    View::update(dt, mstate, config);
+
+    int consoleSizeX = config.state.viewWidth;
+    int consoleSizeY = Math::iround(config.state.viewHeight * 0.25f);
+    // Draw console
+    {
+        // Draw console background image
+        Textures::Texture& background = m_Engine.getEngineTextureAlloc().getTexture(m_BackgroundTexture);
+
+        bgfx::ProgramHandle program = config.programs.imageProgram;
+        drawTexture(BGFX_VIEW,
+                    0, 0,
+                    consoleSizeX, consoleSizeY,
+                    config.state.viewWidth, config.state.viewHeight, background.m_TextureHandle, program,
+                    config.uniforms.diffuseTexture);
+
+        // draw console output + current line
+        std::stringstream ss;
+        auto& outputList = m_Console.getOutputLines();
+        std::size_t maxDisplayLines = 10;
+        std::size_t numLines = std::min(outputList.size(), maxDisplayLines);
+        std::vector<std::string> outputLines(numLines);
+        std::copy_n(outputList.begin(), numLines, outputLines.rbegin());
+        outputLines.push_back(m_Console.getTypedLine());
+        auto joined = Utils::join(outputLines.begin(), outputLines.end(), "\n");
+        drawText(joined, 0, consoleSizeY, A_BottomLeft, config, font);
+    }
+    // Draw suggestions
+    {
+        const auto& suggestionsList = m_Console.getSuggestions();
+        if (suggestionsList.empty() || suggestionsList.back().empty())
+            return;
+
+        const auto& suggestions = suggestionsList.back();
+        std::size_t maxSuggestions = 10;
+        std::vector<std::string> lines;
+        std::size_t i = 0;
+        std::size_t fillWidth = 40;
+        for (auto& suggestionEntry : suggestions)
+        {
+            if (i >= maxSuggestions)
+            {
+                lines.back() = "...";
+                break;
+            }
+            std::stringstream ss;
+            for (auto& alias : suggestionEntry)
+            {
+                ss << std::left << std::setw(fillWidth) << alias;
+            }
+            lines.push_back(ss.str());
+            i++;
+        }
+        // FIXME: glyphs are not monospace. print each column separately?
+        int glyphWidth = 10;
+        int fontHeight = fnt->getFontHeight();
+        int suggestionBoxSizeX = fillWidth * suggestions.front().size() * glyphWidth;
+        int suggestionBoxSizeY = fontHeight * lines.size();
+        auto joined = Utils::join(lines.begin(), lines.end(), "\n");
+        // Get background image
+        Textures::Texture& background = m_Engine.getEngineTextureAlloc().getTexture(m_SuggestionsBackgroundTexture);
+
+        bgfx::ProgramHandle program = config.programs.imageProgram;
+        drawTexture(BGFX_VIEW,
+                    0, consoleSizeY,
+                    suggestionBoxSizeX, suggestionBoxSizeY,
+                    config.state.viewWidth, config.state.viewHeight, background.m_TextureHandle, program,
+                    config.uniforms.diffuseTexture);
+        drawText(joined, 0, consoleSizeY + suggestionBoxSizeY, A_BottomLeft, config, font);
+    }
+}

--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -32,6 +32,9 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
 
     View::update(dt, mstate, config);
 
+    // draw text 13 pixel apart from left screen edge
+    const int textXOffset = 13;
+
     int consoleSizeX = config.state.viewWidth;
     int consoleSizeY = Math::iround(config.state.viewHeight * 0.25f);
     // Draw console
@@ -55,7 +58,7 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
         std::copy_n(outputList.begin(), numLines, outputLines.rbegin());
         outputLines.push_back(m_Console.getTypedLine());
         auto joined = Utils::join(outputLines.begin(), outputLines.end(), "\n");
-        drawText(joined, 0, consoleSizeY, A_BottomLeft, config, font);
+        drawText(joined, textXOffset, consoleSizeY, A_BottomLeft, config, font);
     }
     // Draw suggestions
     {
@@ -98,6 +101,6 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
                     suggestionBoxSizeX, suggestionBoxSizeY,
                     config.state.viewWidth, config.state.viewHeight, background.m_TextureHandle, program,
                     config.uniforms.diffuseTexture);
-        drawText(joined, 0, consoleSizeY + suggestionBoxSizeY, A_BottomLeft, config, font);
+        drawText(joined, textXOffset, consoleSizeY + suggestionBoxSizeY, A_BottomLeft, config, font);
     }
 }

--- a/src/ui/ConsoleBox.h
+++ b/src/ui/ConsoleBox.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <handle/HandleDef.h>
+#include "View.h"
+
+namespace UI
+{
+    class Console;
+    class ConsoleBox : public View
+    {
+    public:
+        ConsoleBox(Engine::BaseEngine& e, Console& console);
+        ~ConsoleBox();
+
+        /**
+         * Updates/draws the UI-Views
+         * @param dt time since last frame
+         * @param mstate mouse-state
+         */
+        void update(double dt, Engine::Input::MouseState &mstate, Render::RenderConfig &config) override;
+
+    protected:
+
+        struct
+        {
+            /**
+             * Lines of history + current line
+             */
+            int height;
+        } m_Config;
+
+        Console& m_Console;
+
+        /**
+         * Console background image
+         */
+        Handle::TextureHandle m_BackgroundTexture;
+
+        /**
+         * Suggestions background image
+         */
+        Handle::TextureHandle m_SuggestionsBackgroundTexture;
+    };
+}

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -15,7 +15,9 @@
 #include <utils/logger.h>
 #include "DialogBox.h"
 
-UI::Hud::Hud(Engine::BaseEngine& e) : View(e)
+UI::Hud::Hud(Engine::BaseEngine& e) :
+        View(e),
+        m_Console(e)
 {
     Textures::TextureAllocator& alloc = m_Engine.getEngineTextureAlloc();
 
@@ -169,12 +171,7 @@ void UI::Hud::onInputAction(UI::EInputAction action)
     // Close console or last menu, in case it's open
     if(action == IA_Close)
     {
-        if(m_Console.isOpen())
-        {
-            m_Console.setOpen(false);
-            return;
-        }
-        else if(!m_MenuChain.empty())
+        if(!m_MenuChain.empty())
         {
             popMenu();
             return;

--- a/src/ui/SubtitleBox.cpp
+++ b/src/ui/SubtitleBox.cpp
@@ -58,7 +58,14 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
     float pyMax = (absTranslation.y + 0.02f) * config.state.viewHeight;
 
     float sxMax = 0.5f * config.state.viewWidth;
-    float syMax = 13 * 6; // 6 lines of dialog
+    int wrapAroundWidth = Math::iround(0.95f * sxMax);
+    std::vector<std::string> lines = fnt->layoutText(m_Text.text, wrapAroundWidth);
+    auto fontHeight = fnt->getFontHeight();
+    std::size_t linesOfText = lines.size() + 1; // +1 for speaker
+    // render the Box as if there were at least 4 lines of text
+    // so that the size won't change as often, but is still adjusted for very long texts (mods?)
+    linesOfText = std::max(linesOfText, 4ul);
+    float syMax = fontHeight * (linesOfText + 2); // +2 for some extra space
 
     Math::float2 maxSize = {sxMax, syMax};
     Math::float2 posMax = {pxMax, pyMax};
@@ -82,9 +89,7 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
     {
         int centerx = Math::iround(center.x);
         int centery = Math::iround(center.y);
-        int wrapAroundWidth = Math::iround(0.95f * sxMax);
         // split so that each line is not longer than wrapAroundWidth pixel
-        std::vector<std::string> lines = fnt->layoutText(m_Text.text, wrapAroundWidth);
         const char * speakerFont = DEFAULT_FONT_HI;
         const char * dialogTextFont = DEFAULT_FONT;
         // TODO read alignment from config

--- a/src/ui/SubtitleBox.cpp
+++ b/src/ui/SubtitleBox.cpp
@@ -2,6 +2,7 @@
 // Created by desktop on 11.08.16.
 //
 
+#include <algorithm>
 #include <imgui/imgui.h>
 #include <render/RenderSystem.h>
 #include <entry/input.h>
@@ -48,7 +49,7 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
 
     imguiEndScrollArea();*/
 
-    m_Scaling += dt / GROW_SHRINK_TIME * m_growDirection;
+    m_Scaling += static_cast<float>(dt) / GROW_SHRINK_TIME * m_growDirection;
     m_Scaling = Math::clamp(m_Scaling, 0.0f, 1.0f);
 
     // Un-normalize transforms
@@ -61,10 +62,10 @@ void UI::SubtitleBox::update(double dt, Engine::Input::MouseState& mstate, Rende
     int wrapAroundWidth = Math::iround(0.95f * sxMax);
     std::vector<std::string> lines = fnt->layoutText(m_Text.text, wrapAroundWidth);
     auto fontHeight = fnt->getFontHeight();
-    std::size_t linesOfText = lines.size() + 1; // +1 for speaker
+    int linesOfText = static_cast<int>(lines.size()) + 1; // +1 for speaker
     // render the Box as if there were at least 4 lines of text
     // so that the size won't change as often, but is still adjusted for very long texts (mods?)
-    linesOfText = std::max(linesOfText, 4ul);
+    linesOfText = std::max(linesOfText, 4);
     float syMax = fontHeight * (linesOfText + 2); // +2 for some extra space
 
     Math::float2 maxSize = {sxMax, syMax};

--- a/src/ui/zFont.cpp
+++ b/src/ui/zFont.cpp
@@ -8,6 +8,8 @@
 
 #include <content/VertexTypes.h>
 
+constexpr unsigned int DISTANCE_BETWEEN_GLYPHS = 1;
+
 namespace FontUtil
 {
     void appendGlyph(std::vector<Meshes::PositionUVVertex2D>& vxStream,
@@ -120,7 +122,7 @@ void UI::zFont::appendGlyph(UI::zFont::GlyphStream& glyphStream, unsigned char c
                               g.uvBottomRight);
 
         // Shift xpos for the next character
-        glyphStream.xPos += g.width;
+        glyphStream.xPos += g.width + DISTANCE_BETWEEN_GLYPHS;
     }
 }
 
@@ -163,7 +165,7 @@ void UI::zFont::calcTextMetrics(const std::string& txt, int& width, int& height)
             Glyph g;
             getGlyphOf((unsigned char)txt[i], g);
 
-            xPos += g.width;
+            xPos += g.width + DISTANCE_BETWEEN_GLYPHS;
         }
 
         xMax = std::max(xPos, xMax);
@@ -191,7 +193,7 @@ std::vector<std::string> UI::zFont::layoutText(const std::string& text, int maxW
             lastSpace = i;
         }
 
-        w += g.width;
+        w += g.width + DISTANCE_BETWEEN_GLYPHS;
         if(w > maxWidth && spaceFound)
         {
             spaceFound = false;

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -455,6 +455,21 @@ bool Utils::containsLike(const std::string& searchSpace, const std::string& part
     return pos != std::string::npos;
 }
 
+
+std::vector<std::string> Utils::findNameInGroups(const std::vector<std::vector<std::string>>& groups, const std::string& name){
+    std::string nameLowered = Utils::lowered(name);
+    for (auto& aliasGroup : groups)
+    {
+        for (auto& alias : aliasGroup) {
+            if (Utils::lowered(alias) == nameLowered)
+            {
+                return aliasGroup;
+            }
+        }
+    }
+    return {};
+};
+
 Utils::Profiler::Profiler(const std::string& n) :
     name(n),
     start(std::chrono::high_resolution_clock::now())

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -457,18 +457,28 @@ bool Utils::containsLike(const std::string& searchSpace, const std::string& part
 
 
 std::vector<std::string> Utils::findNameInGroups(const std::vector<std::vector<std::string>>& groups, const std::string& name){
-    std::string nameLowered = Utils::lowered(name);
     for (auto& aliasGroup : groups)
     {
         for (auto& alias : aliasGroup) {
-            if (Utils::lowered(alias) == nameLowered)
+            if (Utils::stringEqualIngoreCase(alias, name))
             {
                 return aliasGroup;
             }
         }
     }
     return {};
-};
+}
+
+bool Utils::stringEqualIngoreCase(const std::string a, const std::string b) {
+    if (a.size() != b.size())
+        return false;
+    for (std::size_t i = 0; i < a.size(); i++)
+    {
+        if (::tolower(a[i]) != ::tolower(b[i]))
+            return false;
+    }
+    return true;
+}
 
 Utils::Profiler::Profiler(const std::string& n) :
     name(n),

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -426,3 +426,17 @@ bool Utils::containsLike(const std::string &searchSpace, const std::string &part
     return pos != std::string::npos;
 }
 
+Utils::Profiler::Profiler(const std::string& n) :
+    name(n),
+    start(std::chrono::high_resolution_clock::now())
+{}
+
+Utils::Profiler::~Profiler()
+{
+    using dura = std::chrono::duration<double>;
+    auto end = std::chrono::high_resolution_clock::now();
+    auto d = end - start;
+    LogInfo() << name << ": "
+        << std::chrono::duration_cast<dura>(d).count() * 1000
+        << " milliseconds";
+}

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -417,6 +417,13 @@ void Utils::lower(std::string& in)
     std::transform(in.begin(), in.end(), in.begin(), ::tolower);
 }
 
+std::string Utils::lowered(const std::string& in)
+{
+    auto copy = in;
+    Utils::lower(copy);
+    return copy;
+}
+
 std::size_t Utils::commonStartLength(const std::string& a, const std::string& b)
 {
     auto minSize = std::min(a.size(), b.size());

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -412,16 +412,21 @@ std::string Utils::stripJsonComments(const std::string& json, const std::string&
     return r;
 }
 
-std::string Utils::strippedAndLowered(const std::string &in)
+void Utils::lower(std::string& in)
+{
+    std::transform(in.begin(), in.end(), in.begin(), ::tolower);
+}
+
+std::string Utils::strippedAndLowered(const std::string& in)
 {
     std::function<bool(char)> isNotAlNum = [](char c){ return std::isalnum(c) == 0;};
     std::string out = in;
-    std::transform(out.begin(), out.end(), out.begin(), ::tolower);
+    lower(out);
     out.erase(std::remove_if(out.begin(), out.end(), isNotAlNum), out.end());
     return out;
 }
 
-bool Utils::containsLike(const std::string &searchSpace, const std::string &part) {
+bool Utils::containsLike(const std::string& searchSpace, const std::string& part) {
     auto pos = strippedAndLowered(searchSpace).find(strippedAndLowered(part));
     return pos != std::string::npos;
 }

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -417,6 +417,23 @@ void Utils::lower(std::string& in)
     std::transform(in.begin(), in.end(), in.begin(), ::tolower);
 }
 
+std::size_t Utils::commonStartLength(const std::string& a, const std::string& b)
+{
+    auto minSize = std::min(a.size(), b.size());
+    std::size_t common = 0;
+    for (std::size_t i = 0; i < minSize; i++)
+    {
+        if (a[i] == b[i])
+        {
+            common++;
+        } else
+        {
+            break;
+        }
+    }
+    return common;
+}
+
 std::string Utils::strippedAndLowered(const std::string& in)
 {
     std::function<bool(char)> isNotAlNum = [](char c){ return std::isalnum(c) == 0;};

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -480,6 +480,12 @@ bool Utils::stringEqualIngoreCase(const std::string a, const std::string b) {
     return true;
 }
 
+std::vector<std::string> Utils::splitAndRemoveEmpty(const std::string &s, const char delim) {
+    std::vector<std::string> tokens = Utils::split(s, delim);
+    tokens.erase(std::remove(tokens.begin(), tokens.end(), ""), tokens.end());
+    return tokens;
+}
+
 Utils::Profiler::Profiler(const std::string& n) :
     name(n),
     start(std::chrono::high_resolution_clock::now())

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <memory>
 #include <chrono>
+#include <sstream>
 
 namespace Utils
 {
@@ -481,12 +482,37 @@ namespace Utils
      * returns empty vector if not found any
      * @param groups groups to search in
      * @param name token to find
-
      */
     std::vector<std::string> findNameInGroups(const std::vector<std::vector<std::string>>& groups, const std::string& name);
 
     /**
-     * small class for easy to use time measurement via RAII
+     * performs case insensitive euqal check
+     * @return true if strings are equal ignoring case
+     */
+    bool stringEqualIngoreCase(const std::string a, const std::string b);
+
+    /**
+     * concatenates tokens using delim inbetweeen
+     * @tparam Iterator
+     * @param begin
+     * @param end
+     * @param delim
+     * @return concatenated string
+     */
+    template<class Iterator>
+    std::string join(Iterator begin, Iterator end, const std::string& delim){
+        std::stringstream ss;
+        for (auto it = begin; it != end; it++)
+        {
+            if (it != begin)
+                ss << delim;
+            ss << *it;
+        }
+        return ss.str();
+    }
+
+    /**
+     * small class for easy to use time measurement
      */
     struct Profiler
     {

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -449,6 +449,11 @@ namespace Utils
     void lower(std::string& in);
 
     /**
+     *  @return lowered copy of the string
+     */
+    std::string lowered(const std::string& in);
+
+    /**
      * number of equal characters at begin
      * @param a
      * @param b

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -477,6 +477,15 @@ namespace Utils
     bool containsLike(const std::string& searchSpace, const std::string& part);
 
     /**
+     * searches for the first group (vector<string>) wich contains name and returns the group
+     * returns empty vector if not found any
+     * @param groups groups to search in
+     * @param name token to find
+
+     */
+    std::vector<std::string> findNameInGroups(const std::vector<std::vector<std::string>>& groups, const std::string& name);
+
+    /**
      * small class for easy to use time measurement via RAII
      */
     struct Profiler
@@ -486,6 +495,4 @@ namespace Utils
         Profiler(const std::string& n);
         ~Profiler();
     };
-
-    #define PROFILE_BLOCK(pbn) Utils::Profiler _pfinstance(pbn)
 }

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include <stdlib.h>
 #include <memory>
+#include <chrono>
 
 namespace Utils
 {
@@ -457,4 +458,16 @@ namespace Utils
      */
     bool containsLike(const std::string& searchSpace, const std::string& part);
 
+    /**
+     * small class for easy to use time measurement via RAII
+     */
+    struct Profiler
+    {
+        std::string name;
+        std::chrono::high_resolution_clock::time_point start;
+        Profiler(const std::string& n);
+        ~Profiler();
+    };
+
+    #define PROFILE_BLOCK(pbn) Utils::Profiler _pfinstance(pbn)
 }

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -512,6 +512,14 @@ namespace Utils
     }
 
     /**
+     * splits s on the given delimiter and removes empty entries caused by multiple delimiters
+     * @param s
+     * @param delim
+     * @return vector of tokens
+     */
+    std::vector<std::string> splitAndRemoveEmpty(const std::string &s, const char delim);
+
+    /**
      * small class for easy to use time measurement
      */
     struct Profiler

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -449,6 +449,14 @@ namespace Utils
     void lower(std::string& in);
 
     /**
+     * number of equal characters at begin
+     * @param a
+     * @param b
+     * @return number of equal characters at begin
+     */
+    std::size_t commonStartLength(const std::string& a, const std::string& b);
+
+    /**
      * removes all non alphanumeric characters and lowers the case
      * @param in old string
      * @return new string

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -444,6 +444,11 @@ namespace Utils
     };
 
     /**
+     * lower all characters inplace
+     */
+    void lower(std::string& in);
+
+    /**
      * removes all non alphanumeric characters and lowers the case
      * @param in old string
      * @return new string


### PR DESCRIPTION
- Added auto complete for console (F10): `TAB key`
- auto complete acts on all words (since there is no cursor)
- auto complete works on both commands and arguments
- `TAB` also displays a suggestion list, ~~which is currently showed in the Terminal (from which the program was started)~~ Suggestion list is now working and triggered on each character added.
- If a command is entered, all checks are caseinsensitive. (Though the case is still preserved/corrected by auto complete, to give a better feedback)
- new command `removeitem`. Removes items from player's inventory.
- `giveitem` / `removeitem` now searches in Datfile-Names (=gothic insert codes), `description` (=Inventory Name) and `name` =(name when on ground)
- `tp` command now supports teleporting npc A to npc B via `tp A B`, `A` is optional and defaults to `PC_HERO`
- bugfix: fixed incorrect usages of `C_Item.count[0]` as amount. `count`/`text` arrays are used by Gothic for storing Inventory Information (manacost, goldcost, ...).
- inventory displays now the correct name instead of the "name when on ground"
- unified `kill`/`knockout` command.
- it should be no longer possible to crash REGoth via invalid ingame console arguments (string instead of integer or too large integer).
- Inserting an item whose name contains a whitespace is possible. Simply use underscores instead. This was a compromise between ease of use and implementation complexity. (using quotation marks would pull in many other issues, like names containing quotation marks)