### PR TITLE
Daedalus vm debug features

### DIFF
--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -313,7 +313,7 @@ void DialogManager::startDialog(Daedalus::GameState::NpcHandle target)
     targetVob.playerController->getEM().onMessage(msg, playerVob.entity);
 
     /*m_World.getScriptEngine().prepareRunFunction();
-    m_World.getScriptEngine().runFunction(getVM().getDATFile().getSymbolByName("ZS_Talk").address);*/
+    m_World.getScriptEngine().runFunction("ZS_Talk");*/
 }
 
 void DialogManager::endDialog()

--- a/src/logic/ScriptEngine.cpp
+++ b/src/logic/ScriptEngine.cpp
@@ -60,18 +60,18 @@ void ScriptEngine::prepareRunFunction()
     m_pVM->pushState();
 }
 
-int32_t ScriptEngine::runFunction(const std::string& fname)
+int32_t ScriptEngine::runFunction(const std::string& fname, bool clearDataStack)
 {
     assert(getVM().getDATFile().hasSymbolName(fname));
-    return runFunctionBySymIndex(getVM().getDATFile().getSymbolIndexByName(fname));
+    return runFunctionBySymIndex(getVM().getDATFile().getSymbolIndexByName(fname), clearDataStack);
 }
 
-int32_t ScriptEngine::runFunctionBySymIndex(size_t symIdx)
+int32_t ScriptEngine::runFunctionBySymIndex(size_t symIdx, bool clearDataStack)
 {
 #if PROFILE_SCRIPT_CALLS
     startProfiling(symIdx);
 #endif
-    int32_t ret = m_pVM->runFunctionBySymIndex(symIdx);
+    int32_t ret = m_pVM->runFunctionBySymIndex(symIdx, clearDataStack);
 #if PROFILE_SCRIPT_CALLS
     stopProfiling(symIdx);
 #endif

--- a/src/logic/ScriptEngine.cpp
+++ b/src/logic/ScriptEngine.cpp
@@ -63,38 +63,10 @@ void ScriptEngine::prepareRunFunction()
     pushInt(0);
 }
 
-
 int32_t ScriptEngine::runFunction(const std::string& fname)
 {
-    assert(m_pVM->getDATFile().hasSymbolName(fname));
-
-    return runFunction(m_pVM->getDATFile().getSymbolByName(fname).address);
-}
-
-int32_t ScriptEngine::runFunction(size_t addr)
-{
-	if(addr == 0)
-		return -1;
-
-    // Place the call-operation
-    m_pVM->doCallOperation(addr);
-
-    m_pVM->clearCallStack();
-
-    // Execute the instructions
-    while(m_pVM->doStack());
-
-    int32_t ret = 0;
-
-    // Only pop if the VM didn't mess up
-    if(!m_pVM->isStackEmpty())
-        ret = m_pVM->popDataValue();
-    else
-        LogWarn() << "DaedalusVM: Safety int was popped by scriptcode!";
-
-    // Restore to previous VM-State
-    m_pVM->popState();
-    return ret;
+    assert(getVM().getDATFile().hasSymbolName(fname));
+    return runFunctionBySymIndex(getVM().getDATFile().getSymbolIndexByName(fname));
 }
 
 int32_t ScriptEngine::runFunctionBySymIndex(size_t symIdx)
@@ -102,17 +74,12 @@ int32_t ScriptEngine::runFunctionBySymIndex(size_t symIdx)
 #if PROFILE_SCRIPT_CALLS
     startProfiling(symIdx);
 #endif
-
-    int32_t r = runFunction(getVM().getDATFile().getSymbolByIndex(symIdx).address);
-
+    int32_t ret = m_pVM->runFunctionBySymIndex(symIdx);
 #if PROFILE_SCRIPT_CALLS
     stopProfiling(symIdx);
 #endif
-
-    return r;
+    return ret;
 }
