### PR TITLE
Improved Console Suggestion ordering and selecting + navigation

### DIFF
--- a/src/engine/Input.cpp
+++ b/src/engine/Input.cpp
@@ -53,6 +53,7 @@ std::multimap<ActionType, Action> Input::actionTypeToActionMap;
 
 std::bitset<Input::NUM_KEYS> Input::keyState;
 std::bitset<Input::NUM_KEYS> Input::keyTriggered;
+std::vector<int32_t> Input::modsTriggered(Input::NUM_KEYS);
 
 std::bitset<Input::NUM_MOUSEBUTTONS> Input::mouseButtonState;
 std::bitset<Input::NUM_MOUSEBUTTONS> Input::mouseButtonTriggered;
@@ -124,10 +125,17 @@ void Input::keyEvent(int key, int scancode, int action, int mods)
     {
         keyState[key] = true;
         keyTriggered[key] = true;
+        modsTriggered[key] = mods;
+    }
+    else if (KEY_ACTION_REPEAT == action)
+    {
+        keyTriggered[key] = true;
+        modsTriggered[key] = mods;
     }
     else if(KEY_ACTION_RELEASE == action)
     {
         keyState[key] = false;
+        modsTriggered[key] = 0;
     }
 }
 
@@ -314,6 +322,7 @@ void Input::clearTriggered()
     for(int i=0;i<NUM_KEYS;i++)
     {
         keyTriggered[i] = false;
+        modsTriggered[i] = 0;
     }
 }
 

--- a/src/engine/Input.h
+++ b/src/engine/Input.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <bitset>
 #include <functional>
+#include <vector>
 #include <map>
 #include <unordered_map>
 #include <type_traits>
@@ -160,6 +161,7 @@ namespace Engine
 		static void setMouseLockCallback(std::function<void(bool /* lock */)> callback);
 
 		static const std::bitset<NUM_KEYS>& getKeysTriggered(){ return keyTriggered; }
+		static const std::vector<int32_t>& getModsTriggered(){ return modsTriggered; }
         static const std::bitset<NUM_KEYS>& getKeysState() { return keyState; }
 
 		static void clearTriggered();
@@ -174,6 +176,7 @@ namespace Engine
 
 		static std::bitset<NUM_KEYS> keyState;
 		static std::bitset<NUM_KEYS> keyTriggered;
+		static std::vector<int32_t> modsTriggered;
 
 		static std::bitset<NUM_MOUSEBUTTONS> mouseButtonState;
 		static std::bitset<NUM_MOUSEBUTTONS> mouseButtonTriggered;

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -975,32 +975,15 @@ public:
 
         std::string frameInputText = getFrameTextInput();
         for (int i = 0; i < NUM_KEYS; i++) {
-            if (getKeysTriggered()[i]) // If key has been triggered start the stopwatch
+            if (getKeysTriggered()[i]) // If key has been pushed the first time or repeatedly
             {
-                int mods = 0; // TODO lookup mods
-                m_stopWatch.start();
+                int mods = getModsTriggered()[i];
 
                 if(m_pEngine->getHud().getConsole().isOpen())
                     m_pEngine->getHud().getConsole().onKeyDown(i, mods);
                 if (keyMap.find(i) != keyMap.end())
                 {
                     m_pEngine->getHud().onInputAction(keyMap[i]);
-                }
-            }
-            else if (getKeysState()[i]) // If key is being held and stopwatch reached time limit, fire actions
-            {
-                int mods = 0; // TODO lookup mods
-                if (m_stopWatch.getTimeDiffFromStartToNow() > 400)
-                {
-                    if (m_stopWatch.DelayedByArgMS(70))
-                    {
-                        if(m_pEngine->getHud().getConsole().isOpen())
-                            m_pEngine->getHud().getConsole().onKeyDown(i, mods);
-                        if (keyMap.find(i) != keyMap.end())
-                        {
-                            m_pEngine->getHud().onInputAction(keyMap[i]);
-                        }
-                    }
                 }
             }
         }
@@ -1143,7 +1126,6 @@ public:
     int64_t m_timeOffset;
     float axis;
     int32_t m_scrollArea;
