### PR TITLE
Autocomplete Rework (select suggestion) & Internal Dialog rework

### DIFF
--- a/src/logic/DialogManager.h
+++ b/src/logic/DialogManager.h
@@ -53,7 +53,7 @@ namespace Logic
         bool init();
 
         /**
-         * Updates the boxes according to the coices taken by the user
+         * Updates the boxes according to the choices taken by the user
          * @param dt time since last frame
          */
         void update(double dt);
@@ -116,11 +116,6 @@ namespace Logic
          * @return new choice number guaranteed to be smaller than all existing ones
          */
         int beforeFrontIndex();
-
-        /**
-         * Sets whether the DialogManager is in in the SubDialog state
-         */
-        void setSubDialogActive(bool flag);
 
         /**
          * Sets the current Dialog Message. To be able to cancel it
@@ -218,6 +213,11 @@ namespace Logic
             std::vector<Daedalus::GameState::InfoHandle> infos;
             std::vector<size_t> functions;
             std::vector<std::pair<size_t, size_t>> optionsSorted;
+            /**
+             * Handle to the the current Dialogoption
+             * Used to identify which Subchoices to show or to check if there are any
+             */
+            Daedalus::GameState::InfoHandle CurrentInfo;
         } m_Interaction;
 
         /**
@@ -239,13 +239,6 @@ namespace Logic
          * Whether a subtitlebox is currently shown
          */
         bool m_Talking;
