### PR TITLE
Save game fix

### DIFF
--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -36,6 +36,7 @@ BaseEngine::BaseEngine() : m_RootUIView(*this)
 {
     m_pHUD = nullptr;
     m_pFontCache = nullptr;
+    m_Quickload = false;
 }
 
 BaseEngine::~BaseEngine()

--- a/src/engine/BaseEngine.h
+++ b/src/engine/BaseEngine.h
@@ -179,6 +179,9 @@ namespace Engine
 		 */
 		void togglePaused() { setPaused(!m_DisableLogic); }
 
+        void setQuickload(bool active) { m_Quickload = active; }
+        bool getQuickload() { return m_Quickload; }
+
 	protected:
 
 		/**
@@ -256,5 +259,11 @@ namespace Engine
          * Debug only
          */
 		bool m_DisableLogic;
+
+        /**
+         * Flag indicating whether the engine should load the quicksave slot after frame drawing.
+         * This flag is introduced to guarantee a specific execution point (not when the binding fires)
+         */
+		bool m_Quickload;
 	};
 }

--- a/src/engine/Input.h
+++ b/src/engine/Input.h
@@ -59,8 +59,6 @@ namespace Engine
 
 		Quicksave,
 		Quickload,
-		OpenStatusMenu,
-		OpenConsole,
         Escape,
 		UI_Up,
 		UI_Down,

--- a/src/engine/Input.h
+++ b/src/engine/Input.h
@@ -57,6 +57,8 @@ namespace Engine
 
 		DebugSkySpeed,
 
+		Quicksave,
+		Quickload,
 		OpenStatusMenu,
 		OpenConsole,
         Escape,

--- a/src/engine/PlatformGLFW.cpp
+++ b/src/engine/PlatformGLFW.cpp
@@ -213,6 +213,8 @@ int32_t PlatformGLFW::run(int argc, char** argv)
     bindKey(GLFW_KEY_LEFT_SHIFT, ActionType::DebugMoveSpeed2, true);
     bindKey(GLFW_KEY_LEFT_CONTROL, ActionType::PlayerAction, false);
 
+    bindKey(GLFW_KEY_F5, ActionType::Quicksave, false);
+    bindKey(GLFW_KEY_F9, ActionType::Quickload, false);
     bindKey(GLFW_KEY_P, ActionType::PauseGame, false);
 
     bindKey(GLFW_KEY_B, ActionType::OpenStatusMenu, false);

--- a/src/engine/PlatformGLFW.cpp
+++ b/src/engine/PlatformGLFW.cpp
@@ -217,7 +217,6 @@ int32_t PlatformGLFW::run(int argc, char** argv)
     bindKey(GLFW_KEY_F9, ActionType::Quickload, false);
     bindKey(GLFW_KEY_P, ActionType::PauseGame, false);
 
-    bindKey(GLFW_KEY_B, ActionType::OpenStatusMenu, false);
     bindKey(GLFW_KEY_ESCAPE, ActionType::UI_Close, false);
     bindKey(GLFW_KEY_UP, ActionType::UI_Up, false);
     bindKey(GLFW_KEY_DOWN, ActionType::UI_Down, false);

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -406,21 +406,9 @@ void DialogManager::addChoice(ChoiceEntry& entry)
     m_Interaction.choices.push_back(entry);
 }
 
-int DialogManager::beforeFrontIndex(){
-    if (m_Interaction.choices.empty())
-    {
-        return 0;
-    }
-    else
-    {
-        auto& minEl = *std::min_element(m_Interaction.choices.begin(), m_Interaction.choices.end(),
-                                       ChoiceEntry::comparator);
-        return minEl.nr - 1;
-    }
-}
-
 void DialogManager::sortChoices()
 {
+    // stable (!) sort is needed to keep the order of the (not-numbered) sub-choices
     std::stable_sort(m_Interaction.choices.begin(), m_Interaction.choices.end(), ChoiceEntry::comparator);
 }
 
@@ -487,6 +475,15 @@ void DialogManager::importDialogManager(const json& j)
 
         for(int info : it.value())
             m_World.getDialogManager().getScriptDialogManager()->setNpcInfoKnown((unsigned int)npcInstance, (unsigned int)info);
+    }
+}
+
+void DialogManager::onInputAction(UI::EInputAction action) {
+    auto& dialogBox = m_World.getEngine()->getHud().getDialogBox();
+    if(!dialogBox.isHidden()){
+        dialogBox.onInputAction(action);
+    } else if (isTalking() && action == UI::EInputAction::IA_Close) {
+        cancelTalk();
     }
 }
 

--- a/src/logic/DialogManager.h
+++ b/src/logic/DialogManager.h
@@ -59,6 +59,12 @@ namespace Logic
         void update(double dt);
 
         /**
+         * To be called when one of the given actions were triggered
+         * @param action Input action
+         */
+        void onInputAction(UI::EInputAction action);
+
+        /**
          * Start dialog
          */
         void startDialog(Daedalus::GameState::NpcHandle target);
@@ -111,11 +117,6 @@ namespace Logic
          * @param entry Choice entry.
          */
         void addChoice(ChoiceEntry& entry);