-    Utils::StopWatch m_stopWatch;
     bool m_NoHUD;
     // prevents imgui from crashing if we failed on startup and didn't init it
     bool m_ImgUiCreated = false;

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -977,10 +977,11 @@ public:
         for (int i = 0; i < NUM_KEYS; i++) {
             if (getKeysTriggered()[i]) // If key has been triggered start the stopwatch
             {
+                int mods = 0; // TODO lookup mods
                 m_stopWatch.start();
 
                 if(m_pEngine->getHud().getConsole().isOpen())
-                    m_pEngine->getHud().getConsole().onKeyDown(i);
+                    m_pEngine->getHud().getConsole().onKeyDown(i, mods);
                 if (keyMap.find(i) != keyMap.end())
                 {
                     m_pEngine->getHud().onInputAction(keyMap[i]);
@@ -988,12 +989,13 @@ public:
             }
             else if (getKeysState()[i]) // If key is being held and stopwatch reached time limit, fire actions
             {
+                int mods = 0; // TODO lookup mods
                 if (m_stopWatch.getTimeDiffFromStartToNow() > 400)
                 {
                     if (m_stopWatch.DelayedByArgMS(70))
                     {
                         if(m_pEngine->getHud().getConsole().isOpen())
-                            m_pEngine->getHud().getConsole().onKeyDown(i);
+                            m_pEngine->getHud().getConsole().onKeyDown(i, mods);
                         if (keyMap.find(i) != keyMap.end())
                         {
                             m_pEngine->getHud().onInputAction(keyMap[i]);

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -593,6 +593,7 @@ public:
         });
 
         UI::ConsoleCommand::CandidateListGenerator worlddNpcNamesGen = [this]() {
+            using Suggestion = UI::ConsoleCommand::Suggestion;
             auto& worldInstance = m_pEngine->getMainWorld().get();
             auto& scriptEngine = worldInstance.getScriptEngine();
             auto& datFile = scriptEngine.getVM().getDATFile();
@@ -613,7 +614,7 @@ public:
                     std::replace(npcName.begin(), npcName.end(), ' ', '_');
                     group.push_back(std::move(npcName));
                 }
-                UI::ConsoleCommand::Suggestion suggestion = std::make_shared<UI::NPCSuggestion>(group, npc);
+                Suggestion suggestion = std::make_shared<UI::NPCSuggestion>(group, npc);
                 suggestions.push_back(suggestion);
             }
             return suggestions;

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -18,11 +18,11 @@ namespace UI
     {
         SuggestionBase(const std::vector<std::string>& aliasList) :
                 aliasList(aliasList),
-                bestAliasMatchIndex(0)
+                anyStartsWith(false)
         {}
         virtual ~SuggestionBase() {};
         std::vector<std::string> aliasList;
-        std::size_t bestAliasMatchIndex;
+        bool anyStartsWith;
     };
 
     struct NPCSuggestion : SuggestionBase

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -66,8 +66,9 @@ namespace UI
         /**
          * To be called when a key got pressed.
          * @param glfwKey Key ID, glfw style
+         * @param mods glfw key modifier flags
          */
-        void onKeyDown(int glfwKey);
+        void onKeyDown(int glfwKey, int mods);
 
         /**
          * To be called when there was text input since the last frame
@@ -91,6 +92,11 @@ namespace UI
         void generateSuggestions(const std::string& input, bool limitToFixed);
 
         /**
+         * inserts the current selected suggestion
+         */
+        void replaceSelectedToken();
+
+        /**
          * splits line, removes empty entries, adds empty string for lookahead trigger
          */
         static std::vector<std::string> tokenized(const std::string& line);
@@ -107,6 +113,13 @@ namespace UI
          *         - "NOTFOUND", if the command was not found
          */
         std::string submitCommand(std::string command);
+
+        /**
+         * sets the typed line to the given value
+         * @param triggerSuggestions if true, the suggestion list is recalculated
+         * @param newLine new line
+         */
+        void setTypedLine(const std::string& newLine, bool triggerSuggestions = true);
 
         /**
          * Adds a message to the history

--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -13,7 +13,7 @@ UI::ConsoleBox::ConsoleBox(Engine::BaseEngine& e, UI::Console& console) :
     m_Config.height = 10;
     m_BackgroundTexture = e.getEngineTextureAlloc().loadTextureVDF("CONSOLE.TGA");
     m_SuggestionsBackgroundTexture = e.getEngineTextureAlloc().loadTextureVDF("DLG_CHOICE.TGA");
-    m_CurrentlySelected = 0;
+    m_CurrentlySelected = -1;
 }
 
 UI::ConsoleBox::~ConsoleBox()
@@ -83,10 +83,11 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
         const auto& suggestions = suggestionsList.back();
 
         // find preview range
-        m_CurrentlySelected = Math::clamp(m_CurrentlySelected, 0, static_cast<int>(suggestions.size() - 1));
-        int shownStart = m_CurrentlySelected - previewBefore;
+        m_CurrentlySelected = Math::clamp(m_CurrentlySelected, -1, static_cast<int>(suggestions.size() - 1));
+        int currentlySelectedRelative = m_CurrentlySelected == -1 ? 0 : m_CurrentlySelected;
+        int shownStart = currentlySelectedRelative - previewBefore;
         // past the end index
-        int shownEnd = m_CurrentlySelected + previewAfter + 1;
+        int shownEnd = currentlySelectedRelative + previewAfter + 1;
         if (shownStart < 0)
         {
             shownEnd += -shownStart;
@@ -99,7 +100,8 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
         }
         // clamp start index
         shownStart = std::max(shownStart, 0);
-        int currentlySelectedRelative = m_CurrentlySelected - shownStart;
+        currentlySelectedRelative -= shownStart;
+
 
         // fill columns
         std::size_t columnID = 0;
@@ -170,7 +172,8 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
         int columnOffsetX = strBeforeWidth;
         for (auto& column : columns){
             std::vector<std::string> columnsSelected(column.size());
-            std::swap(column.at(currentlySelectedRelative), columnsSelected.at(currentlySelectedRelative));
+            if (m_CurrentlySelected != -1)
+                std::swap(column.at(currentlySelectedRelative), columnsSelected.at(currentlySelectedRelative));
             auto joined = Utils::join(column.begin(), column.end(), "\n");
             drawText(joined, xDistanceToEdge + columnOffsetX, consoleSizeY + suggestionBoxSizeY, A_BottomLeft, config, font);
             auto joinedSelected = Utils::join(columnsSelected.begin(), columnsSelected.end(), "\n");


### PR DESCRIPTION
- press `TAB` to show suggestions (when none are available)
- if only one suggestion is found it is inserted directly
- Press or hold `TAB`/ `SHIFT` + `TAB` to cycle through suggestions forwards/backwards. (Page up/down, home/end keys still work)
- selecting suggestion will now always insert the value from column 1 (=Scriptname for items/npcs) instead of the best match column.
- choose selection with `ENTER`
- submit command with `ENTER` (when nothing is selected)
- changed sorting of suggestions (again). Suggestions are sorted lexicographically by scriptnames. (but candidates that start with the given string are still first)
- reworked key repeat to use the default GLFW behaviour. Added modifers (i.e. `SHIFT`). Time until key repetition and in between repetition is now smaller.