-
-        /**
-         * Whether a hero is inside a multiple choice test.
-         * When true the queue will not be cleared and normal dialog options will not be added
-         * This state is left when the script calls the script function Info_ClearChoices
-         */
-        bool m_SubDialogActive;
 
         /**
          * Can be used to cancel the current Dialog Sound, when IA_Close occurs.

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -930,29 +930,21 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         std::string text = vm.popString();
         uint32_t info = vm.popVar();
 
-        Daedalus::GameState::InfoHandle hinfo = ZMemory::handleCast<Daedalus::GameState::InfoHandle>(
+        Daedalus::GameState::InfoHandle hInfo = ZMemory::handleCast<Daedalus::GameState::InfoHandle>(
                 pWorld->getScriptEngine().getVM().getDATFile().getSymbolByIndex(info).instanceDataHandle);
 
-        DialogManager& dialogManager = pWorld->getDialogManager();
-        Logic::DialogManager::ChoiceEntry choice;
-        choice.info = hinfo;
-        choice.text = text;
-        choice.nr = dialogManager.beforeFrontIndex();
-        choice.functionSym = func;
-        choice.important = false;
-
-        // calling the script function info_addchoice always opens the SubDialog for special multiple choices
-        dialogManager.setSubDialogActive(true);
-        dialogManager.addChoice(choice);
-        dialogManager.flushChoices();
+        auto& cInfo = vm.getGameState().getInfo(hInfo);
+        cInfo.addChoice(Daedalus::GEngineClasses::SubChoice{text, func});
     });
 
     vm->registerExternalFunction("info_clearchoices", [=](Daedalus::DaedalusVM& vm){
         uint32_t info = vm.popVar();
 
-        // after info_clearchoices is called the SubDialog is never active
-        pWorld->getDialogManager().setSubDialogActive(false);
-        pWorld->getDialogManager().clearChoices();
+        Daedalus::GameState::InfoHandle hInfo = ZMemory::handleCast<Daedalus::GameState::InfoHandle>(
+                vm.getDATFile().getSymbolByIndex(info).instanceDataHandle);
+
+        auto& cInfo = vm.getGameState().getInfo(hInfo);
+        cInfo.subChoices.clear();
     });
 
     vm->registerExternalFunction("ai_stopprocessinfos", [=](Daedalus::DaedalusVM& vm){

--- a/src/math/mathlib.h
+++ b/src/math/mathlib.h
@@ -643,7 +643,7 @@ namespace Math
 	template<class T>
 	T clamp(T v, T lo, T hi)
 	{
-		assert(lo < hi);
+		assert(lo <= hi);
 		return (v < lo) ? lo : (hi < v) ? hi : v;
 	}
 }

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -957,28 +957,36 @@ public:
 
 	bool update() BX_OVERRIDE
 	{
-        const int KEY_UP = 265;
-        const int KEY_DOWN = 264;
-        const int KEY_LEFT = 263;
-        const int KEY_RIGHT = 262;
-        const int KEY_ENTER = 257;
-        const int KEY_ESCAPE = 256;
-	const int KEY_BACKSPACE = 259;
-        std::map<int, UI::EInputAction> keyMap = {{KEY_UP,     UI::IA_Up},
-                                                  {KEY_DOWN,   UI::IA_Down},
-                                                  {KEY_LEFT,   UI::IA_Left},
-                                                  {KEY_RIGHT,  UI::IA_Right},
-                                                  {KEY_ENTER,  UI::IA_Accept},
-                                                  {KEY_ESCAPE, UI::IA_Close},
-						  {KEY_BACKSPACE, UI::IA_Backspace}};
+        std::map<int, UI::EInputAction> keyMap = {{GLFW_KEY_UP,     UI::IA_Up},
+                                                  {GLFW_KEY_DOWN,   UI::IA_Down},
+                                                  {GLFW_KEY_LEFT,   UI::IA_Left},
+                                                  {GLFW_KEY_RIGHT,  UI::IA_Right},
+                                                  {GLFW_KEY_ENTER,  UI::IA_Accept},
+                                                  {GLFW_KEY_ESCAPE, UI::IA_Close},
+                                                  {GLFW_KEY_BACKSPACE, UI::IA_Backspace},
+                                                  {GLFW_KEY_0, UI::IA_0},
+                                                  {GLFW_KEY_1, UI::IA_1},
+                                                  {GLFW_KEY_2, UI::IA_2},
+                                                  {GLFW_KEY_3, UI::IA_3},
+                                                  {GLFW_KEY_4, UI::IA_4},
+                                                  {GLFW_KEY_5, UI::IA_5},
+                                                  {GLFW_KEY_6, UI::IA_6},
+                                                  {GLFW_KEY_7, UI::IA_7},
+                                                  {GLFW_KEY_8, UI::IA_8},
+                                                  {GLFW_KEY_9, UI::IA_9},
+                                                  {GLFW_KEY_HOME, UI::IA_HOME},
+                                                  {GLFW_KEY_END, UI::IA_END},
+                                                  {GLFW_KEY_PAGE_UP, UI::IA_Up},
+                                                  {GLFW_KEY_PAGE_DOWN, UI::IA_Down}};
 
+        const auto CONSOLE_TOGGLE_KEY = GLFW_KEY_F10;
         std::string frameInputText = getFrameTextInput();
         for (int i = 0; i < NUM_KEYS; i++) {
             if (getKeysTriggered()[i]) // If key has been triggered start the stopwatch
             {
                 m_stopWatch.start();
 
-                if(m_pEngine->getHud().getConsole().isOpen() || i == GLFW_KEY_F10)
+                if(m_pEngine->getHud().getConsole().isOpen() || i == CONSOLE_TOGGLE_KEY)
                     m_pEngine->getHud().getConsole().onKeyDown(i);
                 else if (keyMap.find(i) != keyMap.end())
                 {
@@ -991,7 +999,7 @@ public:
                 {
                     if (m_stopWatch.DelayedByArgMS(70))
                     {
-                        if(m_pEngine->getHud().getConsole().isOpen() || i == GLFW_KEY_F10)
+                        if(m_pEngine->getHud().getConsole().isOpen() || i == CONSOLE_TOGGLE_KEY)
                             m_pEngine->getHud().getConsole().onKeyDown(i);
                         else if (keyMap.find(i) != keyMap.end())
                         {

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -178,7 +178,8 @@ ConsoleCommand& Console::registerCommand(const std::string& command, ConsoleComm
     auto tokens = Utils::splitAndRemoveEmpty(command, ' ');
     std::vector<ConsoleCommand::CandidateListGenerator> generators;
     auto simpleGen = [](std::string token) -> std::vector<ConsoleCommand::Suggestion> {
-        return {ConsoleCommand::Suggestion {{token}}};
+        ConsoleCommand::Suggestion suggestion = std::make_shared<SuggestionBase>(SuggestionBase {{token}});
+        return {suggestion};
     };
     for (auto tokenIt = tokens.begin(); tokenIt != tokens.end(); tokenIt++)
     {
@@ -228,7 +229,7 @@ int Console::determineCommand(const std::vector<std::string>& tokens)
         for (std::size_t tokenID = 0; tokenID < command.numFixTokens; tokenID++)
         {
             auto suggestion = Utils::findSuggestion(command.generators.at(tokenID)(), tokens.at(tokenID));
-            if (suggestion.aliasList.empty())
+            if (suggestion == nullptr)
                 allStagesMatched = false;
         }
         if (allStagesMatched)
@@ -290,7 +291,7 @@ std::vector<std::vector<Suggestion>> Console::autoComplete(std::string& input, b
                 {
                     auto& suggestion = suggestions[suggestionID];
                     suggestionsByCommand[cmdID].push_back(suggestion);
-                    auto& aliasList = suggestion.aliasList;
+                    auto& aliasList = suggestion->aliasList;
                     if (aliasList.empty())
                         continue;
                     std::vector<MatchInfo> groupInfos;
@@ -354,7 +355,7 @@ std::vector<std::vector<Suggestion>> Console::autoComplete(std::string& input, b
                 for (auto& matchInfo : *matchInfos)
                 {
                     auto& suggestion = suggestionsByCommand[matchInfo.commandID][matchInfo.groupID];
-                    auto& aliasList = suggestion.aliasList;
+                    auto& aliasList = suggestion->aliasList;
                     bool notInSet = known.insert(Utils::lowered(Utils::join(aliasList.begin(), aliasList.end(), ""))).second;
                     if (notInSet)
                     {

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -75,11 +75,28 @@ void Console::onKeyDown(int glfwKey)
     if(glfwKey == Keys::GLFW_KEY_ESCAPE){
         setOpen(false);
     }
-
     if(glfwKey == Keys::GLFW_KEY_F10){
         setOpen(!isOpen());
     }
-
+    if(glfwKey == Keys::GLFW_KEY_PAGE_DOWN)
+    {
+        m_ConsoleBox.addSelectionIndex(1);
+    }
+    if(glfwKey == Keys::GLFW_KEY_PAGE_UP)
+    {
+        m_ConsoleBox.addSelectionIndex(-1);
+    }
+    if(glfwKey == Keys::GLFW_KEY_HOME)
+    {
+        m_ConsoleBox.setSelectionIndex(0);
+    }
+    if(glfwKey == Keys::GLFW_KEY_END)
+    {
+        if (!m_SuggestionsList.empty())
+        {
+            m_ConsoleBox.setSelectionIndex(m_SuggestionsList.back().size() - 1);
+        }
+    }
     if(glfwKey == Keys::GLFW_KEY_UP)
     {
         const int historySize = m_History.size();
@@ -89,7 +106,7 @@ void Console::onKeyDown(int glfwKey)
                 m_PendingLine = m_TypedLine;
             ++m_HistoryIndex;
             m_TypedLine = m_History.at(m_History.size() - m_HistoryIndex - 1);
-            m_SuggestionsList.clear();
+            invalidateSuggestions();
         }
     }else if(glfwKey == Keys::GLFW_KEY_DOWN)
     {
@@ -100,7 +117,7 @@ void Console::onKeyDown(int glfwKey)
                 m_TypedLine = m_PendingLine;
             else
                 m_TypedLine = m_History.at(m_History.size() - m_HistoryIndex - 1);
-            m_SuggestionsList.clear();
+            invalidateSuggestions();
         }
     }else if(glfwKey == Keys::GLFW_KEY_BACKSPACE)
     {
@@ -113,7 +130,7 @@ void Console::onKeyDown(int glfwKey)
     {
         submitCommand(m_TypedLine);
         m_TypedLine.clear();
-        m_SuggestionsList.clear();
+        invalidateSuggestions();
     }else if(glfwKey == Keys::GLFW_KEY_TAB)
     {
         std::string oldLine;
@@ -209,10 +226,10 @@ struct MatchInfo
     static bool compare(const MatchInfo& a, const MatchInfo& b) {
         if (a.pos != b.pos){
             return a.pos < b.pos;
-        } else if (a.candidate.size() != b.candidate.size()){
-            return a.candidate.size() < b.candidate.size();
-        } else {
+        } else if (a.caseMatches != b.caseMatches){
             return a.caseMatches > b.caseMatches;
+        } else {
+            return a.candidate < b.candidate;
         }
     };
 };
@@ -384,6 +401,11 @@ std::vector<std::vector<Suggestion>> Console::autoComplete(std::string& input, b
         input = tokenConCat.str();
     }
     return suggestionsList;
+}
+
+void Console::invalidateSuggestions() {
+    m_ConsoleBox.setSelectionIndex(0);
+    m_SuggestionsList.clear();
 }
 
 

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -72,11 +72,11 @@ void Console::onKeyDown(int glfwKey)
     }
     if(glfwKey == Keys::GLFW_KEY_PAGE_DOWN)
     {
-        m_ConsoleBox.addSelectionIndex(1);
+        m_ConsoleBox.increaseSelectionIndex(1);
     }
     if(glfwKey == Keys::GLFW_KEY_PAGE_UP)
     {
-        m_ConsoleBox.addSelectionIndex(-1);
+        m_ConsoleBox.increaseSelectionIndex(-1);
     }
     if(glfwKey == Keys::GLFW_KEY_HOME)
     {

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -335,15 +335,17 @@ std::vector<std::vector<Suggestion>> Console::autoComplete(std::string& input, b
         // generate suggestions
         {
             vector<vector<string>> suggestionsForThisToken;
+            std::set<string> known;
             for (auto matchInfos : {&matchInfosStartsWith, &matchInfosInMiddle})
             {
                 std::sort(matchInfos->begin(), matchInfos->end(), MatchInfo::compare);
                 for (auto& matchInfo : *matchInfos)
                 {
-                    suggestionsForThisToken.push_back({});
-                    for (auto& alias : allGroups[matchInfo.commandID][matchInfo.groupID])
+                    auto& aliasGroup = allGroups[matchInfo.commandID][matchInfo.groupID];
+                    bool notInSet = known.insert(Utils::lowered(Utils::join(aliasGroup.begin(), aliasGroup.end(), ""))).second;
+                    if (notInSet)
                     {
-                        suggestionsForThisToken.back().push_back(alias);
+                        suggestionsForThisToken.push_back(aliasGroup);
                     }
                 }
             }

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -51,14 +51,6 @@ Console::Console(Engine::BaseEngine& e) :
 
     m_BaseEngine.getRootUIView().addChild(&m_ConsoleBox);
     outputAdd(" ----------- REGoth Console -----------");
-
-    registerCommand("list", [this](const std::vector<std::string>& args) -> std::string {
-        for(auto& command : m_Commands)
-        {
-            outputAdd(command.commandName);
-        }
-        return "";
-    });
 }
 
 Console::~Console() {

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -127,6 +127,11 @@ namespace UI
     private:
 
         /**
+         * clears the suggestion list and sets the current selection index to 0
+         */
+        void invalidateSuggestions();
+
+        /**
          * Last submitted commands
          */
         std::vector<std::string> m_History;

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -17,10 +17,12 @@ namespace UI
     struct SuggestionBase
     {
         SuggestionBase(const std::vector<std::string>& aliasList) :
-                aliasList(aliasList)
+                aliasList(aliasList),
+                bestAliasMatchIndex(0)
         {}
         virtual ~SuggestionBase() {};
         std::vector<std::string> aliasList;
+        std::size_t bestAliasMatchIndex;
     };
 
     struct NPCSuggestion : SuggestionBase