-
-
 
 void ScriptEngine::pushInt(int32_t v)
 {

--- a/src/logic/ScriptEngine.cpp
+++ b/src/logic/ScriptEngine.cpp
@@ -58,9 +58,6 @@ void ScriptEngine::prepareRunFunction()
 {
     // Clean the VM for this run
     m_pVM->pushState();
-
-    // Init stack with a value of 0. Some functions do not return, and thus, a default must be given.
-    pushInt(0);
 }
 
 int32_t ScriptEngine::runFunction(const std::string& fname)

--- a/src/logic/ScriptEngine.h
+++ b/src/logic/ScriptEngine.h
@@ -81,10 +81,11 @@ namespace Logic
          * Runs a complete function with the arguments given by pushing onto the stack
          * Note: Must be prepared first, using prepareRunFunction.
          * @param fname Symbol-name of the function to look up and call
+         * @param clearDataStack indicates whether the datastack should be cleared before running
          * @return value returned by the function
          */
-        int32_t runFunction(const std::string& fname);
-        int32_t runFunctionBySymIndex(size_t symIdx);
+        int32_t runFunction(const std::string& fname, bool clearDataStack = true);
+        int32_t runFunctionBySymIndex(size_t symIdx, bool clearDataStack = true);
 
         /**
          * Returns the current script-gamestate

--- a/src/logic/ScriptEngine.h
+++ b/src/logic/ScriptEngine.h
@@ -84,7 +84,6 @@ namespace Logic
          * @return value returned by the function
          */
         int32_t runFunction(const std::string& fname);
-        int32_t runFunction(size_t addr);
         int32_t runFunctionBySymIndex(size_t symIdx);
 
         /**

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -809,8 +809,6 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 
             npc.playerController->getEM().onMessage(sm);
         }
-
-        vm.setReturn(0);
     });
 
     vm->registerExternalFunction("ai_playani", [=](Daedalus::DaedalusVM& vm){

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -36,12 +36,10 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         if(!hnpc.isValid())
         {
             LogWarn() << "Invalid handle in instance: " << instance << " (" << vm->getDATFile().getSymbolByIndex(instance).name << ")";
+            LogWarn() << "Callstack: " << vm->getCallStack();
 
             VobTypes::NpcVobInformation vob;
             vob.entity.invalidate();
-
-            LogInfo() << "Callstack: " << vm->getCallStack();
-
             return vob;
         }
 
@@ -933,20 +931,20 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
     vm->registerExternalFunction("info_addchoice", [=](Daedalus::DaedalusVM& vm){
         uint32_t func = vm.popVar();
         std::string text = vm.popString();
-        uint32_t info = vm.popVar();
+        uint32_t infoInstance = vm.popDataValue();
 
         Daedalus::GameState::InfoHandle hInfo = ZMemory::handleCast<Daedalus::GameState::InfoHandle>(
-                pWorld->getScriptEngine().getVM().getDATFile().getSymbolByIndex(info).instanceDataHandle);
+                pWorld->getScriptEngine().getVM().getDATFile().getSymbolByIndex(infoInstance).instanceDataHandle);
 
         auto& cInfo = vm.getGameState().getInfo(hInfo);
         cInfo.addChoice(Daedalus::GEngineClasses::SubChoice{text, func});
     });
 
     vm->registerExternalFunction("info_clearchoices", [=](Daedalus::DaedalusVM& vm){
-        uint32_t info = vm.popVar();
+        uint32_t infoInstance = vm.popDataValue();
 
         Daedalus::GameState::InfoHandle hInfo = ZMemory::handleCast<Daedalus::GameState::InfoHandle>(
-                vm.getDATFile().getSymbolByIndex(info).instanceDataHandle);
+                vm.getDATFile().getSymbolByIndex(infoInstance).instanceDataHandle);
 
         auto& cInfo = vm.getGameState().getInfo(hInfo);
         cInfo.subChoices.clear();

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -833,8 +833,6 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
                 npc.playerController->getEM().onMessage(sm);
             }
         }
-
-        vm.setReturn(0);
     });
 
     vm->registerExternalFunction("mdl_applyoverlaymds", [=](Daedalus::DaedalusVM& vm){
@@ -847,8 +845,6 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         {
             npc.playerController->getModelVisual()->applyOverlay(overlayname);
         }
-
-        vm.setReturn(0);
     });
 
     vm->registerExternalFunction("mdl_removeoverlaymds", [=](Daedalus::DaedalusVM& vm){
@@ -862,8 +858,6 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
             // TODO: Implement using of multiple overlays!
             npc.playerController->getModelVisual()->applyOverlay("");
         }
-
-        vm.setReturn(0);
     });
 
     vm->registerExternalFunction("wld_isfpavailable", [=](Daedalus::DaedalusVM& vm){

--- a/src/logic/scriptExternals/Stubs.cpp
+++ b/src/logic/scriptExternals/Stubs.cpp
@@ -111,7 +111,9 @@ void ::Logic::ScriptExternals::registerStubs(Daedalus::DaedalusVM& vm, bool verb
         std::string schemename = vm.popString(); if(verbose) LogInfo() << "schemename: " << schemename;
         uint32_t arr_self;
         int32_t self = vm.popVar(arr_self); if(verbose) LogInfo() << "self: " << self;
-        vm.setReturn(0);
+        // this function is actually declared as int, but the return value is never used in the original scripts
+        // and the Gothic compiler doesn't pop unused expressions
+        // vm.setReturn(0);
     });
 
     vm.registerExternalFunction("doc_create", [=](Daedalus::DaedalusVM& vm) {
@@ -722,13 +724,9 @@ void ::Logic::ScriptExternals::registerStubs(Daedalus::DaedalusVM& vm, bool verb
     vm.registerExternalFunction("playvideo", [=](Daedalus::DaedalusVM& vm) {
         if(verbose) LogInfo() << "playvideo";
         std::string filename = vm.popString(); if(verbose) LogInfo() << "filename: " << filename;
-        vm.setReturn(0);
-    });
-
-    vm.registerExternalFunction("playvideo", [=](Daedalus::DaedalusVM& vm) {
-        if(verbose) LogInfo() << "playvideo";
-        std::string s0 = vm.popString(); if(verbose) LogInfo() << "s0: " << s0;
-        vm.setReturn(0);
+        // this function is actually declared as int, but the return value is never used in the original scripts
+        // and the Gothic compiler doesn't pop unused expressions
+        // vm.setReturn(0);
     });
 
     vm.registerExternalFunction("playvideoex", [=](Daedalus::DaedalusVM& vm) {
@@ -736,7 +734,9 @@ void ::Logic::ScriptExternals::registerStubs(Daedalus::DaedalusVM& vm, bool verb
         int exitsession = vm.popDataValue(); if(verbose) LogInfo() << "exitsession: " << exitsession;
         int screenblend = vm.popDataValue(); if(verbose) LogInfo() << "screenblend: " << screenblend;
         std::string filename = vm.popString(); if(verbose) LogInfo() << "filename: " << filename;
-        vm.setReturn(0);
+        // this function is actually declared as int, but the return value is never used in the original scripts
+        // and the Gothic compiler doesn't pop unused expressions
+        // vm.setReturn(0);
     });
 
     vm.registerExternalFunction("printdialog", [=](Daedalus::DaedalusVM& vm) {

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -642,7 +642,7 @@ public:
             int exp = std::stoi(args[1]);
             s1.prepareRunFunction();
             s1.pushInt(exp);
-            s1.runFunction(scriptName);
+            s1.runFunction(scriptName, false);
 
             return "Experience points successfully given";
         });


### PR DESCRIPTION
- printing the VM's callstack now actually works (script functions, externals, arbitrary depth)
- fixed many superfluous pushes to the data stack (`pushint(0)`), since the VM already pops 0 by default
- script function calls from engine (outermost call): VM now only pop's a value if the function has a return flag (specifed in DAT-file).
- VM now complains about missing return values on the stack (i.e. happens on many  dialog conditions: DIA_..._CONDITION)
- fixed some externals that messed up the stack.
- VM's stack gets cleared before engine calls a script function (outermost call)