-
-        /**
-         * @return new choice number guaranteed to be smaller than all existing ones
-         */
-        int beforeFrontIndex();
 
         /**
          * Sets the current Dialog Message. To be able to cancel it

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -23,6 +23,7 @@
 #include <ui/Hud.h>
 #include <ui/Menu_Status.h>
 #include <ui/SubtitleBox.h>
+#include <logic/SavegameManager.h>
 
 #define DEBUG_PLAYER (isPlayerControlled() && false)
 
@@ -2001,6 +2002,20 @@ void PlayerController::changeAttribute(Daedalus::GEngineClasses::C_Npc::EAttribu
 void PlayerController::setupKeyBindings()
 {
     // Engine::Input::clearActions();
+
+    Engine::Input::RegisterAction(Engine::ActionType::Quicksave, [this](bool triggered, float)
+    {
+        if(triggered && !m_World.getEngine()->getHud().isMenuActive() && !m_World.getDialogManager().isDialogActive()){
+            Engine::SavegameManager::saveToSaveGameSlot(0, "");
+        }
+    });
+
+    Engine::Input::RegisterAction(Engine::ActionType::Quickload, [this](bool triggered, float)
+    {
+        if(triggered){
+            m_World.getEngine()->setQuickload(true);
+        }
+    });
 
     Engine::Input::RegisterAction(Engine::ActionType::PauseGame, [this](bool, float triggered)
     {

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2017,27 +2017,10 @@ void PlayerController::setupKeyBindings()
         }
     });
 
-    Engine::Input::RegisterAction(Engine::ActionType::PauseGame, [this](bool, float triggered)
+    Engine::Input::RegisterAction(Engine::ActionType::PauseGame, [this](bool triggered, float)
     {
-        if(triggered > 0.0f && !m_World.getEngine()->getHud().isMenuActive()){
+        if(triggered && !m_World.getEngine()->getHud().isMenuActive()){
             m_World.getEngine()->togglePaused();
-        }
-    });
-
-    Engine::Input::RegisterAction(Engine::ActionType::OpenStatusMenu, [this](bool triggered, float) {
-
-        if(triggered && !m_World.getDialogManager().isDialogActive())
-        {
-            UI::Hud &hud = m_World.getEngine()->getHud();
-            if (!hud.isMenuActive())
-            {
-                UI::Menu_Status& statsScreen = hud.pushMenu<UI::Menu_Status>();
-
-                // Update the players status menu once
-                updateStatusScreen(statsScreen);
-            }
-            else if (hud.isTopMenu<UI::Menu_Status>())
-                hud.popMenu();
         }
     });
 

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -75,14 +75,16 @@ void SavegameManager::clearSavegame(int idx)
     Utils::forEachFile(buildSavegamePath(idx), [](const std::string& path, const std::string& name, const std::string& ext)
     {
         // Make sure this is a REGoth-file
-        if(name.find("regoth_") == std::string::npos && name.find("world_") == std::string::npos)
+        bool isRegothFile = (Utils::startsWith(name, "regoth_") || Utils::startsWith(name, "world_"))
+                            && Utils::endsWith(name, ".json");
+        if(!isRegothFile)
             return; // Better not touch that one
 
         // Empty the file
-        FILE* f = fopen((path + "/" + name).c_str(), "w");
+        FILE* f = fopen(path.c_str(), "w");
         if(!f)
         {
-            LogWarn() << "Failed to clear file: " << path << "/" << name;
+            LogWarn() << "Failed to clear file: " << path;
             return;
         }
 

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -196,14 +196,11 @@ bool Engine::SavegameManager::init(Engine::GameEngine& engine)
     return true;
 }
 
-std::vector<std::string> SavegameManager::gatherAvailableSavegames()
+std::vector<std::shared_ptr<const std::string>> SavegameManager::gatherAvailableSavegames()
 {
-    constexpr int G1_MAX_SLOTS = 15 + 1; // 15 usual slots + current
-    constexpr int G2_MAX_SLOTS = 20 + 1; // 20 usual slots + current
+    int numSlots = maxSlots();
 
-    int numSlots = (gameEngine->getMainWorld().get().getBasicGameType() == World::EGameType::GT_Gothic1) ? G1_MAX_SLOTS : G2_MAX_SLOTS;
-
-    std::vector<std::string> names(numSlots);
+    std::vector<std::shared_ptr<const std::string>> names(numSlots, nullptr);
 
     // Try every slot, skip current (slot 0)
     for (int i = 1; i < numSlots; ++i)
@@ -211,12 +208,85 @@ std::vector<std::string> SavegameManager::gatherAvailableSavegames()
         if (isSavegameAvailable(i))
         {
             SavegameInfo info = readSavegameInfo(i);
-            names[i] = info.name;
+            names[i] = std::make_shared<const std::string>(info.name);
         } 
     }
-
-    LogInfo() << "Available savegames: " << names;
+    // for log purpose only
+    {
+        std::vector<std::string> names2;
+        for (auto& namePtr : names)
+        {
+            if (namePtr)
+                names2.push_back(*namePtr);
+            else
+                names2.push_back("");
+        }
+        LogInfo() << "Available savegames: " << names2;
+    }
 
     return names;
+}
+
+std::string Engine::SavegameManager::loadSaveGameSlot(int index) {
+    // Lock to number of savegames
+    assert(index > 0 && index < maxSlots());
+
+    if(!isSavegameAvailable(index))
+    {
+        return "Savegame at slot " + std::to_string(index) + " not available!";
+    }
+
+    // Read general information about the saved game. Most importantly the world the player saved in
+    SavegameInfo info = readSavegameInfo(index);
+
+    std::string worldPath = buildWorldPath(index, info.world);
+
+    // Sanity check, if we really got a safe for this world. Otherwise we would end up in the fresh version
+    // if it was missing. Also, IF the player saved there, there should be a save for this.
+    if(!Utils::getFileSize(worldPath))
+    {
+        return "Target world-file invalid: " + worldPath;
+    }
+
+    gameEngine->loadWorld(info.world + ".zen", worldPath);
+    gameEngine->getGameClock().setTotalSeconds(info.timePlayed);
+    return "";
+}
+
+int Engine::SavegameManager::maxSlots() {
+    switch(gameEngine->getMainWorld().get().getBasicGameType())
+    {
+        case World::EGameType::GT_Gothic1:
+            return G1_MAX_SLOTS;
+        case World::EGameType::GT_Gothic2:
+            return G2_MAX_SLOTS;
+        default:
+            return G2_MAX_SLOTS;
+    }
+}
+
+void Engine::SavegameManager::saveToSaveGameSlot(int index, std::string savegameName) {
+    assert(index > 0 && index < maxSlots());
+
+    if (savegameName.empty())
+        savegameName = std::string("Slot ") + std::to_string(index);
+
+    // TODO: Should be writing to a temp-directory first, before messing with the save-files already existing
+    // Clean data from old savegame, so we don't load into worlds we haven't been to yet
+    Engine::SavegameManager::clearSavegame(index);
+
+    // Write information about the current game-state
+    Engine::SavegameManager::SavegameInfo info;
+    info.version = Engine::SavegameManager::SavegameInfo::LATEST_KNOWN_VERSION;
+    info.name = savegameName;
+    info.world = Utils::stripExtension(gameEngine->getMainWorld().get().getZenFile());
+    info.timePlayed = gameEngine->getGameClock().getTotalSeconds();
+    Engine::SavegameManager::writeSavegameInfo(index, info);
+
+    json j;
+    gameEngine->getMainWorld().get().exportWorld(j);
+
+    // Save
+    Engine::SavegameManager::writeWorld(index, info.world, Utils::iso_8859_1_to_utf8(j.dump(4)));
 }
 

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -202,8 +202,8 @@ std::vector<std::shared_ptr<const std::string>> SavegameManager::gatherAvailable
 
     std::vector<std::shared_ptr<const std::string>> names(numSlots, nullptr);
 
-    // Try every slot, skip current (slot 0)
-    for (int i = 1; i < numSlots; ++i)
+    // Try every slot
+    for (int i = 0; i < numSlots; ++i)
     {
         if (isSavegameAvailable(i))
         {
@@ -229,7 +229,7 @@ std::vector<std::shared_ptr<const std::string>> SavegameManager::gatherAvailable
 
 std::string Engine::SavegameManager::loadSaveGameSlot(int index) {
     // Lock to number of savegames
-    assert(index > 0 && index < maxSlots());
+    assert(index >= 0 && index < maxSlots());
 
     if(!isSavegameAvailable(index))
     {
@@ -266,10 +266,10 @@ int Engine::SavegameManager::maxSlots() {
 }
 
 void Engine::SavegameManager::saveToSaveGameSlot(int index, std::string savegameName) {
-    assert(index > 0 && index < maxSlots());
+    assert(index >= 0 && index < maxSlots());
 
     if (savegameName.empty())
-        savegameName = std::string("Slot ") + std::to_string(index);
+        savegameName = std::string("Slot") + std::to_string(index);
 
     // TODO: Should be writing to a temp-directory first, before messing with the save-files already existing
     // Clean data from old savegame, so we don't load into worlds we haven't been to yet

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -31,10 +31,10 @@ void ensureSavegameFolders(int idx)
         gameType = "/Gothic 2";
     }
 
-    if (Utils::mkdir(userdata + gameType))
+    if (!Utils::mkdir(userdata + gameType))
         LogError() << "Failed to create gametype-directory at: " << userdata + gameType;
 
-    if(Utils::mkdir(SavegameManager::buildSavegamePath(idx)))
+    if(!Utils::mkdir(SavegameManager::buildSavegamePath(idx)))
 		LogError() << "Failed to create savegame-directory at: " << SavegameManager::buildSavegamePath(idx);
 }
 

--- a/src/logic/SavegameManager.h
+++ b/src/logic/SavegameManager.h
@@ -1,6 +1,7 @@
 #pragma once 
 #include <vector>
 #include <string>
+#include <memory>
 
 namespace Engine
 {
@@ -15,10 +16,10 @@ namespace Engine
 
         /**
          * Assembles a list of all available savegame names. Every entry will correspond to an index number.
-         * Empty names mean, that there is no save currently stored.
+         * nullptr means, that there is no save currently stored.
          * @return List of available saves
          */