@@ -91,7 +93,12 @@ namespace UI
          * @param input command to work on
          * @param limitToFixed limit the number of tokens evaluated to numFixTokens for each command
          */
-        std::vector<std::vector<UI::ConsoleCommand::Suggestion>> generateSuggestions(const std::string& input, bool limitToFixed);
+        void generateSuggestions(const std::string& input, bool limitToFixed);
+
+        /**
+         * splits line, removes empty entries, adds empty string for lookahead trigger
+         */
+        static std::vector<std::string> tokenized(const std::string& line);
 
         /**
          * searches for command which, could generate the given tokens and returns its index

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <functional>
 #include <map>
+#include <memory>
 #include <ui/ConsoleBox.h>
 
 namespace UI
@@ -15,7 +16,20 @@ namespace UI
 
     struct SuggestionBase
     {
+        SuggestionBase(const std::vector<std::string>& aliasList) :
+                aliasList(aliasList)
+        {}
+        virtual ~SuggestionBase() {};
         std::vector<std::string> aliasList;
+    };
+
+    struct NPCSuggestion : SuggestionBase
+    {
+        NPCSuggestion(const std::vector<std::string>& aliasList, Handle::EntityHandle npcHandle) :
+            SuggestionBase(aliasList),
+            npcHandle(npcHandle)
+        {}
+        Handle::EntityHandle npcHandle;
     };
 
     struct ConsoleCommand
@@ -23,7 +37,7 @@ namespace UI
         // Takes list of arguments as parameter, returns command result
         using Callback = std::function<std::string(const std::vector<std::string>&)>;
 
-        using Suggestion = SuggestionBase;//std::vector<std::string>;
+        using Suggestion = std::shared_ptr<SuggestionBase>;
         // generator, which returns vector of candidates
         using CandidateListGenerator = std::function<std::vector<Suggestion>()>;
 

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -88,12 +88,10 @@ namespace UI
 
         /**
          * Trigger autocompletion
-         * @param command to work on
+         * @param input command to work on
          * @param limitToFixed limit the number of tokens evaluated to numFixTokens for each command
-         * @param showSuggestions show suggestions
-         * @param overwriteTypedLine replace the console line with the suggested one
          */
