### PR TITLE
Npc set state time + Zenlib fixes

### DIFF
--- a/src/audio/AudioWorld.cpp
+++ b/src/audio/AudioWorld.cpp
@@ -316,7 +316,7 @@ namespace World
         }
 
         m_VM = new Daedalus::DaedalusVM(datFile);
-        Daedalus::registerGothicEngineClasses(*m_VM);
+        Daedalus::registerGothicEngineClasses(*m_VM, m_Engine.getMainWorld().get().getBasicGameType());
 
         size_t count = 0;
         m_VM->getDATFile().iterateSymbolsOfClass("C_SFX", [&](size_t i, Daedalus::PARSymbol& s){

--- a/src/content/Sky.cpp
+++ b/src/content/Sky.cpp
@@ -145,7 +145,7 @@ void Sky::initSkyState(World::WorldInstance& world, ESkyPresetType type, Sky::Sk
         if (Flags::skyType.getParam(0).empty()
             || Flags::skyType.getParam(0) == "auto")
         {
-            if (world.getBasicGameType() == World::GT_Gothic2)
+            if (world.getBasicGameType() == Daedalus::GameType::GT_Gothic2)
                 skyColor = skyColor_g2;
             else
                 skyColor = skyColor_g1;

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -681,12 +681,13 @@ std::vector<Handle::EntityHandle> WorldInstance::getFreepoints(const std::string
     return mp;
 }
 
-EGameType WorldInstance::getBasicGameType()
+Daedalus::GameType WorldInstance::getBasicGameType()
 {
-    std::map<std::string, EGameType> m = {{"newworld.zen", GT_Gothic2},
-                                          {"oldworld.zen", GT_Gothic2},
-                                          {"addonworld.zen", GT_Gothic2},
-                                          {"world.zen", GT_Gothic1}};
+    using Daedalus::GameType;
+    std::map<std::string, GameType> m = {{"newworld.zen", GameType::GT_Gothic2},
+                                          {"oldworld.zen", GameType::GT_Gothic2},
+                                          {"addonworld.zen", GameType::GT_Gothic2},
+                                          {"world.zen", GameType::GT_Gothic1}};
 
     std::string lower;
     std::transform(m_ZenFile.begin(), m_ZenFile.end(), std::back_inserter(lower), ::tolower);
@@ -697,7 +698,7 @@ EGameType WorldInstance::getBasicGameType()
     LogInfo() << "ZEN unknown, defaulting to Gothic 2 skycolors";
 
     // Default to gothic 2
-    return GT_Gothic2;
+    return GameType::GT_Gothic2;
 }
 
 void WorldInstance::exportWorld(json& j)

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -69,15 +69,6 @@ namespace World
         std::vector<size_t> m_VisibleEntities;
     };
 
-	/**
-	 * Basic gametype this is. Needed for sky configuration, for example
-	 */
-	enum EGameType
-	{
-		GT_Gothic1,
-		GT_Gothic2
-	};
-
     class WorldInstance : public Handle::HandleTypeDescriptor<Handle::WorldHandle>
     {
     public:
@@ -149,7 +140,7 @@ namespace World
 		/**
 		 * @return Basic gametype this is. Needed for sky configuration, for example
 		 */
-		EGameType getBasicGameType();
+		Daedalus::GameType getBasicGameType();
 
         /**
          * Data access

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -154,7 +154,7 @@ void DialogManager::onAIOutput(Daedalus::GameState::NpcHandle self, Daedalus::Ga
                                const ZenLoad::oCMsgConversationData& msg)
 {
     if(self == target)
-        return; // FIXME: Vatras right here
+        0; // FIXME: Vatras right here
 
     LogInfo() << getGameState().getNpc(self).name[0] << ": " << msg.text;
     // Make a new message for the talking NPC

--- a/src/logic/NpcScriptState.cpp
+++ b/src/logic/NpcScriptState.cpp
@@ -571,3 +571,8 @@ void NpcScriptState::clearRoutine()
     m_Routine.routine.clear();
 }
 
+void NpcScriptState::setCurrentStateTime(float time) {
+    if (m_CurrentState.valid)
+        m_CurrentState.stateTime = time;
+}
+

--- a/src/logic/NpcScriptState.h
+++ b/src/logic/NpcScriptState.h
@@ -161,7 +161,13 @@ namespace Logic
 		/**
 		 * @return Time the Character already is inside this state
 		 */
-		 float getCurrentStateTime(){ return m_CurrentState.valid ? m_CurrentState.stateTime : 0.0f; }
+		float getCurrentStateTime(){ return m_CurrentState.valid ? m_CurrentState.stateTime : 0.0f; }
+
+		/**
+		 * Sets the time the Character is inside this state
+		 * @param time
+		 */
+		void setCurrentStateTime(float time);
 
 		/**
 		 * Gets the current routine function from the script instance and replaces the routine stored with the new one

--- a/src/logic/PfxManager.cpp
+++ b/src/logic/PfxManager.cpp
@@ -36,7 +36,7 @@ bool Logic::PfxManager::loadParticleFXDAT()
 
     // Load DAT-File...
     m_pVM = new Daedalus::DaedalusVM(datFile);
-    Daedalus::registerGothicEngineClasses(*m_pVM);
+    Daedalus::registerGothicEngineClasses(*m_pVM, m_World.getBasicGameType());
 
     m_DefaultEmitter = {0};
 

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2296,7 +2296,7 @@ void PlayerController::exportPart(json& j)
     j["scriptObj"]["spawnDelay"] = scriptObj.spawnDelay;
     j["scriptObj"]["senses"] = scriptObj.senses;
     j["scriptObj"]["senses_range"] = scriptObj.senses_range;
-    j["scriptObj"]["ai"] = Utils::putArray(scriptObj.ai);
+    j["scriptObj"]["aivar"] = Utils::putArray(scriptObj.aivar);
     j["scriptObj"]["wp"] = scriptObj.wp;
     j["scriptObj"]["exp"] = scriptObj.exp;
     j["scriptObj"]["exp_next"] = scriptObj.exp_next;
@@ -2375,7 +2375,7 @@ void PlayerController::importObject(const json& j, bool noTransform)
         scriptObj.spawnDelay = j["scriptObj"]["spawnDelay"];
         scriptObj.senses = j["scriptObj"]["senses"];
         scriptObj.senses_range = j["scriptObj"]["senses_range"];
-        Utils::putArray(scriptObj.ai, j["scriptObj"]["ai"]);
+        Utils::putArray(scriptObj.aivar, j["scriptObj"]["aivar"]);
         scriptObj.wp = j["scriptObj"]["wp"];
         scriptObj.exp = j["scriptObj"]["exp"];
         scriptObj.exp_next = j["scriptObj"]["exp_next"];

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2529,9 +2529,7 @@ std::string PlayerController::getGuildName()
 {
     // Guilds are stored as an array in a symbol called "TXT_GUILDS"
     auto& sym = m_World.getScriptEngine().getVM().getDATFile().getSymbolByName("TXT_GUILDS");
-    std::string* adr = sym.getStrAddr((unsigned int)getScriptInstance().guild);
-
-    return *adr;
+    return sym.getString((unsigned int)getScriptInstance().guild);
 }
 
 void PlayerController::updateStatusScreen(UI::Menu_Status& statsScreen)

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -21,15 +21,7 @@ void ensureSavegameFolders(int idx)
 	if(!Utils::mkdir(userdata))
 		LogError() << "Failed to create userdata-directory at: " << userdata;
 
-    std::string gameType;
-    if (gameEngine->getMainWorld().get().getBasicGameType() == World::EGameType::GT_Gothic1)
-    {
-        gameType = "/Gothic";
-    }
-    else
-    {
-        gameType = "/Gothic 2";
-    }
+    std::string gameType = "/" + SavegameManager::gameSpecificSubFolderName();
 
     if (!Utils::mkdir(userdata + gameType))
         LogError() << "Failed to create gametype-directory at: " << userdata + gameType;
@@ -41,13 +33,7 @@ void ensureSavegameFolders(int idx)
 std::string SavegameManager::buildSavegamePath(int idx)
 {
     std::string userdata = Utils::getUserDataLocation();
-
-    if (gameEngine->getMainWorld().get().getBasicGameType() == World::EGameType::GT_Gothic1)
-    {
-        return userdata + "/Gothic/savegame_" + std::to_string(idx);
-    }
-
-    return userdata + "/Gothic 2/savegame_" + std::to_string(idx);
+    return userdata + "/" + SavegameManager::gameSpecificSubFolderName() + "/savegame_" + std::to_string(idx);
 }
 
 std::vector<std::string> SavegameManager::getSavegameWorlds(int idx)
@@ -258,9 +244,9 @@ std::string Engine::SavegameManager::loadSaveGameSlot(int index) {
 int Engine::SavegameManager::maxSlots() {
     switch(gameEngine->getMainWorld().get().getBasicGameType())
     {
-        case World::EGameType::GT_Gothic1:
+        case Daedalus::GameType::GT_Gothic1:
             return G1_MAX_SLOTS;
-        case World::EGameType::GT_Gothic2:
+        case Daedalus::GameType::GT_Gothic2:
             return G2_MAX_SLOTS;
         default:
             return G2_MAX_SLOTS;
@@ -290,5 +276,13 @@ void Engine::SavegameManager::saveToSaveGameSlot(int index, std::string savegame
 
     // Save
     Engine::SavegameManager::writeWorld(index, info.world, Utils::iso_8859_1_to_utf8(j.dump(4)));
+}
+
+std::string Engine::SavegameManager::gameSpecificSubFolderName() {
+    // FIXME can't get gameType from World if no world is loaded (game should start with the menu)
+    if (gameEngine->getMainWorld().get().getBasicGameType() == Daedalus::GameType::GT_Gothic1)
+        return  "Gothic";
+    else
+        return  "Gothic 2";
 }
 

--- a/src/logic/SavegameManager.h
+++ b/src/logic/SavegameManager.h
@@ -115,6 +115,8 @@ namespace Engine
         constexpr int G1_MAX_SLOTS = 15 + 1; // 15 usual slots + current
         constexpr int G2_MAX_SLOTS = 20 + 1; // 20 usual slots + current
 
+        std::string gameSpecificSubFolderName();
+
         int maxSlots();
     }
 }

--- a/src/logic/ScriptEngine.cpp
+++ b/src/logic/ScriptEngine.cpp
@@ -40,7 +40,7 @@ bool ScriptEngine::loadDAT(const std::string& file)
     // Register externals
     const bool verbose = false;
     Logic::ScriptExternals::registerStubs(*m_pVM, verbose);
-    Logic::ScriptExternals::registerStdLib(*m_pVM, verbose);
+    Daedalus::registerGothicEngineClasses(*m_pVM, m_World.getBasicGameType());
     Logic::ScriptExternals::registerEngineExternals(m_World, m_pVM, verbose);
 
     // Register our externals

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -294,7 +294,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         VobTypes::NpcVobInformation npcvob = getNPCByInstance(npc);
         Vob::VobInformation itemvob = getItemByInstance(item);
 
-        if (not itemvob.isValid())
+        if (!itemvob.isValid())
         {
             vm.setReturn(INT32_MAX);
             return;

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -13,13 +13,6 @@
 #include <logic/visuals/ModelVisual.h>
 #include <debugdraw/debugdraw.h>
 
-void ::Logic::ScriptExternals::registerStdLib(Daedalus::DaedalusVM& vm, bool verbose)
-{
-    // don't use ZenLib externals
-    // Daedalus::registerDaedalusStdLib(vm, verbose);
-    Daedalus::registerGothicEngineClasses(vm);
-}
-
 void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& world, Daedalus::DaedalusVM* vm, bool verbose)
 {
     Engine::BaseEngine* engine = world.getEngine();

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -71,28 +71,31 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 
     auto getItemByInstance = [vm, engine](size_t instance)
     {
+        auto& parSymbol = vm->getDATFile().getSymbolByIndex(instance);
         Daedalus::GameState::ItemHandle hitem = ZMemory::handleCast<Daedalus::GameState::ItemHandle>
-                (vm->getDATFile().getSymbolByIndex(instance).instanceDataHandle);
+                (parSymbol.instanceDataHandle);
 
-        // Get data of npc this belongs to
-        Daedalus::GEngineClasses::C_Item& itemData = vm->getGameState().getItem(hitem);
-        VobTypes::ScriptInstanceUserData* userData = reinterpret_cast<VobTypes::ScriptInstanceUserData*>(itemData.userPtr);
+        if (hitem.isValid())
+        {
+            // Get data of npc this belongs to
+            Daedalus::GEngineClasses::C_Item& itemData = vm->getGameState().getItem(hitem);
+            VobTypes::ScriptInstanceUserData* userData = reinterpret_cast<VobTypes::ScriptInstanceUserData*>(itemData.userPtr);
 
-		if(userData)
-		{
-			World::WorldInstance& world = engine->getWorldInstance(userData->world);
-			Vob::VobInformation vob = Vob::asVob(world, userData->vobEntity);
+            if(userData)
+            {
+                World::WorldInstance& world = engine->getWorldInstance(userData->world);
+                Vob::VobInformation vob = Vob::asVob(world, userData->vobEntity);
 
-			return vob;
-		}
-		else{
-			LogWarn() << "No userptr on item: " << itemData.name;
-
-			Vob::VobInformation vob;
-			vob.entity.invalidate();
-
-			return vob;
-		}
+                return vob;
+            } else {
+                LogWarn() << "No userptr on item: " << itemData.name;
+            }
+        } else {
+            LogWarn() << "could not get item handle from ParSymbol: " << parSymbol.name;
+        }
+        Vob::VobInformation vob;
+        vob.entity.invalidate();
+        return vob;
     };
 
     /**
@@ -284,12 +287,18 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 
     vm->registerExternalFunction("npc_getdisttoitem", [=](Daedalus::DaedalusVM& vm){
 
-        uint32_t item = static_cast<uint32_t>(vm.popDataValue());
+        uint32_t item = vm.popVar();
         uint32_t arr_npc;
         int32_t npc = vm.popVar(arr_npc); if(verbose) LogInfo() << "npc: " << npc;
 
         VobTypes::NpcVobInformation npcvob = getNPCByInstance(npc);
         Vob::VobInformation itemvob = getItemByInstance(item);
+
+        if (not itemvob.isValid())
+        {
+            vm.setReturn(INT32_MAX);
+            return;
+        }
 
         float dist = (Vob::getTransform(npcvob).Translation() - Vob::getTransform(itemvob).Translation()).length();
 

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -686,11 +686,22 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 
         if(npc.isValid())
         {
-            vm.setReturn((int)npc.playerController->getAIStateMachine().getCurrentStateTime());
+            float time = npc.playerController->getAIStateMachine().getCurrentStateTime();
+            vm.setReturn(static_cast<int>(time));
         }else
         {
             vm.setReturn(0);
         }
+    });
+
+    vm->registerExternalFunction("npc_setstatetime", [=](Daedalus::DaedalusVM& vm) {
+        if(verbose) LogInfo() << "npc_setstatetime";
+        int seconds = vm.popDataValue(); if(verbose) LogInfo() << "seconds: " << seconds;
+        uint32_t arr_self;
+        int32_t self = vm.popVar(arr_self); if(verbose) LogInfo() << "self: " << self;
+
+        VobTypes::NpcVobInformation npc = getNPCByInstance(self);
+        npc.playerController->getAIStateMachine().setCurrentStateTime(seconds);
     });
 
     vm->registerExternalFunction("wld_detectnpc", [=](Daedalus::DaedalusVM& vm){

--- a/src/logic/scriptExternals/Externals.h
+++ b/src/logic/scriptExternals/Externals.h
@@ -19,11 +19,6 @@ namespace Logic
     namespace ScriptExternals
     {
         /**
-         * Registers the standard-library
-         */
-        void registerStdLib(Daedalus::DaedalusVM& vm, bool verbose = false);
-
-        /**
          * Registers our externals
          */
         void registerEngineExternals(World::WorldInstance& world, Daedalus::DaedalusVM* vm, bool verbose = false);

--- a/src/ui/Menu.cpp
+++ b/src/ui/Menu.cpp
@@ -145,8 +145,8 @@ void UI::Menu::initializeInstance(const std::string& instance)
             Daedalus::PARSymbol& symX =  m_pVM->getDATFile().getSymbolByName("MENU_INFO_X");
             Daedalus::PARSymbol& symY =  m_pVM->getDATFile().getSymbolByName("MENU_INFO_Y");
 
-            infoX = symX.getIntValue() / 8192.0f;
-            infoY = symY.getIntValue() / 8192.0f;
+            infoX = symX.getInt() / 8192.0f;
+            infoY = symY.getInt() / 8192.0f;
         }
         float sX = 1.0f - infoX * 2.0f;
         float sY = 1.0f - infoY;
@@ -176,7 +176,7 @@ bool UI::Menu::loadMenuDAT()
 
     // Load DAT-File...
     m_pVM = new Daedalus::DaedalusVM(datFile);
-    Daedalus::registerGothicEngineClasses(*m_pVM);
+    Daedalus::registerGothicEngineClasses(*m_pVM, Daedalus::GameType::GT_Gothic2);
 
     return true;
 }


### PR DESCRIPTION
- implemented external `Npc_SetStateTime`. In example: Vatras will now make a short pause between his preaches
- Zenlib: added and registered all missing (Gothic-2-only-)data members of engine classes (C_Classes).
- Zenlib: fixed invalid member registering for the wrong VMs (Particle, Menu, Gothic). Menu classes no longer registered in non Menu-VMs and vice versa.
- Zenlib: fixed incorrect registering of aivar array. This means script functions using the aivar array should work now. In example the Lefty-water quest can now be completed. (though Lefty still is on invalid position and must be teleported to the hero via `tp Lefty PC_HERO`). Also Vatras now tells the full story instead of the first talk over and over again. TODO: Fix: Vatras' monolog interferes with the player's dialog.
- Zenlib: unifed array accesses for registered members (float, int, string).
- Zenlib: added Log-Warning for array out of bounds check for registered data members (scalar/arrays)
- Zenlib: added pedantic log-warnings for invalid script operations in the Daedalus VM.
- fixed incorrect popping operation of item instance in `npc_getdisttoitem`
- added handle validation check in getItemByInstance