-        std::vector<std::string> gatherAvailableSavegames();
+        std::vector<std::shared_ptr<const std::string>> gatherAvailableSavegames();
 
         /**
          * Checks if the given savegame-slot contains valid data
@@ -90,11 +91,30 @@ namespace Engine
         std::string readWorld(int idx, const std::string& worldName);
 
         /**
+         * loads the savegame of the specified slotindex
+         * @param index slotindex
+         * @return empty string if successful, else error message
+         */
+        std::string loadSaveGameSlot(int index);
+
+        /**
+         * saves the current world to the given slot
+         * @param index slotindex
+         * @param savegameName label of the savegame. If empty string, then "Slot <index>" is used as name
+         */
+        void saveToSaveGameSlot(int index, std::string savegameName);
+
+        /**
          * Builds the path to a saved worldfile from the given slot
          * @param idx Index of the savegame
          * @param worldName Name of the world to appear in the path
          * @return full path + filename to the given world
          */
         std::string buildWorldPath(int idx, const std::string& worldName);
+
+        constexpr int G1_MAX_SLOTS = 15 + 1; // 15 usual slots + current
+        constexpr int G2_MAX_SLOTS = 20 + 1; // 20 usual slots + current
+
+        int maxSlots();
     }
 }

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -965,7 +965,8 @@ public:
                                                   {GLFW_KEY_HOME, UI::IA_HOME},
                                                   {GLFW_KEY_END, UI::IA_END},
                                                   {GLFW_KEY_PAGE_UP, UI::IA_Up},