-        std::vector<std::vector<UI::ConsoleCommand::Suggestion>> autoComplete(std::string& input, bool limitToFixed, bool overwriteInput);
+        std::vector<std::vector<UI::ConsoleCommand::Suggestion>> generateSuggestions(const std::string& input, bool limitToFixed);
 
         /**
          * searches for command which, could generate the given tokens and returns its index

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -12,12 +12,20 @@
 
 namespace UI
 {
+
+    struct SuggestionBase
+    {
+        std::vector<std::string> aliasList;
+    };
+
     struct ConsoleCommand
     {
         // Takes list of arguments as parameter, returns command result
-        typedef std::function<std::string(const std::vector<std::string>&)> Callback;
+        using Callback = std::function<std::string(const std::vector<std::string>&)>;
+
+        using Suggestion = SuggestionBase;//std::vector<std::string>;
         // generator, which returns vector of candidates
-        using CandidateListGenerator = std::function<std::vector<std::vector<std::string>>()>;
+        using CandidateListGenerator = std::function<std::vector<Suggestion>()>;
 
         std::string commandName;
         std::vector<CandidateListGenerator> generators;
@@ -71,8 +79,7 @@ namespace UI
          * @param showSuggestions show suggestions
          * @param overwriteTypedLine replace the console line with the suggested one
          */
-        using Suggestion = std::vector<std::string>;
-        std::vector<std::vector<Suggestion>> autoComplete(std::string& input, bool limitToFixed, bool overwriteInput);
+        std::vector<std::vector<UI::ConsoleCommand::Suggestion>> autoComplete(std::string& input, bool limitToFixed, bool overwriteInput);
 
         /**
          * searches for command which, could generate the given tokens and returns its index
@@ -101,7 +108,7 @@ namespace UI
 
         const std::list<std::string>& getOutputLines() { return m_Output; }
         const std::string& getTypedLine() { return m_TypedLine; }
-        const std::vector<std::vector<Suggestion>>& getSuggestions() { return m_SuggestionsList; }
+        const std::vector<std::vector<UI::ConsoleCommand::Suggestion>>& getSuggestions() { return m_SuggestionsList; }
 
     private:
 
@@ -133,7 +140,7 @@ namespace UI
         /**
          * suggestions for each token
          */
-        std::vector<std::vector<Suggestion>> m_SuggestionsList;
+        std::vector<std::vector<UI::ConsoleCommand::Suggestion>> m_SuggestionsList;
 
         /**
          * Currently typed line

--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -191,3 +191,16 @@ void UI::ConsoleBox::addSelectionIndex(int add) {
     int suggestionCount = static_cast<int>(suggestionsList.back().size());
     m_CurrentlySelected = Utils::mod(m_CurrentlySelected + add, suggestionCount);
 }
+
+void UI::ConsoleBox::setSelectionIndex(int newIndex) {
+    /*
+    const auto& suggestionsList = m_Console.getSuggestions();
+    // check if suggestions for last token are empty
+    if (suggestionsList.empty() || suggestionsList.back().empty())
+        return;
+
+    int suggestionCount = static_cast<int>(suggestionsList.back().size());
+    m_CurrentlySelected = Math::clamp(newIndex, 0, suggestionCount - 1);
+    */
+    m_CurrentlySelected = newIndex;
+}