-                                                  {GLFW_KEY_PAGE_DOWN, UI::IA_Down}};
+                                                  {GLFW_KEY_PAGE_DOWN, UI::IA_Down},
+                                                  {GLFW_KEY_B, UI::IA_ToggleStatusMenu}};
 
         const auto CONSOLE_TOGGLE_KEY = GLFW_KEY_F10;
         std::string frameInputText = getFrameTextInput();
@@ -1001,7 +1002,8 @@ public:
         // Pass text input from this frame
         m_pEngine->getHud().onTextInput(frameInputText);
 
-        if(!m_pEngine->getHud().getConsole().isOpen())
+        bool disableBindings = m_pEngine->getHud().getConsole().isOpen() || m_pEngine->getHud().isMenuActive();
+        if(!disableBindings)
             Engine::Input::fireBindings();
 
 
@@ -1103,7 +1105,8 @@ public:
         if(m_pEngine->getHud().getConsole().isOpen())
         {
             m_pEngine->getHud().getConsole().update();
-
+        }
+        if (disableBindings){
             Engine::Input::clearTriggered();
         }
 

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -1104,7 +1104,9 @@ public:
 
         if(m_pEngine->getHud().getConsole().isOpen())
         {
-            m_pEngine->getHud().getConsole().update();
+            float gameSpeed = m_pEngine->getGameEngineSpeedFactor();
+            m_pEngine->getHud().getConsole().getConsoleBox().update(
+                    dt * gameSpeed, ms, m_pEngine->getDefaultRenderSystem().getConfig());
         }
         if (disableBindings){
             Engine::Input::clearTriggered();

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -555,8 +555,8 @@ public:
 
             int index = std::stoi(args[1]);
             int maxSlots = SavegameManager::maxSlots();
-            if (index < 1 || index >= maxSlots){
-                return "invalid slot index " + std::to_string(index) + ". allowed range: 1.." + std::to_string(maxSlots-1);
+            if (!(index >= 0 && index < maxSlots)){
+                return "invalid slot index " + std::to_string(index) + ". allowed range: 0.." + std::to_string(maxSlots-1);
             }
             auto error = SavegameManager::loadSaveGameSlot(index);
             if (!error.empty()){
@@ -572,8 +572,8 @@ public:
 
             int index = std::stoi(args[1]);
             int maxSlots = Engine::SavegameManager::maxSlots();
-            if (index < 1 || index >= maxSlots){
-                return "invalid slot index " + std::to_string(index) + ". allowed range: 1.." + std::to_string(maxSlots-1);
+            if (!(index >= 0 && index < maxSlots)){
+                return "invalid slot index " + std::to_string(index) + ". allowed range: 0.." + std::to_string(maxSlots-1);
             }
 
             std::string saveGameName;

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -1110,6 +1110,17 @@ public:
         // Advance to next frame. Rendering thread will be kicked to
         // process submitted rendering primitives.
         bgfx::frame();
+        if (m_pEngine->getQuickload())
+        {
+            m_pEngine->setQuickload(false);
+
+            if (!m_pEngine->getHud().isMenuActive() && !m_pEngine->getMainWorld().get().getDialogManager().isDialogActive())
+            {
+                auto error = Engine::SavegameManager::loadSaveGameSlot(0);
+                if (!error.empty())
+                    LogWarn() << error;
+            }
+        }
 
         return true;
 	}

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -966,18 +966,18 @@ public:
                                                   {GLFW_KEY_END, UI::IA_END},
                                                   {GLFW_KEY_PAGE_UP, UI::IA_Up},
                                                   {GLFW_KEY_PAGE_DOWN, UI::IA_Down},
-                                                  {GLFW_KEY_B, UI::IA_ToggleStatusMenu}};
+                                                  {GLFW_KEY_B, UI::IA_ToggleStatusMenu},
+                                                  {GLFW_KEY_F10, UI::IA_ToggleConsole}};
 
-        const auto CONSOLE_TOGGLE_KEY = GLFW_KEY_F10;
         std::string frameInputText = getFrameTextInput();
         for (int i = 0; i < NUM_KEYS; i++) {
             if (getKeysTriggered()[i]) // If key has been triggered start the stopwatch
             {
                 m_stopWatch.start();
 
-                if(m_pEngine->getHud().getConsole().isOpen() || i == CONSOLE_TOGGLE_KEY)
+                if(m_pEngine->getHud().getConsole().isOpen())
                     m_pEngine->getHud().getConsole().onKeyDown(i);
-                else if (keyMap.find(i) != keyMap.end())
+                if (keyMap.find(i) != keyMap.end())
                 {
                     m_pEngine->getHud().onInputAction(keyMap[i]);
                 }
@@ -988,9 +988,9 @@ public:
                 {
                     if (m_stopWatch.DelayedByArgMS(70))
                     {
-                        if(m_pEngine->getHud().getConsole().isOpen() || i == CONSOLE_TOGGLE_KEY)
+                        if(m_pEngine->getHud().getConsole().isOpen())
                             m_pEngine->getHud().getConsole().onKeyDown(i);
-                        else if (keyMap.find(i) != keyMap.end())
+                        if (keyMap.find(i) != keyMap.end())
                         {
                             m_pEngine->getHud().onInputAction(keyMap[i]);
                         }

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -2,16 +2,12 @@
 #include <ZenLib/utils/split.h>
 #include <utils/logger.h>
 #include "Console.h"
-#include <cctype>
 #include <iterator>
-#include <algorithm>
 #include <utils/Utils.h>
 #include <iomanip>
 #include <engine/BaseEngine.h>
 
 using namespace UI;
-
-const uint16_t GLOBAL_Y = 25;
 
 /* Function keys */
 namespace Keys
@@ -47,18 +43,11 @@ Console::Console(Engine::BaseEngine& e) :
     m_ConsoleBox(e, *this)
 {
     m_HistoryIndex = 0;
-    m_IsOpen = false;
-
-    m_BaseEngine.getRootUIView().addChild(&m_ConsoleBox);
+    setOpen(false);
     outputAdd(" ----------- REGoth Console -----------");
 }
 
 Console::~Console() {
-    m_BaseEngine.getRootUIView().removeChild(&m_ConsoleBox);
-}
-
-void Console::update()
-{
 }
 
 void Console::onKeyDown(int glfwKey)

--- a/src/ui/Console.cpp
+++ b/src/ui/Console.cpp
@@ -63,13 +63,6 @@ void Console::update()
 
 void Console::onKeyDown(int glfwKey)
 {
-    // If this is Escape or F10, close/open the console
-    if(glfwKey == Keys::GLFW_KEY_ESCAPE){
-        setOpen(false);
-    }
-    if(glfwKey == Keys::GLFW_KEY_F10){
-        setOpen(!isOpen());
-    }
     if(glfwKey == Keys::GLFW_KEY_PAGE_DOWN)
     {
         m_ConsoleBox.increaseSelectionIndex(1);

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -64,11 +64,6 @@ namespace UI
         ~Console();
 
         /**
-         * Updates and draws the console
-         */
-        void update();
-
-        /**
          * To be called when a key got pressed.
          * @param glfwKey Key ID, glfw style
          */
@@ -122,12 +117,13 @@ namespace UI
         /**
          * @return Whether the console is currently shown
          */
-        bool isOpen(){ return m_IsOpen; }
-        void setOpen(bool open){ m_IsOpen = open; }
+        bool isOpen(){ return !m_ConsoleBox.isHidden(); }
+        void setOpen(bool open){ m_ConsoleBox.setHidden(!open); }
 
         const std::list<std::string>& getOutputLines() { return m_Output; }
         const std::string& getTypedLine() { return m_TypedLine; }
         const std::vector<std::vector<UI::ConsoleCommand::Suggestion>>& getSuggestions() { return m_SuggestionsList; }
+        ConsoleBox& getConsoleBox() { return m_ConsoleBox; }
 
     private:
 
@@ -170,11 +166,6 @@ namespace UI
          * Currently typed line
          */
         std::string m_TypedLine;
-
-        /**
-         * Whether the console is currently shown
-         */
-        bool m_IsOpen;
 
         Engine::BaseEngine& m_BaseEngine;
 

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -13,7 +13,9 @@
 #include "Menu_Save.h"
 #include "Menu_Settings.h"
 #include <utils/logger.h>
+#include <components/VobClasses.h>
 #include "DialogBox.h"
+#include <logic/PlayerController.h>
 
 UI::Hud::Hud(Engine::BaseEngine& e) :
         View(e),
@@ -152,15 +154,13 @@ void UI::Hud::onInputAction(UI::EInputAction action)
 
     if(!m_MenuChain.empty())
     {
-        // case: a menu is open
-        if (action == IA_Close)
+        // Notify last menu in chain
+        bool close = m_MenuChain.back()->onInputAction(action);
+        if (close)
             popMenu();
-        else
-            m_MenuChain.back()->onInputAction(action); // Notify last menu in chain
         return;
     }else if(dialogManager.isDialogActive())
     {
-        // case: a dialog is active
         dialogManager.onInputAction(action);
         return;
     }
@@ -172,6 +172,16 @@ void UI::Hud::onInputAction(UI::EInputAction action)
             // Show main-menu
             pushMenu<UI::Menu_Main>();
             return;
+        case IA_ToggleStatusMenu:
+        {
+            UI::Menu_Status& statsScreen = pushMenu<UI::Menu_Status>();
+            // TODO: Refactor move this into menu_status.create/new function?
+            // Update the players status menu once
+            auto& s = m_Engine.getMainWorld().get().getScriptEngine();
+            VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_Engine.getMainWorld().get(), s.getPlayerEntity());
+            player.playerController->updateStatusScreen(statsScreen);
+            return;
+        }
         default:
             return;
     }

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -150,38 +150,30 @@ void UI::Hud::onInputAction(UI::EInputAction action)
 {
     auto& dialogManager = m_Engine.getMainWorld().get().getDialogManager();
 
-    // Notify last menu in chain
-    if(!m_MenuChain.empty() && action != IA_Close)
+    if(!m_MenuChain.empty())
     {
-        m_MenuChain.back()->onInputAction(action);
+        // case: a menu is open
+        if (action == IA_Close)
+            popMenu();
+        else
+            m_MenuChain.back()->onInputAction(action); // Notify last menu in chain
         return;
     }else if(dialogManager.isDialogActive())
     {
-        if(!m_pDialogBox->isHidden()){
-            m_pDialogBox->onInputAction(action);
-            return;
-        }
-        else if (dialogManager.isTalking() && action == IA_Close) {
-            dialogManager.cancelTalk();
-            return;
-        }
+        // case: a dialog is active
+        dialogManager.onInputAction(action);
         return;
     }
 
-    // Close console or last menu, in case it's open
-    if(action == IA_Close)
+    // case: Nothing is open right now.
+    switch (action)
     {
-        if(!m_MenuChain.empty())
-        {
-            popMenu();
-            return;
-        }
-        else
-        {
-            // Nothing is open right now. Show main-menu
+        case IA_Close:
+            // Show main-menu
             pushMenu<UI::Menu_Main>();
             return;
-        }
+        default:
+            return;
     }
 }
 

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -151,8 +151,12 @@ void UI::Hud::onTextInput(const std::string& text)
 void UI::Hud::onInputAction(UI::EInputAction action)
 {
     auto& dialogManager = m_Engine.getMainWorld().get().getDialogManager();
-
-    if(!m_MenuChain.empty())
+    if (m_Engine.getHud().getConsole().isOpen())
+    {
+        if (action == IA_Close || action == IA_ToggleConsole)
+            m_Console.setOpen(false);
+        return;
+    } else if(!m_MenuChain.empty())
     {
         // Notify last menu in chain
         bool close = m_MenuChain.back()->onInputAction(action);
@@ -171,6 +175,9 @@ void UI::Hud::onInputAction(UI::EInputAction action)
         case IA_Close:
             // Show main-menu
             pushMenu<UI::Menu_Main>();
+            return;
+        case IA_ToggleConsole:
+            m_Engine.getHud().getConsole().setOpen(true);
             return;
         case IA_ToggleStatusMenu:
         {

--- a/src/ui/Menu.cpp
+++ b/src/ui/Menu.cpp
@@ -95,7 +95,7 @@ void UI::Menu::update(double dt, Engine::Input::MouseState& mstate, Render::Rend
         // Update info-text
         if((getScriptData().flags & Daedalus::GEngineClasses::C_Menu::MENU_SHOW_INFO) != 0 && m_pInfoText)
         {
-           m_pInfoText->setText(getItemScriptData(m_SelectableItems[m_SelectedItem]).text[1]); 
+            m_pInfoText->setText(getItemScriptData(m_SelectableItems[m_SelectedItem]).text[1]);
         }
     }
 
@@ -156,9 +156,7 @@ void UI::Menu::initializeInstance(const std::string& instance)
 
         m_pInfoText->setTranslation(Math::float2(infoX, infoY));
         m_pInfoText->setAlignment(A_TopCenter);
-        m_pInfoText->setText("Ein neues Abenteuer beginnen");
         m_pInfoText->setFont(UI::DEFAULT_FONT);
-
     }
 }
 
@@ -219,7 +217,8 @@ std::map<Daedalus::GameState::MenuItemHandle, UI::MenuItem*> UI::Menu::initializ
             m_pVM->initializeInstance(ZMemory::toBigHandle(items.back()),
                                       m_pVM->getDATFile().getSymbolIndexByName(menu.items[i]),
                                       Daedalus::IC_MenuItem);
-
+            //LogInfo() << getItemScriptData(items.back()).text[0];
+            //LogInfo() << getItemScriptData(items.back()).text[1];
         }
     }
 

--- a/src/ui/Menu.cpp
+++ b/src/ui/Menu.cpp
@@ -217,8 +217,6 @@ std::map<Daedalus::GameState::MenuItemHandle, UI::MenuItem*> UI::Menu::initializ
             m_pVM->initializeInstance(ZMemory::toBigHandle(items.back()),
                                       m_pVM->getDATFile().getSymbolIndexByName(menu.items[i]),
                                       Daedalus::IC_MenuItem);
-            //LogInfo() << getItemScriptData(items.back()).text[0];
-            //LogInfo() << getItemScriptData(items.back()).text[1];
         }
     }
 

--- a/src/ui/Menu.cpp
+++ b/src/ui/Menu.cpp
@@ -255,7 +255,7 @@ std::map<Daedalus::GameState::MenuItemHandle, UI::MenuItem*> UI::Menu::initializ
 }
 
 
-void UI::Menu::onInputAction(EInputAction action)
+bool UI::Menu::onInputAction(EInputAction action)
 {
     switch(action)
     {
@@ -286,11 +286,12 @@ void UI::Menu::onInputAction(EInputAction action)
             break;
 
         case IA_Close:
-            setHidden(true);
-            break;
+            return true;
+
         default:
             break;
     }
+    return false;
 }
 
 

--- a/src/ui/Menu.h
+++ b/src/ui/Menu.h
@@ -57,8 +57,9 @@ namespace UI
         /**
          * To be called when one of the given actions were triggered
          * @param action Input action
+         * @return returns true if the menu should be closed after this function
          */
-        virtual void onInputAction(EInputAction action);
+        virtual bool onInputAction(EInputAction action);
 
         /**
          * To be called when there was text input since the last frame

--- a/src/ui/Menu_Load.cpp
+++ b/src/ui/Menu_Load.cpp
@@ -50,7 +50,7 @@ void Menu_Load::gatherAvailableSavegames()
         }else 
         {
             getItemScriptData(sym).flags &= ~C_Menu_Item::IT_SELECTABLE;
-            displayName = "---";
+            displayName = Menu_Load::EMPTY_SLOT_DISPLAYNAME;
         }
         // never overwrite displayname of quicksave slot (i==0)
         if (i != 0)

--- a/src/ui/Menu_Load.cpp
+++ b/src/ui/Menu_Load.cpp
@@ -32,23 +32,29 @@ void Menu_Load::gatherAvailableSavegames()
 
     auto names = SavegameManager::gatherAvailableSavegames();
 
-    // There are 15/20 labels in the original menus
-    // Slot 0 is for the current game, so skip it
-    for(unsigned i=1;i<names.size();i++)
+    // gothic 1: Slot 1-15. gothic 2: Slot 1-20 + Slot0 (quicksave)
+    for(unsigned i=0;i<names.size();i++)
     {
         std::string sym = "MENUITEM_LOAD_SLOT" + std::to_string(i);
-        assert(m_pVM->getDATFile().hasSymbolName(sym));
-        
+        bool slotSymbolFound = m_pVM->getDATFile().hasSymbolName(sym);
+        if (!slotSymbolFound && i == 0)
+            continue; // Gothic 1 does not have a quicksave slot in the load-menu
+
+        assert(slotSymbolFound);
+        std::string displayName;
         if(names[i] != nullptr)
         {
             // Toggle selectable depending on whether we actually have a slot here
             getItemScriptData(sym).flags |= C_Menu_Item::IT_SELECTABLE;
-            getItemScriptData(sym).text[0] = *names[i];
+            displayName = *names[i];
         }else 
         {
             getItemScriptData(sym).flags &= ~C_Menu_Item::IT_SELECTABLE;
-            getItemScriptData(sym).text[0] = "---";
+            displayName = "---";
         }
+        // never overwrite displayname of quicksave slot (i==0)
+        if (i != 0)
+            getItemScriptData(sym).text[0] = displayName;
     }
 }
 

--- a/src/ui/Menu_Load.h
+++ b/src/ui/Menu_Load.h
@@ -21,6 +21,8 @@ namespace UI
         void gatherAvailableSavegames();   
 
         void onCustomAction(const std::string& action);
+
+        static constexpr auto const EMPTY_SLOT_DISPLAYNAME = "---";
     private:
     };
 }

--- a/src/ui/Menu_Main.cpp
+++ b/src/ui/Menu_Main.cpp
@@ -25,20 +25,9 @@ Menu_Main* Menu_Main::create(Engine::BaseEngine& e)
     return s;
 }
 
-void Menu_Main::onInputAction(EInputAction action)
+bool Menu_Main::onInputAction(EInputAction action)
 {
-    Menu::onInputAction(action);
-
-    switch(action)
-    {
-        case IA_Up:break;
-        case IA_Down:break;
-        case IA_Left:break;
-        case IA_Right:break;
-        case IA_Close: getHud().popMenu(); break;
-        case IA_Accept:break;
-        default:break;
-    }
+    return Menu::onInputAction(action);
 }
 
 

--- a/src/ui/Menu_Main.h
+++ b/src/ui/Menu_Main.h
@@ -21,7 +21,7 @@ namespace UI
          * To be called when one of the given actions were triggered
          * @param action Input action
          */
-        virtual void onInputAction(EInputAction action) override;
+        virtual bool onInputAction(EInputAction action) override;
 
         /**
          * Creates an instance of this class and appends it to the root UI-View

--- a/src/ui/Menu_Save.h
+++ b/src/ui/Menu_Save.h
@@ -26,13 +26,15 @@ namespace UI
          * To be called when one of the given actions were triggered
          * @param action Input action
          */
-        virtual void onInputAction(EInputAction action) override;
+        virtual bool onInputAction(EInputAction action) override;
 
         /**
          * To be called when there was text input since the last frame
          * @param text Characters input since the last frame
          */
         virtual void onTextInput(const std::string& text) override;
+
+        static constexpr auto const EMPTY_SLOT_DISPLAYNAME = "---";
 
     private:
 

--- a/src/ui/Menu_Status.cpp
+++ b/src/ui/Menu_Status.cpp
@@ -79,18 +79,9 @@ void Menu_Status::setExperienceNext(int xpNext)
     getItemScriptData("MENU_ITEM_LEVEL_NEXT").text[0] = std::to_string(xpNext);
 }
 
-void Menu_Status::onInputAction(EInputAction action)
+bool Menu_Status::onInputAction(EInputAction action)
 {
-    Menu::onInputAction(action);
-
-    switch(action)
-    {
-        case IA_Up:break;
-        case IA_Down:break;
-        case IA_Left:break;
-        case IA_Right:break;
-        case IA_Close: break;
-        case IA_Accept:break;
-        default:break;
-    }
+    bool baseclassClose = Menu::onInputAction(action);
+    // close this menu if either the parent function wants to close or this function
+    return baseclassClose || (action == IA_ToggleStatusMenu);
 }

--- a/src/ui/Menu_Status.h
+++ b/src/ui/Menu_Status.h
@@ -46,7 +46,7 @@ namespace UI
          * To be called when one of the given actions were triggered
          * @param action Input action
          */
-        virtual void onInputAction(EInputAction action) override;
+        virtual bool onInputAction(EInputAction action) override;
 
         /**
          * Creates an instance of this class and appends it to the root UI-View

--- a/src/ui/View.h
+++ b/src/ui/View.h
@@ -32,7 +32,9 @@ namespace UI
         IA_8,
         IA_9,
         IA_HOME,
-        IA_END
+        IA_END,
+        IA_ToggleStatusMenu,
+        IA_ToggleConsole
     };
 
     // BGFX-View to be used for rendering views

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -322,7 +322,8 @@ bool Utils::mkdir(const std::string& dir)
     mode_t nMode = 0733; // UNIX style permissions
     nError = ::mkdir(dir.c_str(),nMode); // can be used on non-Windows
 #endif
-	return nError == 0 || (nError == -1 && errno == EEXIST);
+    auto errorCode = errno;
+	return nError == 0 || (nError == -1 && errorCode == EEXIST);
 }
     
 std::string Utils::getUserDataLocation()

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -499,3 +499,12 @@ Utils::Profiler::~Profiler()
         << std::chrono::duration_cast<dura>(d).count() * 1000
         << " milliseconds";
 }
+
+bool Utils::startsWith(const std::string& searchSpace, const std::string& start) {
+    return searchSpace.find(start) == 0;
+}
+
+bool Utils::endsWith(const std::string& searchSpace, const std::string& end) {
+    auto pos = searchSpace.size() - end.size();
+    return end.size() <= searchSpace.size() && searchSpace.find(end, pos) != std::string::npos;
+}

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -530,4 +530,14 @@ namespace Utils
         Profiler(const std::string& n);
         ~Profiler();
     };
+
+    /**
+     * checks if string searchSpace starts with start
+     */
+    bool startsWith(const std::string& searchSpace, const std::string& start);
+
+    /**
+     * checks if string searchSpace ends with end
+     */
+    bool endsWith(const std::string& searchSpace, const std::string& end);
 }


### PR DESCRIPTION
- fixed lots of issues with savegame slots. Different number of save game slots in gothic 1/gothic 2 (15/20+1) should now be handled correctly.
- implemented quicksave/quickload (F5/F9) functionalities for G1+G2.
- G1 does not have a visible quicksave slot in the loading menu (this could be fixed by extending the scripts like G2 does). Loading in G1 is therefore only possible via console (quicksave is slot 0) or hotkey (F9).
- fixed player moving around while saving via menu. #164 .  (@degenerated1123  Bindings no longer fire when a menu is open).
- console is no longer hidden, when the hud is hidden via the console command `hud`