--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -91,14 +91,14 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
             {
                 if (row >= maxSuggestions)
                     break;
-
-                if (columnID < suggestionEntry.size())
+                auto& aliasList = suggestionEntry.aliasList;
+                if (columnID < aliasList.size())
                 {
                     columnEmpty = false;
                     int w, h;
-                    fnt->calcTextMetrics(suggestionEntry[columnID], w, h);
+                    fnt->calcTextMetrics(aliasList[columnID], w, h);
                     columnWidth = std::max(columnWidth, w);
-                    column.push_back(suggestionEntry[columnID]);
+                    column.push_back(aliasList[columnID]);
                 } else {
                     column.push_back("");
                 }

--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -83,9 +83,7 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
         const auto& suggestions = suggestionsList.back();
 
         // find preview range
-        // clamp in range
-        m_CurrentlySelected = std::min(m_CurrentlySelected, static_cast<int>(suggestions.size() - 1));
-        m_CurrentlySelected = std::max(m_CurrentlySelected, 0);
+        m_CurrentlySelected = Math::clamp(m_CurrentlySelected, 0, static_cast<int>(suggestions.size() - 1));
         int shownStart = m_CurrentlySelected - previewBefore;
         // past the end index
         int shownEnd = m_CurrentlySelected + previewAfter + 1;
@@ -182,25 +180,16 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
     }
 }
 
-void UI::ConsoleBox::addSelectionIndex(int add) {
+void UI::ConsoleBox::increaseSelectionIndex(int amount) {
     const auto& suggestionsList = m_Console.getSuggestions();
     // check if suggestions for last token are empty
     if (suggestionsList.empty() || suggestionsList.back().empty())
         return;
 
     int suggestionCount = static_cast<int>(suggestionsList.back().size());
-    m_CurrentlySelected = Utils::mod(m_CurrentlySelected + add, suggestionCount);
+    m_CurrentlySelected = Utils::mod(m_CurrentlySelected + amount, suggestionCount);
 }
 
 void UI::ConsoleBox::setSelectionIndex(int newIndex) {
-    /*
-    const auto& suggestionsList = m_Console.getSuggestions();
-    // check if suggestions for last token are empty
-    if (suggestionsList.empty() || suggestionsList.back().empty())
-        return;
-
-    int suggestionCount = static_cast<int>(suggestionsList.back().size());
-    m_CurrentlySelected = Math::clamp(newIndex, 0, suggestionCount - 1);
-    */
     m_CurrentlySelected = newIndex;
 }

--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -91,7 +91,7 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
             {
                 if (row >= maxSuggestions)
                     break;
-                auto& aliasList = suggestionEntry.aliasList;
+                auto& aliasList = suggestionEntry->aliasList;
                 if (columnID < aliasList.size())
                 {
                     columnEmpty = false;

--- a/src/ui/ConsoleBox.h
+++ b/src/ui/ConsoleBox.h
@@ -29,7 +29,9 @@ namespace UI
         /**
          * sets the current selection index
          */
-        void setSelectionIndex(int newIndex) {m_CurrentlySelected = newIndex;};
+        void setSelectionIndex(int newIndex);
+
+        int getSelectionIndex() const { return m_CurrentlySelected;}
 
     protected:
 

--- a/src/ui/ConsoleBox.h
+++ b/src/ui/ConsoleBox.h
@@ -19,6 +19,18 @@ namespace UI
          */
         void update(double dt, Engine::Input::MouseState &mstate, Render::RenderConfig &config) override;
 
+        /**
+         * Increases the selection index by the given amount.
+         * perform periodic wrap around
+         */
+
+        void addSelectionIndex(int add);
+
+        /**
+         * sets the current selection index
+         */
+        void setSelectionIndex(int newIndex) {m_CurrentlySelected = newIndex;};
+
     protected:
 
         struct
@@ -40,5 +52,10 @@ namespace UI
          * Suggestions background image
          */
         Handle::TextureHandle m_SuggestionsBackgroundTexture;
+
+        /**
+         * Index of selected entry
+         */
+        int m_CurrentlySelected;
     };
 }

--- a/src/ui/ConsoleBox.h
+++ b/src/ui/ConsoleBox.h
@@ -21,10 +21,10 @@ namespace UI
 
         /**
          * Increases the selection index by the given amount.
-         * perform periodic wrap around
+         * performs periodic wrap around
+         * @param amount may be positive or negative
          */
-
-        void addSelectionIndex(int add);
+        void increaseSelectionIndex(int amount);
 
         /**
          * sets the current selection index

--- a/src/ui/DialogBox.cpp
+++ b/src/ui/DialogBox.cpp
@@ -62,7 +62,7 @@ void DialogBox::update(double dt, Engine::Input::MouseState& mstate, Render::Ren
     Math::float2 absSize = getAbsoluteSize();
 
     int sx = Math::iround(absSize.x * config.state.viewWidth); // Span whole viewport
-    int sy = fnt->getFontHeight() * std::max(8, (int)m_Choices.size()); // Scale with number of choices
+    int sy = fnt->getFontHeight() * std::max(8, (int)m_Choices.size() + 1); // Scale with number of choices +1 for some extra space
 
 
     int px = Math::iround(absTranslation.x * config.state.viewWidth);
@@ -122,6 +122,28 @@ void DialogBox::onInputAction(EInputAction action)
         case IA_Down: m_CurrentlySelected = Utils::mod(m_CurrentlySelected + 1, (int)m_Choices.size()); break;
         case IA_Left:break;
         case IA_Right:break;
+        case IA_0:
+            break;
+        case IA_1:
+        case IA_2:
+        case IA_3:
+        case IA_4:
+        case IA_5:
+        case IA_6:
+        case IA_7:
+        case IA_8:
+        case IA_9:
+        {
+            int index = action - IA_1;
+            m_CurrentlySelected = std::min(index, (int)m_Choices.size() - 1);
+        }
+            break;
+        case IA_HOME:
+            m_CurrentlySelected = 0;
+            break;
+        case IA_END:
+            m_CurrentlySelected = static_cast<int>(m_Choices.size()) - 1;
+            break;
         case IA_Close:
             // closing Dialog-Option-Box when pressing Escape
             //m_Engine.getMainWorld().get().getDialogManager().performChoice(m_Choices.size()-1);break;
@@ -131,6 +153,8 @@ void DialogBox::onInputAction(EInputAction action)
         case IA_Accept:
             if (m_CurrentlySelected != -1)
                 m_Engine.getMainWorld().get().getDialogManager().performChoice(static_cast<size_t>(m_CurrentlySelected));
+            break;
+        default:
             break;
     }
 }

--- a/src/ui/Menu_Main.cpp
+++ b/src/ui/Menu_Main.cpp
@@ -37,6 +37,7 @@ void Menu_Main::onInputAction(EInputAction action)
         case IA_Right:break;
         case IA_Close: getHud().popMenu(); break;
         case IA_Accept:break;
+        default:break;
     }
 }
 

--- a/src/ui/Menu_Status.cpp
+++ b/src/ui/Menu_Status.cpp
@@ -91,5 +91,6 @@ void Menu_Status::onInputAction(EInputAction action)
         case IA_Right:break;
         case IA_Close: break;
         case IA_Accept:break;
+        default:break;
     }
 }

--- a/src/ui/View.h
+++ b/src/ui/View.h
@@ -20,7 +20,19 @@ namespace UI
         IA_Right,
         IA_Close,
         IA_Accept,
-	IA_Backspace
+        IA_Backspace,
+        IA_0,
+        IA_1,
+        IA_2,
+        IA_3,
+        IA_4,
+        IA_5,
+        IA_6,
+        IA_7,
+        IA_8,
+        IA_9,
+        IA_HOME,
+        IA_END
     };
 
     // BGFX-View to be used for rendering views

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -456,17 +456,16 @@ bool Utils::containsLike(const std::string& searchSpace, const std::string& part
 }
 
 
-std::vector<std::string> Utils::findNameInGroups(const std::vector<std::vector<std::string>>& groups, const std::string& name){
-    for (auto& aliasGroup : groups)
+UI::ConsoleCommand::Suggestion Utils::findSuggestion(const std::vector<UI::ConsoleCommand::Suggestion>& suggestions, const std::string& name){
+    for (auto& suggestion : suggestions)
     {
-        for (auto& alias : aliasGroup) {
-            if (Utils::stringEqualIngoreCase(alias, name))
-            {
-                return aliasGroup;
-            }
+        auto& aliasList = suggestion.aliasList;
+        if (std::find(aliasList.begin(), aliasList.end(), name) != aliasList.end())
+        {
+            return suggestion;
         }
     }
-    return {};
+    return UI::ConsoleCommand::Suggestion();
 }
 
 bool Utils::stringEqualIngoreCase(const std::string a, const std::string b) {

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -459,13 +459,13 @@ bool Utils::containsLike(const std::string& searchSpace, const std::string& part
 UI::ConsoleCommand::Suggestion Utils::findSuggestion(const std::vector<UI::ConsoleCommand::Suggestion>& suggestions, const std::string& name){
     for (auto& suggestion : suggestions)
     {
-        auto& aliasList = suggestion.aliasList;
+        auto& aliasList = suggestion->aliasList;
         if (std::find(aliasList.begin(), aliasList.end(), name) != aliasList.end())
         {
             return suggestion;
         }
     }
-    return UI::ConsoleCommand::Suggestion();
+    return nullptr;
 }
 
 bool Utils::stringEqualIngoreCase(const std::string a, const std::string b) {

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -480,7 +480,7 @@ namespace Utils
 
     /**
      * searches for the first suggestion which contains name and returns it
-     * returns suggestion with empty vector if not found any
+     * returns nullptr if not found any
      * @param suggestions suggestions to search in
      * @param name token to find
      */

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <chrono>
 #include <sstream>
+#include <ui/Console.h>
 
 namespace Utils
 {
@@ -478,12 +479,12 @@ namespace Utils
     bool containsLike(const std::string& searchSpace, const std::string& part);
 
     /**
-     * searches for the first group (vector<string>) wich contains name and returns the group
-     * returns empty vector if not found any
-     * @param groups groups to search in
+     * searches for the first suggestion which contains name and returns it
+     * returns suggestion with empty vector if not found any
+     * @param suggestions suggestions to search in
      * @param name token to find
      */
-    std::vector<std::string> findNameInGroups(const std::vector<std::vector<std::string>>& groups, const std::string& name);
+    UI::ConsoleCommand::Suggestion findSuggestion(const std::vector<UI::ConsoleCommand::Suggestion>& suggestions, const std::string& name);
 
     /**
      * performs case insensitive euqal check


### PR DESCRIPTION
- Auto-complete rework:
  - Navigation through suggestions via: `PAGE_UP`, `PAGE_DOWN`, `HOME`, `END`
  - auto-complete no longer works on all tokens simultaneously (now: only the last/next)
  - `TAB` inserts currently selected entry
  - Sorting of suggestions improved a bit
  - Console now demands exact case. (to distinguish between `WOLF` (`Wolf`) and `Wolf` (`ORG_855_WOLF`) )
  - No more duplicate suggestions
- Changed the behavior of the externals `Info_AddChoice` and `Info_ClearChoices` to match the exact same behavior as in the original game. Though there should be no observable change compared to master branch. Sub-choices are now associated to the corresponding `C_Info` and survive the end of the Dialog (like in the original, though this behavior is never used).