### PR TITLE
Switch world & Control any NPC & fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,16 +103,18 @@ Additionally, for a list of possible commands, run `REGoth --help`.
  * Actions: Left CTRL for everything
  * Menus: B for status-screen
  * Console: F10
-   * Available commands:
-      * `kill`: Kill a nearby NPC
-      * `knockout`: Knockout a nearby NPC
-      * `save <name>`: Save the game
-      * `load <name>`: Load a game
+   * Available commands (square brackets mean optional argument):
+      * `tp [<teleporter:default=player>] <target>`: Teleport NPC `teleporter` (= player if none is given) to NPC `target`
+      * `goto waypoint <waypoint>`: Teleport player to `waypoint`
+      * `kill [<npc>]`: Kill `npc` or a nearby NPC if none is given
+      * `knockout [<npc>]`: Knockout `npc` or a nearby NPC if none is given
+      * `save <slotindex>`: Save the game to the given slot
+      * `load <slotindex>`: Load the game from the given slot
       * `switchlevel <zenfile>`: Switch to an other level in current session
       * `usemana <amount>`: Use mana
       * `hurtself <amount>`: Hurt yourself
-      * `timeset <x>`: Set time to 12:00. `x` doesn't matter but must be a number.
-      * `list`: Print a list of available commands
+      * `set clock <hour> [<min:default=0>]`: Set time of day to `hour`:`min`
+      * `control <npc>`: Take control over `npc`
       
 # Development
 
@@ -125,7 +127,9 @@ If you want to help out and don't know where to start, I suggest reading the [wi
 
 **Gothic 1 - Freemine:** `REGoth -g "path/to/gothic1" -w freemine.zen`
 
-**Gothic 1 - Sleeper temple:** `REGoth -g "path/to/gothic1" -w orctemple.zen`
+**Gothic 1 - Orc graveyard:** `REGoth -g "path/to/gothic1" -w orcgraveyard.zen`
+
+**Gothic 1 - Sleeper temple:** `REGoth -g "path/to/gothic1" -w orctempel.zen`
 
 **Gothic 2 - Overworld:** `REGoth -g "path/to/gothic2" -w newworld.zen`
 

--- a/src/audio/AudioWorld.cpp
+++ b/src/audio/AudioWorld.cpp
@@ -170,7 +170,7 @@ namespace World
 
         // TODO: pitch?
         //alSourcef(source, AL_PITCH, snd.sfx.);
-        alSourcef(s.m_Handle, AL_PITCH, m_Engine.getGameEngineSpeedFactor());
+        alSourcef(s.m_Handle, AL_PITCH, m_Engine.getGameClock().getGameEngineSpeedFactor());
         alSourcef(s.m_Handle, AL_GAIN, snd.sfx.vol / 127.0f);
         alSource3f(s.m_Handle, AL_POSITION, 0, 0, 0);
         alSource3f(s.m_Handle, AL_VELOCITY, 0, 0, 0);

--- a/src/audio/AudioWorld.cpp
+++ b/src/audio/AudioWorld.cpp
@@ -316,7 +316,7 @@ namespace World
         }
 
         m_VM = new Daedalus::DaedalusVM(datFile);
-        Daedalus::registerGothicEngineClasses(*m_VM, m_Engine.getMainWorld().get().getBasicGameType());
+        Daedalus::registerGothicEngineClasses(*m_VM);
 
         size_t count = 0;
         m_VM->getDATFile().iterateSymbolsOfClass("C_SFX", [&](size_t i, Daedalus::PARSymbol& s){

--- a/src/components/VobClasses.cpp
+++ b/src/components/VobClasses.cpp
@@ -354,6 +354,14 @@ Handle::EntityHandle VobTypes::MOB_GetByName(World::WorldInstance& world, const 
     return Handle::EntityHandle::makeInvalidHandle();
 }
 
+void VobTypes::Wld_RemoveNpc(World::WorldInstance &world, Handle::EntityHandle npc) {
+    world.getScriptEngine().unregisterNpc(npc);
+    VobTypes::NpcVobInformation vob = VobTypes::asNpcVob(world, npc);
+    world.getScriptEngine().getGameState().removeNPC(vob.playerController->getScriptHandle());
+    // finally remove entity from game
+    world.removeEntity(npc);
+}
+
 
 
 

--- a/src/components/VobClasses.cpp
+++ b/src/components/VobClasses.cpp
@@ -355,10 +355,20 @@ Handle::EntityHandle VobTypes::MOB_GetByName(World::WorldInstance& world, const 
 }
 
 void VobTypes::Wld_RemoveNpc(World::WorldInstance &world, Handle::EntityHandle npc) {
-    world.getScriptEngine().unregisterNpc(npc);
     VobTypes::NpcVobInformation vob = VobTypes::asNpcVob(world, npc);
+
+    // if npc is the current controlled entity clear up bindings, "hero" and invalidate player entity
+    if(npc == world.getScriptEngine().getPlayerEntity())
+    {
+        // clear key bindings
+        Engine::Input::clearActions();
+        world.getScriptEngine().setPlayerEntity(Handle::EntityHandle::makeInvalidHandle());
+        auto invalidHandle = Daedalus::GameState::NpcHandle();
+        world.getScriptEngine().setInstanceNPC("hero", invalidHandle);
+    }
+
+    world.getScriptEngine().unregisterNpc(npc);
     world.getScriptEngine().getGameState().removeNPC(vob.playerController->getScriptHandle());
-    // finally remove entity from game
     world.removeEntity(npc);
 }
 

--- a/src/components/VobClasses.h
+++ b/src/components/VobClasses.h
@@ -84,7 +84,7 @@ namespace VobTypes
 
     /**
      * removes npc from the given world, also removes from script engine.
-     * if the script name of npc is PC_HERO, key bindings get cleared and the script engine's player entity gets invalidated
+     * if the npc is the player entity, key bindings get cleared and script engine's player entity gets invalidated
      */
     void Wld_RemoveNpc(World::WorldInstance& world, Handle::EntityHandle npc);
 

--- a/src/components/VobClasses.h
+++ b/src/components/VobClasses.h
@@ -83,6 +83,12 @@ namespace VobTypes
     Handle::EntityHandle Wld_InsertNpc(World::WorldInstance& world, size_t instanceSymbol, const std::string& wpName = "");
 
     /**
+     * removes npc from the given world, also removes from script engine.
+     * if the script name of npc is PC_HERO, key bindings get cleared and the script engine's player entity gets invalidated
+     */
+    void Wld_RemoveNpc(World::WorldInstance& world, Handle::EntityHandle npc);
+
+    /**
      * Unlinks the script-instance from the engine. If this is not done, it will result in a memory-leak.
      */
     void unlinkNPCFromScriptInstance(World::WorldInstance& world, Handle::EntityHandle entity, Daedalus::GameState::NpcHandle scriptInstance);

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -333,9 +333,11 @@ void BaseEngine::processSaveGameActionQueue() {
                     if (!startpoints.empty())
                     {
                         auto playerVob = VobTypes::asNpcVob(newWorld.get(), playerNew);
-                        playerVob.playerController->teleportToWaypoint(startpoints.front());
                         std::string startpoint = newWorld.get().getWaynet().waypoints[startpoints.front()].name;
                         LogInfo() << "Teleporting player to startpoint '" << startpoint << "'";
+                        playerVob.playerController->teleportToWaypoint(startpoints.front());
+                        // FIXME seems like player start-points are inverted?
+                        playerVob.playerController->setDirection(-1 * playerVob.playerController->getDirection());
                     }
                 }
                 break;

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -321,12 +321,12 @@ void BaseEngine::processSaveGameActionQueue() {
                 break;
             case SavegameManager::SwitchLevel:
                 {
-                    auto& oldWorld = getMainWorld().get();
-                    auto exportedPlayer = oldWorld.exportAndRemoveNPC(oldWorld.getScriptEngine().getPlayerEntity());
+                    auto exportedPlayer = getMainWorld().get().exportAndRemoveNPC(
+                            getMainWorld().get().getScriptEngine().getPlayerEntity());
                     removeWorld(getMainWorld());
                     auto newWorld = addWorld(action.savegameName);
                     setMainWorld(newWorld);
-                    auto playerNew = newWorld.get().importSingleVob(exportedPlayer);
+                    auto playerNew = newWorld.get().importVobAndTakeControl(exportedPlayer);
                     // TODO find out start position after level change
                     // TODO move this code out of the BaseEngine
                     std::vector<size_t> startpoints = newWorld.get().findStartPoints();

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -32,6 +32,7 @@ namespace Flags
     Cli::Flag modFile("m", "mod-file", 1, "Additional .mod-file to load", {""}, "Data");
     Cli::Flag world("w", "world", 1, ".ZEN-file to load out of one of the vdf-archives", {""}, "Data");
     Cli::Flag emptyWorld("", "empty-world", 0, "Will load no .ZEN-file at all.");
+    Cli::Flag playerScriptname("p", "player", 1, "When starting a new game the player will play as the given NPC", {"PC_HERO"});
     Cli::Flag sndDevice("snd", "sound-device", 1, "OpenAL sound device", {""}, "Sound");
 }
 
@@ -99,6 +100,9 @@ void BaseEngine::initEngine(int argc, char** argv)
 
     if(Flags::emptyWorld.isSet())
         m_Args.startupZEN = "";
+
+    if(Flags::playerScriptname.isSet())
+        m_Args.playerScriptname = Flags::playerScriptname.getParam(0);
 
     std::string snd_device;
     if(Flags::sndDevice.isSet())

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -246,7 +246,7 @@ void BaseEngine::processSaveGameActionQueue()
                 if (!getMainWorld().get().getDialogManager().isDialogActive())
                 {
                     // only save while not in Dialog
-                    getSession().saveToSlot(action.slot, action.savegameName);
+                    SavegameManager::saveToSlot(action.slot, action.savegameName);
                 }
                 break;
             case SavegameManager::Load:

--- a/src/engine/BaseEngine.h
+++ b/src/engine/BaseEngine.h
@@ -98,7 +98,7 @@ namespace Engine
         /**
          * @return Console
          */
-        UI::Console& getConsole() { return m_Console; }
+        Logic::Console& getConsole() { return m_Console; }
 
         /**
          * @return Arguments passed to the engine
@@ -218,9 +218,9 @@ namespace Engine
 		std::unique_ptr<GameSession> m_Session;
 
         /**
-         * ingame clock
+         * ingame console
          */
-        UI::Console m_Console;
+        Logic::Console m_Console;
 
         /**
          * Arguments

--- a/src/engine/BaseEngine.h
+++ b/src/engine/BaseEngine.h
@@ -36,7 +36,8 @@ namespace Engine
 			EngineArgs() : cmdline(0, NULL) {}
 
             std::string gameBaseDirectory;
-            std::string startupZEN;
+			std::string startupZEN;
+			std::string playerScriptname;
 			std::string testVisual;
 			std::string modfile;
 			bx::CommandLine cmdline;

--- a/src/engine/BaseEngine.h
+++ b/src/engine/BaseEngine.h
@@ -87,10 +87,14 @@ namespace Engine
 		World::WorldInstance& getWorldInstance(Handle::WorldHandle& h);
 
         /**
-         *
-         * @return gameclock
+         * @return Gameclock
          */
         GameClock& getGameClock() { return m_GameClock; }
+
+        /**
+         * @return Console
+         */
+        UI::Console& getConsole() { return m_Console; }
 
         /**
          * @return Arguments passed to the engine
@@ -108,7 +112,7 @@ namespace Engine
 		 */
 		UI::Hud& getHud(){ return *m_pHUD; }
 
-                UI::zFontCache& getFontCache(){ return *m_pFontCache; }
+        UI::zFontCache& getFontCache(){ return *m_pFontCache; }
 
         Audio::AudioEngine &getAudioEngine() { return *m_AudioEngine; }
 
@@ -237,10 +241,15 @@ namespace Engine
 		 */
 		std::vector<Handle::WorldHandle> m_Worlds;
 
-		/**
-		 * ingame clock
-		 */
+        /**
+         * ingame clock
+         */
         GameClock m_GameClock;
+
+        /**
+         * ingame clock
+         */
+        UI::Console m_Console;
 
         /**
          * Arguments

--- a/src/engine/BaseEngine.h
+++ b/src/engine/BaseEngine.h
@@ -4,6 +4,7 @@
 #include <vdfs/fileIndex.h>
 #include <ui/View.h>
 #include <bx/commandline.h>
+#include <logic/SavegameManager.h>
 #include "GameClock.h"
 
 namespace UI
@@ -179,12 +180,23 @@ namespace Engine
 		 */
 		void togglePaused() { setPaused(!m_Paused); }
 
-		void addToExludedFrameTime(int64_t elapsed) { m_ExcludedFrameTime += elapsed; };
+		/**
+		 * increase the time, which the current frame should not treat as elapsed
+		 */
+		void addToExludedFrameTime(int64_t milliseconds) { m_ExcludedFrameTime += milliseconds; };
+
 		int64_t getExludedFrameTime() { return m_ExcludedFrameTime; };
 		void resetExludedFrameTime() { m_ExcludedFrameTime = 0; };
 
-        void setQuickload(bool active) { m_Quickload = active; }
-        bool getQuickload() { return m_Quickload; }
+		/**
+		 * Insert the given action at the end of the queue
+		 */
+		void queueSaveGameAction(SavegameManager::SaveGameAction saveGameAction);
+
+		/**
+		 * process all queued actions by FIFO
+		 */
+		void processSaveGameActionQueue();
 
 	protected:
 
@@ -265,10 +277,9 @@ namespace Engine
 		bool m_Paused;
 
         /**
-         * Flag indicating whether the engine should load the quicksave slot after frame drawing.
-         * This flag is introduced to guarantee a specific execution point (not when the binding fires)
+         * save/load action queue
          */
-		bool m_Quickload;
+		std::queue<Engine::SavegameManager::SaveGameAction> m_SaveGameActionQueue;
 
         /**
          * amount of time for the next frame that should not be considered as elapsed

--- a/src/engine/GameClock.cpp
+++ b/src/engine/GameClock.cpp
@@ -9,6 +9,7 @@ GameClock::GameClock()
 {
     m_ClockSpeedFactor = 1.0;
     m_totalTimeInDays = 0;
+    m_LastFrameDeltaTime = 0;
 
     // day/clock init only necessary for test start world (not started via main menu)
     resetNewGame();
@@ -25,6 +26,7 @@ void GameClock::setDay(int newDay) {
 
 void GameClock::update(double deltaRealTimeSeconds)
 {
+    m_LastFrameDeltaTime = deltaRealTimeSeconds;
     m_totalTimeInDays += totalSpeedUp() * deltaRealTimeSeconds / SECONDS_IN_A_DAY;
 }
 
@@ -93,4 +95,8 @@ void GameClock::resetNewGame() {
     m_totalTimeInDays = 0;
     setDay(0);
     setTimeOfDay(8, 0);
+}
+
+double GameClock::getLastDt() {
+    return m_LastFrameDeltaTime;
 }

--- a/src/engine/GameClock.cpp
+++ b/src/engine/GameClock.cpp
@@ -7,11 +7,16 @@ using namespace Engine;
 
 GameClock::GameClock()
 {
-    m_ClockSpeedFactor = 1.0;
     m_totalTimeInDays = 0;
     m_LastFrameDeltaTime = 0;
 
-    // day/clock init only necessary for test start world (not started via main menu)
+    // reset clock speed and game speed to default value on new session
+    m_ClockSpeedFactor = 1.0;
+    m_GameEngineSpeedFactor = 1.0;
+
+    // for test purpose make the clock run 7 times faster than usual gameplay
+    // setClockSpeedFactor(7.0);
+
     resetNewGame();
 }
 

--- a/src/engine/GameClock.h
+++ b/src/engine/GameClock.h
@@ -13,6 +13,11 @@ namespace Engine
         GameClock();
 
         /**
+         * @return the delta time of the last frame update
+         */
+        double getLastDt();
+
+        /**
          * sets the clock to the default settings of a new game
          */
         void resetNewGame();
@@ -117,5 +122,8 @@ namespace Engine
 
         // define an extra speedup for the ingame clock
         float m_ClockSpeedFactor;
+
+        // last known delta t
+        double m_LastFrameDeltaTime;
     };
 }

--- a/src/engine/GameClock.h
+++ b/src/engine/GameClock.h
@@ -111,6 +111,25 @@ namespace Engine
          */
         static void dayTimeTohm(double timeOfDay, int& hours, int& minutes);
 
+        /**
+         * additional factor for deltaTime when updating world instances. Speeds up everything
+         * i.e. world (ergo animations), in game clock (ergo sky) even the camera
+         * only for fun / debug purpose (default = 1.0)
+         * @param factor
+         */
+        void setGameEngineSpeedFactor(float factor)
+        {
+            m_GameEngineSpeedFactor = factor;
+        }
+
+        /**
+         * @return m_GameEngineSpeedFactor
+         */
+        float getGameEngineSpeedFactor() const
+        {
+            return m_GameEngineSpeedFactor;
+        }
+
         static constexpr unsigned int SECONDS_IN_A_DAY = 24 * 60 * 60;
 
         // Defines how much faster the ingame clock runs compared to the real time clock. Don't change this value
@@ -125,5 +144,8 @@ namespace Engine
 
         // last known delta t
         double m_LastFrameDeltaTime;
+
+        // Global speed factor for the engine
+        float m_GameEngineSpeedFactor;
     };
 }

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -97,7 +97,8 @@ void GameEngine::drawFrame(uint16_t width, uint16_t height)
     if (NULL != hmd && 0 != (hmd->flags & BGFX_HMD_RENDERING))
     {
         float view[16];
-        bx::mtxQuatTranslationHMD(view, hmd->eye[0].rotation, getMainWorld().get().getCameraComp<Components::PositionComponent>().m_WorldMatrix.Translation().v);
+        if (getMainWorld().isValid())
+            bx::mtxQuatTranslationHMD(view, hmd->eye[0].rotation, getMainWorld().get().getCameraComp<Components::PositionComponent>().m_WorldMatrix.Translation().v);
         bgfx::setViewTransform(0, view, hmd->eye[0].projection, BGFX_VIEW_STEREO, hmd->eye[1].projection);
 
         // Set view 0 default viewport.
@@ -128,7 +129,6 @@ void GameEngine::drawFrame(uint16_t width, uint16_t height)
         m_DefaultRenderSystem.getConfig().state.viewWidth = width;
         m_DefaultRenderSystem.getConfig().state.viewHeight = height;
     }
-
 
 
     bgfx::touch(0);

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -68,19 +68,18 @@ void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
     {
         if(m_Paused)
         {
-            getMainCamera<Components::LogicComponent>().m_pLogicController->onUpdate(dt);
+            getMainWorld().get().getCameraController()->onUpdate(dt);
         } else
         {
             m_GameClock.update(dt);
             for (auto& s : m_WorldInstances)
             {
                 // Update main-world after every other world, since the camera is in there
-                s.onFrameUpdate(dt, DRAW_DISTANCE * DRAW_DISTANCE,
-                                getMainCamera<Components::PositionComponent>().m_WorldMatrix);
+                s->onFrameUpdate(dt, DRAW_DISTANCE * DRAW_DISTANCE, s->getCameraComp<Components::PositionComponent>().m_WorldMatrix);
             }
 
             // Finally, update main camera
-            getMainCameraController()->onUpdateExplicit(dt);
+            getMainWorld().get().getCameraController()->onUpdateExplicit(dt);
         }
     }
     drawFrame(width, height);
@@ -88,7 +87,9 @@ void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
 
 void GameEngine::drawFrame(uint16_t width, uint16_t height)
 {
-    Math::Matrix view = Components::Actions::Position::makeViewMatrixFrom(getMainWorld().get().getComponentAllocator(), m_MainCamera);
+    Math::Matrix view;
+    if (getMainWorld().isValid())
+        view = Components::Actions::Position::makeViewMatrixFrom(getMainWorld().get().getComponentAllocator(), getMainWorld().get().getCamera());
 
     // Set view and projection matrix for view 0.
     float farPlane = 1000.0f;
@@ -96,7 +97,7 @@ void GameEngine::drawFrame(uint16_t width, uint16_t height)
     if (NULL != hmd && 0 != (hmd->flags & BGFX_HMD_RENDERING))
     {
         float view[16];
-        bx::mtxQuatTranslationHMD(view, hmd->eye[0].rotation, getMainCamera<Components::PositionComponent>().m_WorldMatrix.Translation().v);
+        bx::mtxQuatTranslationHMD(view, hmd->eye[0].rotation, getMainWorld().get().getCameraComp<Components::PositionComponent>().m_WorldMatrix.Translation().v);
         bgfx::setViewTransform(0, view, hmd->eye[0].projection, BGFX_VIEW_STEREO, hmd->eye[1].projection);
 
         // Set view 0 default viewport.
@@ -120,7 +121,8 @@ void GameEngine::drawFrame(uint16_t width, uint16_t height)
         }
 
         // Update the frame-config with the cameras world-matrix
-        m_DefaultRenderSystem.getConfig().state.cameraWorld = getMainCamera<Components::PositionComponent>().m_WorldMatrix;
+        if (getMainWorld().isValid())
+            m_DefaultRenderSystem.getConfig().state.cameraWorld = getMainWorld().get().getCameraComp<Components::PositionComponent>().m_WorldMatrix;
         m_DefaultRenderSystem.getConfig().state.drawDistanceSquared = DRAW_DISTANCE * DRAW_DISTANCE; // TODO: Config for these kind of variables
         m_DefaultRenderSystem.getConfig().state.farPlane = farPlane;
         m_DefaultRenderSystem.getConfig().state.viewWidth = width;
@@ -131,9 +133,9 @@ void GameEngine::drawFrame(uint16_t width, uint16_t height)
 
     bgfx::touch(0);
 
-    // Draw all worlds
-    for(auto& s : m_WorldInstances)
-        Render::drawWorld(s, m_DefaultRenderSystem.getConfig(), m_DefaultRenderSystem);
+    // Draw only main world
+    if (getMainWorld().isValid())
+        Render::drawWorld(getMainWorld().get(), m_DefaultRenderSystem.getConfig(), m_DefaultRenderSystem);
 
     //bgfx::frame();
 }
@@ -142,49 +144,15 @@ void GameEngine::onWorldCreated(Handle::WorldHandle world)
 {
     BaseEngine::onWorldCreated(world);
 
-    // Needed for camera-creation
-    setMainWorld(world);
-
     if(world.isValid())
-        m_MainCamera = createMainCameraIn(m_MainWorld);
+    {
+        world.get().createCamera();
+    }
 }
 
 void GameEngine::onWorldRemoved(Handle::WorldHandle world)
 {
     BaseEngine::onWorldRemoved(world);
-
-    setMainWorld(Handle::WorldHandle::makeInvalidHandle());
 }
-
-Handle::EntityHandle GameEngine::createMainCameraIn(Handle::WorldHandle world)
-{
-    World::WorldInstance& winst = world.get();
-    // Add player-camera
-    m_MainCamera = winst.addEntity(Components::PositionComponent::MASK);
-
-	Math::Matrix lookAt = Math::Matrix::CreateLookAt(Math::float3(0,0,0), Math::float3(1,0,0), Math::float3(0,1,0));
-    getMainCamera<Components::PositionComponent>().m_WorldMatrix
-            = lookAt.Invert();
-
-	getMainCamera<Components::PositionComponent>().m_WorldMatrix.Translation(Math::float3(0.0f, 50.0f, 50.0f));
-
-    Components::LogicComponent& logic = Components::Actions::initComponent<Components::LogicComponent>(
-            winst.getComponentAllocator(),
-            m_MainCamera);
-
-    Logic::CameraController* cam = new Logic::CameraController(winst, m_MainCamera);
-    logic.m_pLogicController = cam;
-
-    cam->setCameraMode(Logic::CameraController::ECameraMode::FirstPerson);
-    //cam->getCameraSettings().freeCameraSettings.moveSpeed = 5.0f;
-    //cam->getCameraSettings().freeCameraSettings.turnSpeed = 3.5f;
-
-	return m_MainCamera;
-}
-
-
-
-
-
 
 

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -64,15 +64,15 @@ void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
 
 //        lastLogicDisableKeyState = inputGetKeyState(entry::Key::Key2);
 //    }
-    if (!m_WorldInstances.empty())
+    if (!getSession().getWorldInstances().empty())
     {
         if(m_Paused)
         {
             getMainWorld().get().getCameraController()->onUpdate(dt);
         } else
         {
-            m_GameClock.update(dt);
-            for (auto& s : m_WorldInstances)
+            getGameClock().update(dt);
+            for (auto& s : getSession().getWorldInstances())
             {
                 // Update main-world after every other world, since the camera is in there
                 s->onFrameUpdate(dt, DRAW_DISTANCE * DRAW_DISTANCE, s->getCameraComp<Components::PositionComponent>().m_WorldMatrix);

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -64,23 +64,25 @@ void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
 
 //        lastLogicDisableKeyState = inputGetKeyState(entry::Key::Key2);
 //    }
-
-    if(m_Paused)
+    if (!m_WorldInstances.empty())
     {
-        getMainCamera<Components::LogicComponent>().m_pLogicController->onUpdate(dt);
-    } else
-    {
-        for (auto& s : m_WorldInstances)
+        if(m_Paused)
         {
-            // Update main-world after every other world, since the camera is in there
-            s.onFrameUpdate(dt, DRAW_DISTANCE * DRAW_DISTANCE,
+            getMainCamera<Components::LogicComponent>().m_pLogicController->onUpdate(dt);
+        } else
+        {
+            m_GameClock.update(dt);
+            for (auto& s : m_WorldInstances)
+            {
+                // Update main-world after every other world, since the camera is in there
+                s.onFrameUpdate(dt, DRAW_DISTANCE * DRAW_DISTANCE,
                                 getMainCamera<Components::PositionComponent>().m_WorldMatrix);
+            }
+
+            // Finally, update main camera
+            getMainCameraController()->onUpdateExplicit(dt);
         }
-
-        // Finally, update main camera
-        getMainCameraController()->onUpdateExplicit(dt);
     }
-
     drawFrame(width, height);
 }
 

--- a/src/engine/GameEngine.h
+++ b/src/engine/GameEngine.h
@@ -18,29 +18,6 @@ namespace Engine
         virtual void initEngine(int argc, char** argv) override;
 
         /**
-         * @brief Adds the main camera to the given world. If there already exists a main camera, it will be overwritten.
-         */
-        Handle::EntityHandle createMainCameraIn(Handle::WorldHandle world);
-
-        /**
-         * @return The given component of the main camera
-         */
-        template<typename T>
-        T& getMainCamera()
-        {
-            return m_MainWorld.get().getComponentAllocator().getElement<T>(m_MainCamera);
-        }
-
-        /**
-         * @return Camera-Controller of the current main camera
-         */
-        Logic::CameraController* getMainCameraController()
-        {
-            return reinterpret_cast<Logic::CameraController*>(
-                    getMainCamera<Components::LogicComponent>().m_pLogicController);
-        }
-
-        /**
          * @return Default set of shaders and constants
          */
         Render::RenderSystem& getDefaultRenderSystem()
@@ -64,11 +41,6 @@ namespace Engine
          * Draws the worlds and presents the frame
          */
         void drawFrame(uint16_t width, uint16_t height);
-
-        /**
-         * Players camera entity
-         */
-        Handle::EntityHandle m_MainCamera;
 
         /**
          * Default rendering system

--- a/src/engine/GameSession.cpp
+++ b/src/engine/GameSession.cpp
@@ -187,10 +187,13 @@ Handle::WorldHandle GameSession::switchToWorld(const std::string &worldFile) {
         newWorldJson = retrieveInactiveWorld(worldFile);
     } else
     {
-        // try read from disk
-        std::string worldFromDisk = SavegameManager::readWorld(m_CurrentSlotIndex, Utils::stripExtension(worldFile));
-        if (!worldFromDisk.empty())
-            newWorldJson = json::parse(worldFromDisk); // we found the world on disk
+        if (m_CurrentSlotIndex != -1)
+        {
+            // try read from disk
+            std::string worldFromDisk = SavegameManager::readWorld(m_CurrentSlotIndex, Utils::stripExtension(worldFile));
+            if (!worldFromDisk.empty())
+                newWorldJson = json::parse(worldFromDisk); // we found the world on disk
+        }
     }
 
     // TODO do this asynchronous

--- a/src/engine/GameSession.cpp
+++ b/src/engine/GameSession.cpp
@@ -1,0 +1,223 @@
+//
+// Created by markus on 23.05.17.
+//
+
+#include "GameSession.h"
+#include <fstream>
+#include <components/VobClasses.h>
+#include <logic/PlayerController.h>
+
+using namespace Engine;
+
+GameSession::GameSession(BaseEngine& engine) :
+    m_Engine(engine)
+{
+    m_CurrentSlotIndex = -1;
+}
+
+GameSession::~GameSession() {
+    removeAllWorlds();
+}
+
+void GameSession::addInactiveWorld(const std::string& worldName, nlohmann::json&& exportedWorld)
+{
+    m_InactiveWorlds[worldName] = exportedWorld;
+}
+
+bool GameSession::hasInactiveWorld(const std::string &worldName)
+{
+    return m_InactiveWorlds.find(worldName) != m_InactiveWorlds.end();
+}
+
+std::map<std::string, nlohmann::json> &GameSession::getInactiveWorlds()
+{
+    return m_InactiveWorlds;
+}
+
+nlohmann::json GameSession::retrieveInactiveWorld(const std::string &worldName)
+{
+    if (hasInactiveWorld(worldName))
+    {
+        nlohmann::json worldJson(std::move(m_InactiveWorlds[worldName]));
+        m_InactiveWorlds.erase(worldName);
+        return worldJson;
+    }
+    else
+        return nlohmann::json();
+}
+
+GameClock &GameSession::getGameClock()
+{
+    return m_GameClock;
+}
+
+void GameSession::removeAllWorlds() {
+    while(!m_WorldInstances.empty())
+    {
+        Handle::WorldHandle w = m_Worlds.front();
+        removeWorld(w);
+    }
+    setMainWorld(Handle::WorldHandle::makeInvalidHandle());
+}
+
+void GameSession::setMainWorld(Handle::WorldHandle world)
+{
+    m_MainWorld = world;
+}
+
+Handle::WorldHandle GameSession::addWorld(const std::string& _worldFile,
+                                          const json& worldJson,
+                                          const json& scriptEngine,
+                                          const json& dialogManger)
+{
+    std::string worldFile = _worldFile;
+
+    std::unique_ptr<World::WorldInstance> pWorldInstance = std::make_unique<World::WorldInstance>(m_Engine);
+    World::WorldInstance& world = *pWorldInstance;
+
+    if (!worldJson.empty())
+    {
+        worldFile = worldJson["zenfile"];
+    }
+    if(!worldFile.empty())
+    {
+        std::vector<uint8_t> zenData;
+        m_Engine.getVDFSIndex().getFileData(worldFile, zenData);
+
+        if (zenData.empty())
+        {
+            LogWarn() << "Failed to find world file: " << worldFile;
+            return Handle::WorldHandle::makeInvalidHandle();
+        }
+    }
+    if (!world.init(worldFile, worldJson, scriptEngine, dialogManger)) // expensive operation
+    {
+        LogError() << "Failed to init world file: " << worldFile;
+        return Handle::WorldHandle::makeInvalidHandle();
+    }
+    m_Engine.onWorldCreated(world.getMyHandle());
+    m_WorldInstances.push_back(std::move(pWorldInstance));
+    m_Worlds.push_back(world.getMyHandle());
+
+    return world.getMyHandle();
+}
+
+void GameSession::removeWorld(Handle::WorldHandle world)
+{
+    if (m_MainWorld.isValid() && m_MainWorld == world)
+        m_MainWorld.invalidate();
+
+    m_Worlds.erase(std::remove(m_Worlds.begin(), m_Worlds.end(), world), m_Worlds.end());
+
+    for(auto it = m_WorldInstances.begin(); it != m_WorldInstances.end(); it++)
+    {
+        if(it->get() == &world.get())
+        {
+            m_WorldInstances.erase(it);
+            break;
+        }
+    }
+    m_Engine.onWorldRemoved(world);
+}
+
+void GameSession::saveToSlot(int index, std::string savegameName) {
+    ExcludeFrameTime exclude(m_Engine);
+    assert(index >= 0 && index < SavegameManager::maxSlots());
+
+    if (savegameName.empty())
+        savegameName = std::string("Slot") + std::to_string(index);
+
+    // TODO: Should be writing to a temp-directory first, before messing with the save-files already existing
+    // Clean data from old savegame, so we don't load into worlds we haven't been to yet
+    Engine::SavegameManager::clearSavegame(index);
+
+    World::WorldInstance& mainWorld = getMainWorld().get();
+    // Write information about the current game-state
+    Engine::SavegameManager::SavegameInfo info;
+    info.version = Engine::SavegameManager::SavegameInfo::LATEST_KNOWN_VERSION;
+    info.name = savegameName;
+    info.world = Utils::stripExtension(mainWorld.getZenFile());
+    info.timePlayed = getGameClock().getTotalSeconds();
+
+    Engine::SavegameManager::writeSavegameInfo(index, info);
+
+    // export left worlds we visited in this session
+    for (auto& pair : m_InactiveWorlds)
+    {
+        std::string worldName = Utils::stripExtension(pair.first);
+        nlohmann::json& worldJson = pair.second;
+        SavegameManager::writeWorld(index, worldName, worldJson);
+    }
+    // no need to keep them in memory anymore and they would be unnecessarily saved each time
+    m_InactiveWorlds.clear();
+
+    // export player
+    json playerJson = mainWorld.exportNPC(mainWorld.getScriptEngine().getPlayerEntity());
+    Engine::SavegameManager::writePlayer(index, "player", playerJson);
+
+    // export mainWorld, but skip the player
+    json mainWorldjson;
+    mainWorld.exportWorld(mainWorldjson, {mainWorld.getScriptEngine().getPlayerEntity()});
+    Engine::SavegameManager::writeWorld(index, info.world, mainWorldjson);
+
+    // export dialog info
+    json dialogManager;
+    mainWorld.getDialogManager().exportDialogManager(dialogManager);
+    Engine::SavegameManager::writeFileInSlot(index, "dialogmanager.json", Utils::iso_8859_1_to_utf8(dialogManager.dump(4)));
+
+    // export script engine
+    json scriptEngine;
+    mainWorld.getScriptEngine().exportScriptEngine(scriptEngine);
+    Engine::SavegameManager::writeFileInSlot(index, "scriptengine.json", Utils::iso_8859_1_to_utf8(scriptEngine.dump(4)));
+    m_CurrentSlotIndex = index;
+}
+
+Handle::WorldHandle GameSession::switchToWorld(const std::string &worldFile) {
+    auto oldWorld = getMainWorld();
+    auto exportedPlayer = oldWorld.get().exportAndRemoveNPC(
+            oldWorld.get().getScriptEngine().getPlayerEntity());
+    json scriptEngine;
+    oldWorld.get().getScriptEngine().exportScriptEngine(scriptEngine);
+
+    putWorldToSleep(oldWorld);
+
+    json newWorldJson;
+    if (hasInactiveWorld(worldFile))
+    {
+        newWorldJson = retrieveInactiveWorld(worldFile);
+    } else
+    {
+        // try read from disk
+        std::string worldFromDisk = SavegameManager::readWorld(m_CurrentSlotIndex, Utils::stripExtension(worldFile));
+        if (!worldFromDisk.empty())
+            newWorldJson = json::parse(worldFromDisk); // we found the world on disk
+    }
+
+    // TODO do this asynchronous
+    Handle::WorldHandle newWorld = addWorld(worldFile, newWorldJson, scriptEngine);
+
+    setMainWorld(newWorld);
+    auto playerNew = newWorld.get().importVobAndTakeControl(exportedPlayer);
+
+    // TODO find out start position after level change
+    std::vector<size_t> startpoints = newWorld.get().findStartPoints();
+
+    if (!startpoints.empty())
+    {
+        auto playerVob = VobTypes::asNpcVob(newWorld.get(), playerNew);
+        std::string startpoint = newWorld.get().getWaynet().waypoints[startpoints.front()].name;
+        LogInfo() << "Teleporting player to startpoint '" << startpoint << "'";
+        playerVob.playerController->teleportToWaypoint(startpoints.front());
+        // FIXME seems like player start-points (zCVobStartpoint:zCVob) are inverted?
+        playerVob.playerController->setDirection(-1 * playerVob.playerController->getDirection());
+    }
+
+    return Handle::WorldHandle();
+}
+
+void GameSession::putWorldToSleep(Handle::WorldHandle worldHandle) {
+    json worldJson;
+    worldHandle.get().exportWorld(worldJson);
+    addInactiveWorld(worldHandle.get().getZenFile(), std::move(worldJson));
+    removeWorld(worldHandle);
+}

--- a/src/engine/GameSession.h
+++ b/src/engine/GameSession.h
@@ -1,0 +1,161 @@
+//
+// Created by markus on 23.05.17.
+//
+#pragma once
+#include <map>
+#include <memory>
+#include <list>
+#include <json/json.hpp>
+#include <handle/HandleDef.h>
+#include "World.h"
+#include "GameClock.h"
+#include "BaseEngine.h"
+
+namespace Engine
+{
+    class GameSession {
+    public:
+        GameSession(BaseEngine& engine);
+
+        /**
+         * Cleans current session
+         */
+        ~GameSession();
+
+        /**
+         * Store already visited worlds of the current session
+         * @param worldName zen filename including extension
+         * @param exportedWorld world as json object without players in it
+         */
+        void addInactiveWorld(const std::string& worldName, nlohmann::json&& exportedWorld);
+
+        /**
+         * Get the remembered World and removes it from the map if it exists, else returns empty json
+         * @param worldName zen filename including extension
+         */
+        nlohmann::json retrieveInactiveWorld(const std::string &worldName);
+
+        /**
+         * @return refernce to all inactive Worlds of the current session
+         */
+        std::map<std::string, nlohmann::json>& getInactiveWorlds();
+
+        /**
+         * @param worldName zen filename including extension
+         * @return whether a world is currently unloaded to memory as json object
+         */
+        bool hasInactiveWorld(const std::string& worldName);
+
+        /**
+         * saves the current Session to the given slot
+         * @param index slotindex
+         * @param savegameName label of the savegame. If empty string, then "Slot <index>" is used as name
+         */
+        void saveToSlot(int index, std::string savegameName);
+
+        /**
+         * @return Gameclock
+         */
+        GameClock& getGameClock();
+
+        void setCurrentSlot(int index) { m_CurrentSlotIndex = index; }
+
+        std::map<size_t, std::set<size_t>>& getKnownInfoMap() { return m_KnownInfos; };
+
+        /**
+         * @return data-access to the main world of this session
+         */
+        Handle::WorldHandle getMainWorld()
+        {
+            return m_MainWorld;
+        }
+
+        /**
+         * @return const reference to the list of unqiue pointers to loaded worlds
+         */
+        const std::list<std::unique_ptr<World::WorldInstance>>& getWorldInstances() { return m_WorldInstances; }
+
+        /**
+         * Sets the currently active world.
+         * @param world
+         */
+        void setMainWorld(Handle::WorldHandle world);
+
+        /**
+         * @brief Adds a world. If worldJson is non empty, argument worldFile will be ignored
+         * @param worldfile Path to look for the worldfile. Can be inside a VDF-Archive
+         *		  or on disk (TODO)
+         */
+        Handle::WorldHandle addWorld(const std::string& worldFile,
+                                     const json& worldJson = json(),
+                                     const json& scriptEngine = json(),
+                                     const json& dialogManger = json());
+
+        /**
+         * Switch to world with the given name.
+         * The game evaluates the following conditions and chooses the first valid one
+         * - world found in inactive worlds (already visited in this session, json object in memory)
+         * - world found in current save-game slot on disk
+         * - else: First visit. No vobs get imported. <World>_startup script-fu will be executed
+         * @param worldFile including .zen extension
+         * @return handle to the loaded world
+         */
+        Handle::WorldHandle switchToWorld(const std::string &worldFile);
+
+        /**
+         * @brief moves world from worldInstance list to inactive json map.
+         * @param worldHandle
+         */
+        void putWorldToSleep(Handle::WorldHandle worldHandle);
+
+        /**
+         * Removes a world and everything inside
+         * @param world World to remove
+         */
+        void removeWorld(Handle::WorldHandle world);
+
+        /**
+         * Removes all worlds and everything inside
+         */
+        void removeAllWorlds();
+
+    private:
+        std::map<std::string, nlohmann::json> m_InactiveWorlds;
+
+        /**
+         * last savegame slot used in this session (save or load). Is -1 if "new game" was started
+         */
+        int m_CurrentSlotIndex;
+
+        /**
+         * Gameclock
+         */
+        GameClock m_GameClock;
+
+        /**
+         * known infoInstances by npcInstances
+         */
+        std::map<size_t, std::set<size_t>> m_KnownInfos;
+
+        /**
+         * Currently active world instances
+         */
+        std::list<std::unique_ptr<World::WorldInstance>> m_WorldInstances;
+
+        /**
+         * Main world of this engine-instance
+         */
+        Handle::WorldHandle m_MainWorld;
+
+        /**
+         * Registered worlds
+         */
+        std::vector<Handle::WorldHandle> m_Worlds;
+
+        /**
+         * reference to base engine
+         */
+        BaseEngine& m_Engine;
+    };
+
+}

--- a/src/engine/GameSession.h
+++ b/src/engine/GameSession.h
@@ -47,13 +47,6 @@ namespace Engine
         bool hasInactiveWorld(const std::string& worldName);
 
         /**
-         * saves the current Session to the given slot
-         * @param index slotindex
-         * @param savegameName label of the savegame. If empty string, then "Slot <index>" is used as name
-         */
-        void saveToSlot(int index, std::string savegameName);
-
-        /**
          * @return Gameclock
          */
         GameClock& getGameClock();

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -842,6 +842,22 @@ void WorldInstance::exportControllers(Logic::Controller* logicController, Logic:
         visualController->exportObject(j["visual"]);
 }
 
+void WorldInstance::takeControlOver(Handle::EntityHandle entityHandle) {
+    VobTypes::NpcVobInformation npcVob = VobTypes::asNpcVob(*this, entityHandle);
+
+    getScriptEngine().setPlayerEntity(entityHandle);
+    getScriptEngine().setInstanceNPC("hero", VobTypes::getScriptHandle(npcVob));
+    // reset bindings
+    Engine::Input::clearActions();
+    npcVob.playerController->setupKeyBindings();
+}
+
+Handle::EntityHandle WorldInstance::importVobAndTakeControl(const json &j) {
+    auto player = importSingleVob(j);
+    takeControlOver(player);
+    return player;
+}
+
 
 
 

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -800,6 +800,11 @@ void WorldInstance::importVobs(const json& j)
     }
 }
 
+bool WorldInstance::isEntityValid(Handle::EntityHandle e)
+{
+    return m_Allocators.m_ComponentAllocator.isHandleValid(e);
+}
+
 Handle::EntityHandle WorldInstance::createCamera() {
     // Add player-camera
     m_Camera = addEntity(Components::PositionComponent::MASK);

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -490,10 +490,6 @@ Components::ComponentAllocator::Handle WorldInstance::addEntity(Components::Comp
 
 void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, const Math::Matrix& cameraWorld)
 {
-    // Set frametime in worldinfo
-    m_WorldInfo.m_LastFrameDeltaTime = deltaTime;
-    m_pEngine->getGameClock().update(deltaTime);
-
     // Tell script engine the frame started
     m_ScriptEngine.onFrameStart();
 

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -590,12 +590,14 @@ std::vector<size_t> WorldInstance::findStartPoints()
 
 	// General
 
+    /*
     // Gothic 1
     auto it = m_Waynet.waypointsByName.find("WP_INTRO_SHORE");
     if(it != m_Waynet.waypointsByName.end())
         pts.push_back((*it).second);
+    */
 
-	it = m_Waynet.waypointsByName.find("zCVobStartpoint:zCVob");
+	auto it = m_Waynet.waypointsByName.find("zCVobStartpoint:zCVob");
 	if(it != m_Waynet.waypointsByName.end())
 		pts.push_back((*it).second);
 

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -279,8 +279,9 @@ namespace World
 		/**
 		 * Exports this world into a json-object
 		 * @param j json-object to write into
+		 * @param skip entities which shall be excluded from export
 		 */
-		void exportWorld(json& j);
+		void exportWorld(json& j, std::set<Handle::EntityHandle> skip = {});
 
 		/**
 		 * Exports the given controllers to a json-object
@@ -291,10 +292,9 @@ namespace World
 		void exportControllers(Logic::Controller* logicController, Logic::VisualController* visualController, json &j);
 
 		/**
-         * Imports vobs from a json-object
-         * @param j
-         */
-		void importVobs(const json& j);
+		 * @return exported npc as json object
+		 */
+		json exportNPC(Handle::EntityHandle entityHandle);
 
 		/**
 		 * export npc (i.e. player) and remove him from world
@@ -305,6 +305,12 @@ namespace World
 		 * @return world-file this is built after
 		 */
 		const std::string& getZenFile(){ return m_ZenFile; }
+
+		/**
+         * Imports vobs from a json-object
+         * @param j
+         */
+		void importVobs(const json& j);
 
 		/**
          * Imports a single vob from a json-object

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -79,9 +79,15 @@ namespace World
 		~WorldInstance();
 
 		/**
-		* @param zen file
+		 * @param zen filename of world
+		 * @param worldJson may be empty
+		 * @param scriptEngine may be empty
+		 * @param dialogManger shall only be non empty at first world load in each session
 		*/
-		bool init(const std::string& zen, const json& j = json());
+		bool init(const std::string& zen,
+                  const json& worldJson = json(),
+                  const json& scriptEngine = json(),
+                  const json& dialogManger = json());
 
         /**
          * Creates an entity with the given components and returns its handle

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -283,11 +283,11 @@ namespace World
 		 */
 		void exportControllers(Logic::Controller* logicController, Logic::VisualController* visualController, json &j);
 
-        /**
+		/**
          * Imports vobs from a json-object
          * @param j
          */
-        void importVobs(const json& j);
+		void importVobs(const json& j);
 
 		/**
 		 * export npc (i.e. player) and remove him from world
@@ -304,6 +304,17 @@ namespace World
          * @return entity handle if successfull, else invalid handle
          */
 		Handle::EntityHandle importSingleVob(const json& j);
+
+		/**
+         * import single vob from json and take control over it
+         * @return entity handle if successfull, else invalid handle
+         */
+		Handle::EntityHandle importVobAndTakeControl(const json& j);
+
+		/**
+         * take control over the given entity (camera, movement(key bindings))
+         */
+		void takeControlOver(Handle::EntityHandle entityHandle);
 
     private:
         /**

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -73,20 +73,6 @@ namespace World
     {
     public:
 
-        /**
-         * Information about the state of the world
-         */
-        struct WorldInfo
-        {
-            WorldInfo()
-            {
-                m_LastFrameDeltaTime = 0.0;
-            }
-
-            // Last deltatime-value we have gotten here
-            double m_LastFrameDeltaTime;
-		};
-
 		WorldInstance();
 		~WorldInstance();
 
@@ -234,11 +220,6 @@ namespace World
 		UI::PrintScreenMessages& getPrintScreenManager() const { return *m_PrintScreenMessageView; }
 
 		/**
-		 * @return Information about the state of the world
-		 */
-		WorldInfo& getWorldInfo(){ return m_WorldInfo; }
-
-		/**
 		 * @return Map of freepoints
 		 */
 		std::vector<Handle::EntityHandle> getFreepoints(const std::string& tag);
@@ -279,6 +260,12 @@ namespace World
          * Imports a single vob from a json-object
          */
 		void importSingleVob(const json& j);
+
+    private:
+        /**
+         * copying a world is not allowed and results in a compile error
+         */
+        WorldInstance(const WorldInstance& other) = delete;
 
 	protected:
 
@@ -371,11 +358,6 @@ namespace World
 		 * This worlds print-screen manager
 		 */
 		UI::PrintScreenMessages* m_PrintScreenMessageView;
-
-		/**
-		 * Information about the state of the world
-		 */
-		WorldInfo m_WorldInfo;
 
 		/**
 		 * Pfx-cache

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -117,6 +117,13 @@ namespace World
         }
 
 		/**
+		 * Checks whether the passed entity handle points to a valid location
+		 * @param e Handle to check
+		 * @return Whether that entity exists
+		 */
+		bool isEntityValid(Handle::EntityHandle e);
+
+		/**
 		 * Removes the entitiy with the given handle
 		 */
 		void removeEntity(Handle::EntityHandle h);

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -20,6 +20,7 @@
 #include <json.hpp>
 #include <logic/PfxManager.h>
 #include "BspTree.h"
+#include <logic/CameraController.h>
 
 using json = nlohmann::json;
 
@@ -73,18 +74,46 @@ namespace World
     {
     public:
 
-		WorldInstance();
+		WorldInstance(Engine::BaseEngine& engine);
 		~WorldInstance();
 
 		/**
 		* @param zen file
 		*/
-		bool init(Engine::BaseEngine& engine, const std::string& zen, const json& j = json());
+		bool init(const std::string& zen, const json& j = json());
 
         /**
          * Creates an entity with the given components and returns its handle
          */
         Components::ComponentAllocator::Handle addEntity(Components::ComponentMask components = 0);
+
+        /**
+         * creates camera and returns it
+         */
+        Handle::EntityHandle createCamera();
+
+        /**
+         * @return this world's camera
+         */
+        Handle::EntityHandle getCamera();
+
+        /**
+         * @return The given component of the world's camera
+         */
+        template<typename T>
+        T& getCameraComp()
+        {
+            return getComponentAllocator().getElement<T>(m_Camera);
+        }
+
+        /**
+         * @return Camera-Controller of the camera
+         */
+        Logic::CameraController* getCameraController()
+        {
+            Logic::Controller* ptr = getCameraComp<Components::LogicComponent>().m_pLogicController;
+            return dynamic_cast<Logic::CameraController*>(ptr);
+        }
 
 		/**
 		 * Removes the entitiy with the given handle
@@ -363,5 +392,10 @@ namespace World
 		 * Pfx-cache
 		 */
 		Logic::PfxManager m_PfxManager;
+
+		/**
+         * Players camera entity
+         */
+		Handle::EntityHandle m_Camera;
     };
 }

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -21,6 +21,7 @@
 #include <logic/PfxManager.h>
 #include "BspTree.h"
 #include <logic/CameraController.h>
+#include <components/Vob.h>
 
 using json = nlohmann::json;
 
@@ -274,11 +275,24 @@ namespace World
 		 */
 		void exportWorld(json& j);
 
+		/**
+		 * Exports the given controllers to a json-object
+		 * @param logicController may be nullptr
+		 * @param visualController may be nullptr
+		 * @param j json-object to write into
+		 */
+		void exportControllers(Logic::Controller* logicController, Logic::VisualController* visualController, json &j);
+
         /**
          * Imports vobs from a json-object
          * @param j
          */
         void importVobs(const json& j);
+
+		/**
+		 * export npc (i.e. player) and remove him from world
+		 */
+		json exportAndRemoveNPC(Handle::EntityHandle handle);
 
 		/**
 		 * @return world-file this is built after
@@ -287,8 +301,9 @@ namespace World
 
 		/**
          * Imports a single vob from a json-object
+         * @return entity handle if successfull, else invalid handle
          */
-		void importSingleVob(const json& j);
+		Handle::EntityHandle importSingleVob(const json& j);
 
     private:
         /**

--- a/src/logic/Console.cpp
+++ b/src/logic/Console.cpp
@@ -9,15 +9,9 @@
 #include <GLFW/glfw3.h>
 #include <ui/Hud.h>
 
-using namespace UI;
-
-/* Function keys */
-namespace Keys
-{
-    // All keys mapped to ascii-characters
-    const int PrintableBegin = 32;
-    const int PrintableEnd = 93; // Inclusive
-};
+using Logic::Console;
+using Logic::ConsoleCommand;
+using Logic::SuggestionBase;
 
 Console::Console(Engine::BaseEngine& e) :
     m_BaseEngine(e)
@@ -226,7 +220,7 @@ bool naturalComparator(const std::string& left, const std::string& right)
     return left < right;
 }*/
 
-using Suggestion = UI::ConsoleCommand::Suggestion;
+using Suggestion = Logic::ConsoleCommand::Suggestion;
 void Console::generateSuggestions(const std::string& input, bool limitToFixed) {
     using std::vector;
     using std::string;

--- a/src/logic/Console.h
+++ b/src/logic/Console.h
@@ -11,7 +11,7 @@
 #include <memory>
 #include <ui/ConsoleBox.h>
 
-namespace UI
+namespace Logic
 {
 
     struct SuggestionBase
@@ -140,7 +140,7 @@ namespace UI
 
         const std::list<std::string>& getOutputLines() { return m_Output; }
         const std::string& getTypedLine() { return m_TypedLine; }
-        const std::vector<std::vector<UI::ConsoleCommand::Suggestion>>& getSuggestions() { return m_SuggestionsList; }
+        const std::vector<std::vector<Logic::ConsoleCommand::Suggestion>>& getSuggestions() { return m_SuggestionsList; }
 
     private:
 
@@ -177,7 +177,7 @@ namespace UI
         /**
          * suggestions for each token
          */
-        std::vector<std::vector<UI::ConsoleCommand::Suggestion>> m_SuggestionsList;
+        std::vector<std::vector<Logic::ConsoleCommand::Suggestion>> m_SuggestionsList;
 
         /**
          * Currently typed line

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -358,7 +358,9 @@ bool DialogManager::init()
         LogInfo() << "Loading OU-file from: " << ou;
 
     LogInfo() << "Creating script-side dialog-manager";
-    m_ScriptDialogMananger = new Daedalus::GameState::DaedalusDialogManager(getVM(), ou);
+    m_ScriptDialogMananger = new Daedalus::GameState::DaedalusDialogManager(getVM(),
+                                                                            ou,
+                                                                            m_World.getEngine()->getSession().getKnownInfoMap());
 
     LogInfo() << "Adding dialog-UI to root view";
     // Add subtitle box (Hidden if there is nothing to display)
@@ -455,7 +457,7 @@ void DialogManager::exportDialogManager(json& j)
     const std::map<size_t, std::set<size_t>>& info =
             m_World.getDialogManager().getScriptDialogManager()->getKnownNPCInformation();
 
-    json& npcInfo = j["npcInfo"];
+    json& npcInfo = j["npcKnowsInfo"];
     for(const auto& p : info)
     {
         // Converting to string here, because these can get pretty high with huge gaps,
@@ -466,7 +468,7 @@ void DialogManager::exportDialogManager(json& j)
 
 void DialogManager::importDialogManager(const json& j)
 {
-    for(auto it=j["npcInfo"].begin(); it != j["npcInfo"].end(); it++)
+    for(auto it=j["npcKnowsInfo"].begin(); it != j["npcKnowsInfo"].end(); it++)
     {
         // Map of indices -> array of numbers
         int npcInstance = std::stoi(it.key());

--- a/src/logic/PfxManager.cpp
+++ b/src/logic/PfxManager.cpp
@@ -36,7 +36,7 @@ bool Logic::PfxManager::loadParticleFXDAT()
 
     // Load DAT-File...
     m_pVM = new Daedalus::DaedalusVM(datFile);
-    Daedalus::registerGothicEngineClasses(*m_pVM, m_World.getBasicGameType());
+    Daedalus::registerGothicEngineClasses(*m_pVM);
 
     m_DefaultEmitter = {0};
 

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1427,7 +1427,7 @@ bool PlayerController::EV_State(std::shared_ptr<EventMessages::StateMessage> sha
             break;
 
         case EventMessages::StateMessage::EV_Wait:
-            message.waitTime -= static_cast<float>(m_World.getWorldInfo().m_LastFrameDeltaTime);
+            message.waitTime -= static_cast<float>(m_World.getEngine()->getGameClock().getLastDt());
             return message.waitTime < 0.0f;
             break;
 

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -203,7 +203,6 @@ void PlayerController::continueRoutine()
 
 void PlayerController::teleportToWaypoint(size_t wp)
 {
-
     m_AIState.closestWaypoint = wp;
 
     teleportToPosition(m_World.getWaynet().waypoints[wp].position);

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2339,8 +2339,10 @@ void PlayerController::importObject(const json& j, bool noTransform)
 
         // Teleport to position
         {
-            teleportToPosition(getEntityTransform().Translation());
-            setDirection(-1.0f * getEntityTransform().Forward());
+            // need to copy since setting changing position sets the direction of the transform matrix
+            auto transformMatrixCopy = getEntityTransform();
+            teleportToPosition(transformMatrixCopy.Translation());
+            setDirection(-1.0f * transformMatrixCopy.Forward());
         }
     }
 

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2406,13 +2406,7 @@ void PlayerController::importObject(const json& j, bool noTransform)
     }
 
     // import refusetalktime
-    {
-        // Needed for compatibility with savegame version '1'
-        auto it = j.find("refusetalktime");
-        this->setRefuseTalkTime(it != j.end() ? static_cast<float>(*it) : 0.0f);
-        // use the following, when compatibility with savegame version '1' is not needed anymore
-        // this->setRefuseTalkTime(static_cast<float>(j["refusetalktime"]);
-    }
+    this->setRefuseTalkTime(static_cast<float>(j["refusetalktime"]));
 
     // Import state
     m_AIStateMachine.importScriptState(j["AIState"]);

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2517,11 +2517,11 @@ void PlayerController::onUpdateForPlayer(float deltaTime)
     UI::Hud& hud = m_World.getEngine()->getHud();
     auto& stats = getScriptInstance();
 
-    hud.setHealth(stats.attribute[Daedalus::GEngineClasses::C_Npc::EATR_HITPOINTS] /
-                  (float)stats.attribute[Daedalus::GEngineClasses::C_Npc::EATR_HITPOINTSMAX]);
+    hud.setHealth(stats.attribute[Daedalus::GEngineClasses::C_Npc::EATR_HITPOINTS],
+                  stats.attribute[Daedalus::GEngineClasses::C_Npc::EATR_HITPOINTSMAX]);
 
-    hud.setMana(stats.attribute[Daedalus::GEngineClasses::C_Npc::EATR_MANA] /
-                  (float)stats.attribute[Daedalus::GEngineClasses::C_Npc::EATR_MANAMAX]);
+    hud.setMana(stats.attribute[Daedalus::GEngineClasses::C_Npc::EATR_MANA],
+                stats.attribute[Daedalus::GEngineClasses::C_Npc::EATR_MANAMAX]);
 
 }
 

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2011,15 +2011,15 @@ void PlayerController::setupKeyBindings()
 
     Engine::Input::RegisterAction(Engine::ActionType::Quicksave, [this](bool triggered, float)
     {
-        if(triggered && !m_World.getEngine()->getHud().isMenuActive() && !m_World.getDialogManager().isDialogActive()){
-            Engine::SavegameManager::saveToSaveGameSlot(0, "");
+        if(triggered){
+            m_World.getEngine()->queueSaveGameAction({Engine::SavegameManager::Save, 0, ""});
         }
     });
 
     Engine::Input::RegisterAction(Engine::ActionType::Quickload, [this](bool triggered, float)
     {
         if(triggered){
-            m_World.getEngine()->setQuickload(true);
+            m_World.getEngine()->queueSaveGameAction({Engine::SavegameManager::Load, 0, ""});
         }
     });
 

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -599,7 +599,6 @@ namespace Logic
         /**
          * refuse talk countdown
          */
-        // TODO export/import this value in json for savegames
         float m_RefuseTalkTime;
 
         /**

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -282,17 +282,14 @@ void Engine::SavegameManager::saveToSaveGameSlot(int index, std::string savegame
     info.timePlayed = gameEngine->getGameClock().getTotalSeconds();
     Engine::SavegameManager::writeSavegameInfo(index, info);
 
-    // remove all players from this world
-    json playerJson = world.exportAndRemoveNPC(world.getScriptEngine().getPlayerEntity());
+    // export player
+    json playerJson = world.exportNPC(world.getScriptEngine().getPlayerEntity());
     Engine::SavegameManager::writePlayer(index, "player", Utils::iso_8859_1_to_utf8(playerJson.dump()));
 
-    // save world
     json mainWorldjson;
-    world.exportWorld(mainWorldjson);
+    // export world, but skip the player
+    world.exportWorld(mainWorldjson, {world.getScriptEngine().getPlayerEntity()});
     Engine::SavegameManager::writeWorld(index, info.world, Utils::iso_8859_1_to_utf8(mainWorldjson.dump(4)));
-
-    // import player again
-    world.importVobAndTakeControl(playerJson);
 }
 
 std::string Engine::SavegameManager::gameSpecificSubFolderName() {

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -237,13 +237,18 @@ std::string Engine::SavegameManager::loadSaveGameSlot(int index) {
         return "Target world-file invalid: " + worldPath;
     }
 
-    gameEngine->loadWorld(info.world + ".zen", worldPath);
-    gameEngine->getGameClock().setTotalSeconds(info.timePlayed);
+    gameEngine->removeAllWorlds();
+    Handle::WorldHandle worldHandle = gameEngine->loadWorld(info.world + ".zen", worldPath);
+    if (worldHandle.isValid())
+    {
+        gameEngine->setMainWorld(worldHandle);
+        gameEngine->getGameClock().setTotalSeconds(info.timePlayed);
+    }
     return "";
 }
 
 int Engine::SavegameManager::maxSlots() {
-    switch(gameEngine->getMainWorld().get().getBasicGameType())
+    switch(gameEngine->getBasicGameType())
     {
         case Daedalus::GameType::GT_Gothic1:
             return G1_MAX_SLOTS;
@@ -281,8 +286,7 @@ void Engine::SavegameManager::saveToSaveGameSlot(int index, std::string savegame
 }
 
 std::string Engine::SavegameManager::gameSpecificSubFolderName() {
-    // FIXME can't get gameType from World if no world is loaded (game should start with the menu)
-    if (gameEngine->getMainWorld().get().getBasicGameType() == Daedalus::GameType::GT_Gothic1)
+    if (gameEngine->getBasicGameType() == Daedalus::GameType::GT_Gothic1)
         return  "Gothic";
     else
         return  "Gothic 2";

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -239,12 +239,12 @@ std::string Engine::SavegameManager::loadSaveGameSlot(int index) {
     }
 
     gameEngine->removeAllWorlds();
-    Handle::WorldHandle worldHandle = gameEngine->loadWorld(info.world + ".zen", worldPath);
+    Handle::WorldHandle worldHandle = gameEngine->addWorld(info.world + ".zen", worldPath);
     if (worldHandle.isValid())
     {
         gameEngine->setMainWorld(worldHandle);
-        json player = json::parse(readPlayer(index, "player"));
-        gameEngine->getMainWorld().get().importSingleVob(player);
+        json playerJson = json::parse(readPlayer(index, "player"));
+        gameEngine->getMainWorld().get().importVobAndTakeControl(playerJson);
         gameEngine->getGameClock().setTotalSeconds(info.timePlayed);
     }
     return "";
@@ -292,7 +292,7 @@ void Engine::SavegameManager::saveToSaveGameSlot(int index, std::string savegame
     Engine::SavegameManager::writeWorld(index, info.world, Utils::iso_8859_1_to_utf8(mainWorldjson.dump(4)));
 
     // import player again
-    world.importSingleVob(playerJson);
+    world.importVobAndTakeControl(playerJson);
 }
 
 std::string Engine::SavegameManager::gameSpecificSubFolderName() {

--- a/src/logic/SavegameManager.h
+++ b/src/logic/SavegameManager.h
@@ -12,7 +12,11 @@ namespace Engine
         /**
          * @param GameEngine-pointer
          */
-        bool init(Engine::GameEngine& engine);
+        void init(Engine::GameEngine& engine);
+
+        void invalidateCurrentSlotIndex();
+
+        int getCurrentSlotIndex();
 
         /**
          * Assembles a list of all available savegame names. Every entry will correspond to an index number.
@@ -74,6 +78,23 @@ namespace Engine
         SavegameInfo readSavegameInfo(int idx);
 
         /**
+         * Writes actual player-data into the given savegame
+         * @param idx Index of the savegame
+         * @param playerName Name of the player which is saved. No extensions, just the name.
+         * @param data Data containing the playercontroller.
+         * @return success
+         */
+        bool writePlayer(int idx, const std::string& playerName, const std::string& data);
+
+        /**
+         * Reads player-data for the player with the given name.
+         * @param idx Index of the savegame
+         * @param playerName Name of the player to load
+         * @return Data of the given savegame's player. Empty string if not found or no data
+         */
+        std::string readPlayer(int idx, const std::string& playerName);
+
+        /**
          * Writes actual world-data into the given savegame
          * @param idx Index of the savegame
          * @param worldName Name of the world which is saved. No extensions, just the name.
@@ -86,9 +107,25 @@ namespace Engine
          * Reads world-data for the world with the given name.
          * @param idx Index of the savegame
          * @param worldName Name of the world to load
-         * @return Data of the given savegames world. Empty string of not found or no data
+         * @return Data of the given savegames world. Empty string if not found or no data
          */
         std::string readWorld(int idx, const std::string& worldName);
+
+        /**
+         * write the file with the specified filename to the given slot
+         * @param idx slot index
+         * @param relativePath filename relative to the savegame slot folder
+         * @param file content to be saved.
+         * @return success
+         */
+        bool writeFileInSlot(int idx, const std::string& relativePath, const std::string& data);
+
+        /**
+         * reads the file with the specified filename in the given slot
+         * @param idx slot index
+         * @param relativePath filename relative to the savegame slot folder
+         */
+        std::string readFileInSlot(int idx, const std::string& relativePath);
 
         /**
          * loads the savegame of the specified slotindex
@@ -122,7 +159,8 @@ namespace Engine
         enum SaveGameActionType
         {
             Save,
-            Load
+            Load,
+            SwitchLevel
         };
 
         struct SaveGameAction

--- a/src/logic/SavegameManager.h
+++ b/src/logic/SavegameManager.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <json/json.hpp>
 
 namespace Engine
 {
@@ -81,10 +82,10 @@ namespace Engine
          * Writes actual player-data into the given savegame
          * @param idx Index of the savegame
          * @param playerName Name of the player which is saved. No extensions, just the name.
-         * @param data Data containing the playercontroller.
+         * @param player as json object
          * @return success
          */
-        bool writePlayer(int idx, const std::string& playerName, const std::string& data);
+        bool writePlayer(int idx, const std::string& playerName, const nlohmann::json& world);
 
         /**
          * Reads player-data for the player with the given name.
@@ -98,10 +99,10 @@ namespace Engine
          * Writes actual world-data into the given savegame
          * @param idx Index of the savegame
          * @param worldName Name of the world which is saved. No extensions, just the name.
-         * @param data Data containing the world information to be saved. 
+         * @param world as json object
          * @return success
          */
-        bool writeWorld(int idx, const std::string& worldName, const std::string& data);
+        bool writeWorld(int idx, const std::string& worldName, const nlohmann::json& world);
 
         /**
          * Reads world-data for the world with the given name.
@@ -149,8 +150,8 @@ namespace Engine
          */
         std::string buildWorldPath(int idx, const std::string& worldName);
 
-        constexpr int G1_MAX_SLOTS = 15 + 1; // 15 usual slots + current
-        constexpr int G2_MAX_SLOTS = 20 + 1; // 20 usual slots + current
+        constexpr int G1_MAX_SLOTS = 15 + 1; // 15 usual slots + quicksave
+        constexpr int G2_MAX_SLOTS = 20 + 1; // 20 usual slots + quicksave
 
         std::string gameSpecificSubFolderName();
 

--- a/src/logic/SavegameManager.h
+++ b/src/logic/SavegameManager.h
@@ -129,7 +129,8 @@ namespace Engine
         {
             SaveGameActionType type;
             int slot;
-            std::string saveName;
+            // only used for Save-actions
+            std::string savegameName;
         };
     }
 }

--- a/src/logic/SavegameManager.h
+++ b/src/logic/SavegameManager.h
@@ -118,5 +118,18 @@ namespace Engine
         std::string gameSpecificSubFolderName();
 
         int maxSlots();
+
+        enum SaveGameActionType
+        {
+            Save,
+            Load
+        };
+
+        struct SaveGameAction
+        {
+            SaveGameActionType type;
+            int slot;
+            std::string saveName;
+        };
     }
 }

--- a/src/logic/SavegameManager.h
+++ b/src/logic/SavegameManager.h
@@ -140,7 +140,7 @@ namespace Engine
          * @param index slotindex
          * @param savegameName label of the savegame. If empty string, then "Slot <index>" is used as name
          */
-        void saveToSaveGameSlot(int index, std::string savegameName);
+        void saveToSlot(int index, std::string savegameName);
 
         /**
          * Builds the path to a saved worldfile from the given slot

--- a/src/logic/ScriptEngine.cpp
+++ b/src/logic/ScriptEngine.cpp
@@ -40,7 +40,7 @@ bool ScriptEngine::loadDAT(const std::string& file)
     // Register externals
     const bool verbose = false;
     Logic::ScriptExternals::registerStubs(*m_pVM, verbose);
-    Daedalus::registerGothicEngineClasses(*m_pVM, m_World.getBasicGameType());
+    Daedalus::registerGothicEngineClasses(*m_pVM);
     Logic::ScriptExternals::registerEngineExternals(m_World, m_pVM, verbose);
 
     // Register our externals
@@ -175,12 +175,6 @@ void ScriptEngine::initForWorld(const std::string& world, bool firstStart)
 
         }
     }
-
-    LogInfo() << "Setting camera mode to third-person";
-
-    Engine::GameEngine* e = reinterpret_cast<Engine::GameEngine*>(m_World.getEngine());
-    //e->getMainCameraController()->setTransforms(m_World.getWaynet().waypoints[startpoints[0]].position);
-    e->getMainCameraController()->setCameraMode(Logic::CameraController::ECameraMode::ThirdPerson);
 }
 
 void ScriptEngine::onNPCInserted(Daedalus::GameState::NpcHandle npc, const std::string& spawnpoint)

--- a/src/logic/ScriptEngine.h
+++ b/src/logic/ScriptEngine.h
@@ -40,6 +40,11 @@ namespace Logic
         void initForWorld(const std::string& world, bool firstStart = true);
 
         /**
+         * If a new game is started a PC_HERO instance must be created
+         */
+        void createDefaultPlayer();
+
+        /**
          * Returns a list of all global symbols the game would have saved inside a savegame together
          * with their values.
          *
@@ -116,6 +121,11 @@ namespace Logic
         Handle::EntityHandle getPlayerEntity(){ return m_PlayerEntity; }
 
         /**
+         * Sets the entity of the NPC the player is currently playing as
+         */
+        void setPlayerEntity(Handle::EntityHandle player){ m_PlayerEntity = player; }
+
+        /**
          * Returns a list of all npcs found inside the given sphere
          * @param center Center of the search-sphere
          * @param radius Radius of the search-sphere
@@ -154,6 +164,9 @@ namespace Logic
 
         void registerMob(Handle::EntityHandle e);
         void unregisterMob(Handle::EntityHandle e);
+
+        void registerNpc(Handle::EntityHandle e);
+        void unregisterNpc(Handle::EntityHandle e);
 
         /**
          * Applies the given items effects on the given NPC or equips it. Does not delete the item or anything else.
@@ -200,6 +213,11 @@ namespace Logic
          * Called when an npc got inserted into the world
          */
         void onNPCInserted(Daedalus::GameState::NpcHandle npc, const std::string& spawnpoint);
+
+        /**
+         * Called when an npc got removed from the world
+         */
+        void onNPCRemoved(Daedalus::GameState::NpcHandle npc);
 
         /**
          * Called after the NPC got inserted into the world. At this point, it is fully initialized and can be used.

--- a/src/logic/ScriptEngine.h
+++ b/src/logic/ScriptEngine.h
@@ -40,9 +40,9 @@ namespace Logic
         void initForWorld(const std::string& world, bool firstStart = true);
 
         /**
-         * If a new game is started a PC_HERO instance must be created
+         * If a new game this method will create an instance of the class with the given name at some startpoint
          */
-        void createDefaultPlayer();
+        Handle::EntityHandle createDefaultPlayer(const std::string& symbolName);
 
         /**
          * Returns a list of all global symbols the game would have saved inside a savegame together

--- a/src/math/mathlib.h
+++ b/src/math/mathlib.h
@@ -124,7 +124,7 @@ namespace Math
             glm::vec3 _glmt_vector;
         };
 
-		std::string toString()
+		std::string toString() const
 		{
 			std::string out;
 			out = "[" + std::to_string(x)

--- a/src/memory/AllocatorBundle.h
+++ b/src/memory/AllocatorBundle.h
@@ -54,6 +54,20 @@ namespace Memory
         }
 
         /**
+         * @return Whether handle h is still active and valid
+         */
+        bool isHandleValid(const Handle& h)
+        {
+            bool invalid = false;
+            Utils::for_each_in_tuple(m_Allocators, [&](auto& alloc){
+                if(!alloc.isHandleValid(h))
+                    invalid = true;
+            });
+
+            return !invalid;
+        }
+
+        /**
          * @return the actual element to the handle h
          */
         template<typename T>

--- a/src/memory/StaticReferencedAllocator.h
+++ b/src/memory/StaticReferencedAllocator.h
@@ -144,6 +144,15 @@ namespace Memory
         }
 
         /**
+         * @return Whether handle h is still active and valid
+         */
+        bool isHandleValid(const typename T::HandleType& h)
+        {
+            return h.index < NUM
+                   && m_InternalHandles[h.index].m_Handle.generation == h.generation;
+        }
+
+        /**
          * @return the actual element to the handle h (Does not check generation)
          */
         T& getElementForce(const typename T::HandleType& h)

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -1139,6 +1139,7 @@ int main(int argc, char** argv)
         return 0;
 
     ExampleCubes app;
+#ifdef NDEBUG
     try
     {
         ret = app.run(argc, argv);
@@ -1156,6 +1157,10 @@ int main(int argc, char** argv)
         std::cerr << "Caught unknown exception in main loop" << std::endl;
         ret = 1;
     }
+#else
+    ret = app.run(argc, argv);
+    app.shutdown();
+#endif
 
     // Write current config-values
     Cli::writeConfigFile();

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -501,7 +501,7 @@ public:
         console.registerCommand("switchlevel", [this](const std::vector<std::string>& args2) -> std::string {
             auto args = args2;
             if (args.size() == 1)
-                args.push_back("world.zen");
+                args.push_back(m_pEngine->getEngineArgs().startupZEN);
 
             auto& s1 = m_pEngine->getMainWorld().get().getScriptEngine();
 

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -24,7 +24,7 @@
 #include <ZenLib/utils/logger.h>
 #include <json.hpp>
 #include <fstream>
-#include <ui/Console.h>
+#include <logic/Console.h>
 #include <components/VobClasses.h>
 #include <logic/NpcScriptState.h>
 #include <logic/PlayerController.h>
@@ -337,10 +337,10 @@ public:
         auto& console = m_pEngine->getConsole();
 
         // suggestion generator for an integer range. stop is not included
-        auto rangeGen = [this](int start, int stop, int step = 1) -> std::vector<UI::ConsoleCommand::Suggestion> {
-            std::vector<UI::ConsoleCommand::Suggestion> suggestions;
+        auto rangeGen = [this](int start, int stop, int step = 1) -> std::vector<Logic::ConsoleCommand::Suggestion> {
+            std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
             for (int i = start; i < stop; ++i)
-                suggestions.push_back(std::make_shared<UI::SuggestionBase>(UI::SuggestionBase {{std::to_string(i)}}));
+                suggestions.push_back(std::make_shared<Logic::SuggestionBase>(Logic::SuggestionBase {{std::to_string(i)}}));
             return suggestions;
         };
 
@@ -452,12 +452,12 @@ public:
             return "Hero successfully exported to: hero.json";
         });
 
-        auto waypointNamesGen = [this]() -> std::vector<UI::ConsoleCommand::Suggestion> {
-            std::vector<UI::ConsoleCommand::Suggestion> suggestions;
+        auto waypointNamesGen = [this]() -> std::vector<Logic::ConsoleCommand::Suggestion> {
+            std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
             auto& waypoints = m_pEngine->getMainWorld().get().getWaynet().waypoints;
             for (auto& waypoint : waypoints)
             {
-                UI::ConsoleCommand::Suggestion suggestion = std::make_shared<UI::SuggestionBase>(UI::SuggestionBase {{waypoint.name}});
+                Logic::ConsoleCommand::Suggestion suggestion = std::make_shared<Logic::SuggestionBase>(Logic::SuggestionBase {{waypoint.name}});
                 suggestions.push_back(suggestion);
             }
             return suggestions;
@@ -497,20 +497,20 @@ public:
             return "Hero successfully imported from: hero.json";
         });
 
-        auto zenLevelNamesGen = [this]() -> std::vector<UI::ConsoleCommand::Suggestion> {
-            using Suggestion = UI::ConsoleCommand::Suggestion;
+        auto zenLevelNamesGen = [this]() -> std::vector<Logic::ConsoleCommand::Suggestion> {
+            using Suggestion = Logic::ConsoleCommand::Suggestion;
 
             std::vector<std::string> g1WorldNames = {"WORLD.ZEN", "FREEMINE.ZEN", "OLDMINE.ZEN", "ORCGRAVEYARD.ZEN", "ORCTEMPEL.ZEN"};
             std::vector<std::string> g2WorldNames = {"DRAGONISLAND.ZEN", "NEWWORLD.ZEN", "OLDWORLD.ZEN", "ADDONWORLD.ZEN"};
             auto& worldNames = m_pEngine->getBasicGameType() == Daedalus::GameType::GT_Gothic1 ? g1WorldNames : g2WorldNames;
-            std::vector<UI::ConsoleCommand::Suggestion> suggestions;
+            std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
             for (const auto& worldName : worldNames)
-                suggestions.push_back(std::make_shared<UI::SuggestionBase>(UI::SuggestionBase{{worldName}}));
+                suggestions.push_back(std::make_shared<Logic::SuggestionBase>(Logic::SuggestionBase{{worldName}}));
             return suggestions;
 
             // also works, but ugly
             /*
-            static std::vector<UI::ConsoleCommand::Suggestion> suggestions;
+            static std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
             if (!suggestions.empty())
                 return suggestions;
 
@@ -532,7 +532,7 @@ public:
                     {
                         ZenLoad::oCWorld::readObjectData(world, parser, header.version);
                         if (parser.getWorldMesh())
-                            suggestions.push_back(std::make_shared<UI::SuggestionBase>(UI::SuggestionBase{{fileInfo.fileName}}));
+                            suggestions.push_back(std::make_shared<Logic::SuggestionBase>(Logic::SuggestionBase{{fileInfo.fileName}}));
                     }
                     catch (const std::runtime_error&)
                     {
@@ -596,12 +596,12 @@ public:
             return "Saving world to slot: " + std::to_string(index) + "...";
         });
 
-        UI::ConsoleCommand::CandidateListGenerator worlddNpcNamesGen = [this]() {
-            using Suggestion = UI::ConsoleCommand::Suggestion;
+        Logic::ConsoleCommand::CandidateListGenerator worlddNpcNamesGen = [this]() {
+            using Suggestion = Logic::ConsoleCommand::Suggestion;
             auto& worldInstance = m_pEngine->getMainWorld().get();
             auto& scriptEngine = worldInstance.getScriptEngine();
             auto& datFile = scriptEngine.getVM().getDATFile();
-            std::vector<UI::ConsoleCommand::Suggestion> suggestions;
+            std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
             for(const Handle::EntityHandle& npc : scriptEngine.getWorldNPCs())
             {
                 VobTypes::NpcVobInformation npcVobInfo = VobTypes::asNpcVob(worldInstance, npc);
@@ -618,7 +618,7 @@ public:
                     std::replace(npcName.begin(), npcName.end(), ' ', '_');
                     group.push_back(std::move(npcName));
                 }
-                Suggestion suggestion = std::make_shared<UI::NPCSuggestion>(group, npc);
+                Suggestion suggestion = std::make_shared<Logic::NPCSuggestion>(group, npc);
                 suggestions.push_back(suggestion);
             }
             return suggestions;
@@ -635,7 +635,7 @@ public:
 
             auto suggestions = worlddNpcNamesGen();
             auto baseSuggestion = Utils::findSuggestion(suggestions, requested);
-            auto suggestion = std::dynamic_pointer_cast<UI::NPCSuggestion>(baseSuggestion);
+            auto suggestion = std::dynamic_pointer_cast<Logic::NPCSuggestion>(baseSuggestion);
             if (suggestion != nullptr) {
                 worldInstance.takeControlOver(suggestion->npcHandle);
                 VobTypes::NpcVobInformation npcVobInfo = VobTypes::asNpcVob(worldInstance, suggestion->npcHandle);
@@ -705,7 +705,7 @@ public:
                 if (!requestedName.empty())
                 {
                     auto baseSuggestion = Utils::findSuggestion(suggestions, requestedName);
-                    auto suggestion = std::dynamic_pointer_cast<UI::NPCSuggestion>(baseSuggestion);
+                    auto suggestion = std::dynamic_pointer_cast<Logic::NPCSuggestion>(baseSuggestion);
                     if (suggestion != nullptr)
                         entityHandle = suggestion->npcHandle;
                 } else
@@ -775,7 +775,7 @@ public:
                 const std::string& requested = args.at(1);
                 auto suggestions = worlddNpcNamesGen();
                 auto baseSuggestion = Utils::findSuggestion(suggestions, requested);
-                auto suggestion = std::dynamic_pointer_cast<UI::NPCSuggestion>(baseSuggestion);
+                auto suggestion = std::dynamic_pointer_cast<Logic::NPCSuggestion>(baseSuggestion);
                 if (suggestion != nullptr) {
                     npcVobInfo = VobTypes::asNpcVob(worldInstance, suggestion->npcHandle);
                 } else {
@@ -856,10 +856,10 @@ public:
             return "Used " + std::to_string(dmg) + " mana";
         });
 
-        UI::ConsoleCommand::CandidateListGenerator itemNamesGen = [this]() {
+        Logic::ConsoleCommand::CandidateListGenerator itemNamesGen = [this]() {
             auto& se = m_pEngine->getMainWorld().get().getScriptEngine();
             auto& datFile = se.getVM().getDATFile();
-            std::vector<UI::ConsoleCommand::Suggestion> suggestions;
+            std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
             {
                 Daedalus::GameState::ItemHandle dummyHandle = se.getVM().getGameState().createItem();
                 Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(dummyHandle);
@@ -880,7 +880,7 @@ public:
                         // most of the items have description equal to name, so remove one of them
                         aliasList.pop_back();
                     }
-                    UI::ConsoleCommand::Suggestion suggestion = std::make_shared<UI::SuggestionBase>(UI::SuggestionBase {aliasList});
+                    Logic::ConsoleCommand::Suggestion suggestion = std::make_shared<Logic::SuggestionBase>(Logic::SuggestionBase {aliasList});
                     suggestions.push_back(suggestion);
                 });
                 se.getVM().getGameState().removeItem(dummyHandle);

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -335,12 +335,16 @@ public:
 #endif
 
         auto& console = m_pEngine->getConsole();
+        using Command = Logic::Console::Command;
+        using SuggestionBase = Logic::Console::SuggestionBase;
+        using Suggestion = Logic::Console::Suggestion;
+        using CandidateListGenerator = Logic::Console::CandidateListGenerator;
 
         // suggestion generator for an integer range. stop is not included
-        auto rangeGen = [this](int start, int stop, int step = 1) -> std::vector<Logic::ConsoleCommand::Suggestion> {
-            std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
+        auto rangeGen = [this](int start, int stop, int step = 1) -> std::vector<Suggestion> {
+            std::vector<Suggestion> suggestions;
             for (int i = start; i < stop; ++i)
-                suggestions.push_back(std::make_shared<Logic::SuggestionBase>(Logic::SuggestionBase {{std::to_string(i)}}));
+                suggestions.push_back(std::make_shared<SuggestionBase>(SuggestionBase {{std::to_string(i)}}));
             return suggestions;
         };
 
@@ -452,12 +456,12 @@ public:
             return "Hero successfully exported to: hero.json";
         });
 
-        auto waypointNamesGen = [this]() -> std::vector<Logic::ConsoleCommand::Suggestion> {
-            std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
+        auto waypointNamesGen = [this]() -> std::vector<Suggestion> {
+            std::vector<Suggestion> suggestions;
             auto& waypoints = m_pEngine->getMainWorld().get().getWaynet().waypoints;
             for (auto& waypoint : waypoints)
             {
-                Logic::ConsoleCommand::Suggestion suggestion = std::make_shared<Logic::SuggestionBase>(Logic::SuggestionBase {{waypoint.name}});
+                Suggestion suggestion = std::make_shared<SuggestionBase>(SuggestionBase {{waypoint.name}});
                 suggestions.push_back(suggestion);
             }
             return suggestions;
@@ -497,20 +501,20 @@ public:
             return "Hero successfully imported from: hero.json";
         });
 
-        auto zenLevelNamesGen = [this]() -> std::vector<Logic::ConsoleCommand::Suggestion> {
-            using Suggestion = Logic::ConsoleCommand::Suggestion;
+        auto zenLevelNamesGen = [this]() -> std::vector<Suggestion> {
+            using Suggestion = Suggestion;
 
             std::vector<std::string> g1WorldNames = {"WORLD.ZEN", "FREEMINE.ZEN", "OLDMINE.ZEN", "ORCGRAVEYARD.ZEN", "ORCTEMPEL.ZEN"};
             std::vector<std::string> g2WorldNames = {"DRAGONISLAND.ZEN", "NEWWORLD.ZEN", "OLDWORLD.ZEN", "ADDONWORLD.ZEN"};
             auto& worldNames = m_pEngine->getBasicGameType() == Daedalus::GameType::GT_Gothic1 ? g1WorldNames : g2WorldNames;
-            std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
+            std::vector<Suggestion> suggestions;
             for (const auto& worldName : worldNames)
-                suggestions.push_back(std::make_shared<Logic::SuggestionBase>(Logic::SuggestionBase{{worldName}}));
+                suggestions.push_back(std::make_shared<SuggestionBase>(SuggestionBase{{worldName}}));
             return suggestions;
 
             // also works, but ugly
             /*
-            static std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
+            static std::vector<Suggestion> suggestions;
             if (!suggestions.empty())
                 return suggestions;
 
@@ -532,7 +536,7 @@ public:
                     {
                         ZenLoad::oCWorld::readObjectData(world, parser, header.version);
                         if (parser.getWorldMesh())
-                            suggestions.push_back(std::make_shared<Logic::SuggestionBase>(Logic::SuggestionBase{{fileInfo.fileName}}));
+                            suggestions.push_back(std::make_shared<SuggestionBase>(SuggestionBase{{fileInfo.fileName}}));
                     }
                     catch (const std::runtime_error&)
                     {
@@ -596,12 +600,12 @@ public:
             return "Saving world to slot: " + std::to_string(index) + "...";
         });
 
-        Logic::ConsoleCommand::CandidateListGenerator worlddNpcNamesGen = [this]() {
-            using Suggestion = Logic::ConsoleCommand::Suggestion;
+        CandidateListGenerator worlddNpcNamesGen = [this]() {
+            using Suggestion = Suggestion;
             auto& worldInstance = m_pEngine->getMainWorld().get();
             auto& scriptEngine = worldInstance.getScriptEngine();
             auto& datFile = scriptEngine.getVM().getDATFile();
-            std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
+            std::vector<Suggestion> suggestions;
             for(const Handle::EntityHandle& npc : scriptEngine.getWorldNPCs())
             {
                 VobTypes::NpcVobInformation npcVobInfo = VobTypes::asNpcVob(worldInstance, npc);
@@ -618,7 +622,7 @@ public:
                     std::replace(npcName.begin(), npcName.end(), ' ', '_');
                     group.push_back(std::move(npcName));
                 }
-                Suggestion suggestion = std::make_shared<Logic::NPCSuggestion>(group, npc);
+                Suggestion suggestion = std::make_shared<Logic::Console::NPCSuggestion>(group, npc);
                 suggestions.push_back(suggestion);
             }
             return suggestions;
@@ -635,7 +639,7 @@ public:
 
             auto suggestions = worlddNpcNamesGen();
             auto baseSuggestion = Utils::findSuggestion(suggestions, requested);
-            auto suggestion = std::dynamic_pointer_cast<Logic::NPCSuggestion>(baseSuggestion);
+            auto suggestion = std::dynamic_pointer_cast<Logic::Console::NPCSuggestion>(baseSuggestion);
             if (suggestion != nullptr) {
                 worldInstance.takeControlOver(suggestion->npcHandle);
                 VobTypes::NpcVobInformation npcVobInfo = VobTypes::asNpcVob(worldInstance, suggestion->npcHandle);
@@ -705,7 +709,7 @@ public:
                 if (!requestedName.empty())
                 {
                     auto baseSuggestion = Utils::findSuggestion(suggestions, requestedName);
-                    auto suggestion = std::dynamic_pointer_cast<Logic::NPCSuggestion>(baseSuggestion);
+                    auto suggestion = std::dynamic_pointer_cast<Logic::Console::NPCSuggestion>(baseSuggestion);
                     if (suggestion != nullptr)
                         entityHandle = suggestion->npcHandle;
                 } else
@@ -775,7 +779,7 @@ public:
                 const std::string& requested = args.at(1);
                 auto suggestions = worlddNpcNamesGen();
                 auto baseSuggestion = Utils::findSuggestion(suggestions, requested);
-                auto suggestion = std::dynamic_pointer_cast<Logic::NPCSuggestion>(baseSuggestion);
+                auto suggestion = std::dynamic_pointer_cast<Logic::Console::NPCSuggestion>(baseSuggestion);
                 if (suggestion != nullptr) {
                     npcVobInfo = VobTypes::asNpcVob(worldInstance, suggestion->npcHandle);
                 } else {
@@ -856,10 +860,10 @@ public:
             return "Used " + std::to_string(dmg) + " mana";
         });
 
-        Logic::ConsoleCommand::CandidateListGenerator itemNamesGen = [this]() {
+        CandidateListGenerator itemNamesGen = [this]() {
             auto& se = m_pEngine->getMainWorld().get().getScriptEngine();
             auto& datFile = se.getVM().getDATFile();
-            std::vector<Logic::ConsoleCommand::Suggestion> suggestions;
+            std::vector<Suggestion> suggestions;
             {
                 Daedalus::GameState::ItemHandle dummyHandle = se.getVM().getGameState().createItem();
                 Daedalus::GEngineClasses::C_Item& cItem = se.getVM().getGameState().getItem(dummyHandle);
@@ -880,7 +884,7 @@ public:
                         // most of the items have description equal to name, so remove one of them
                         aliasList.pop_back();
                     }
-                    Logic::ConsoleCommand::Suggestion suggestion = std::make_shared<Logic::SuggestionBase>(Logic::SuggestionBase {aliasList});
+                    Suggestion suggestion = std::make_shared<SuggestionBase>(SuggestionBase {aliasList});
                     suggestions.push_back(suggestion);
                 });
                 se.getVM().getGameState().removeItem(dummyHandle);
@@ -903,7 +907,7 @@ public:
                 amount = std::stoi(args[2]);
 
             if (amount < 1)
-                return "invalid ammount " + std::to_string(amount);
+                return "invalid amount " + std::to_string(amount);
 
             auto& se = m_pEngine->getMainWorld().get().getScriptEngine();
 

--- a/src/ui/BarView.cpp
+++ b/src/ui/BarView.cpp
@@ -70,6 +70,16 @@ void UI::BarView::setValue(float v)
     m_Value = v;
 }
 
+void UI::BarView::setValue(int32_t value, int32_t maxValue)
+{
+    if (maxValue != 0)
+    {
+        m_Value = value / static_cast<float>(maxValue);
+    } else {
+        m_Value = 0;
+    }
+}
+
 void UI::BarView::setBackgroundImage(const Textures::Texture& texture)
 {
     m_Background = texture;

--- a/src/ui/BarView.h
+++ b/src/ui/BarView.h
@@ -23,6 +23,12 @@ namespace UI
          */
         void setValue(float v);
 
+        /**
+         * @param value current value
+         * @param maxValue current max Value, if 0 then m_Value will be set to 0
+         */
+        void setValue(int32_t value, int32_t maxValue);
+
         void setBackgroundImage(const Textures::Texture& texture);
         void setBarImage(const Textures::Texture& texture);
 

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -130,13 +130,13 @@ namespace UI
         /**
          * @return Whether the console is currently shown
          */
-        bool isOpen(){ return !m_ConsoleBox.isHidden(); }
-        void setOpen(bool open){ m_ConsoleBox.setHidden(!open); }
+        bool isOpen(){ return m_Open; }
+        void setOpen(bool open);
+        void toggleOpen(){ setOpen(!isOpen()); }
 
         const std::list<std::string>& getOutputLines() { return m_Output; }
         const std::string& getTypedLine() { return m_TypedLine; }
         const std::vector<std::vector<UI::ConsoleCommand::Suggestion>>& getSuggestions() { return m_SuggestionsList; }
-        ConsoleBox& getConsoleBox() { return m_ConsoleBox; }
 
     private:
 
@@ -180,13 +180,12 @@ namespace UI
          */
         std::string m_TypedLine;
 
-        Engine::BaseEngine& m_BaseEngine;
-
         /**
-         * console window
+         * Console active
          */
-        UI::ConsoleBox m_ConsoleBox;
+        bool m_Open;
 
+        Engine::BaseEngine& m_BaseEngine;
     };
 }
 

--- a/src/ui/Console.h
+++ b/src/ui/Console.h
@@ -20,7 +20,11 @@ namespace UI
                 aliasList(aliasList),
                 anyStartsWith(false)
         {}
+
         virtual ~SuggestionBase() {};
+
+        bool operator<(const SuggestionBase& b);
+
         std::vector<std::string> aliasList;
         bool anyStartsWith;
     };

--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -4,7 +4,7 @@
 #include "ConsoleBox.h"
 #include <engine/BaseEngine.h>
 #include "zFont.h"
-#include <ui/Console.h>
+#include <logic/Console.h>
 
 UI::ConsoleBox::ConsoleBox(Engine::BaseEngine& e) :
     View(e)

--- a/src/ui/ConsoleBox.h
+++ b/src/ui/ConsoleBox.h
@@ -9,7 +9,7 @@ namespace UI
     class ConsoleBox : public View
     {
     public:
-        ConsoleBox(Engine::BaseEngine& e, Console& console);
+        ConsoleBox(Engine::BaseEngine& e);
         ~ConsoleBox();
 
         /**
@@ -34,16 +34,6 @@ namespace UI
         int getSelectionIndex() const { return m_CurrentlySelected;}
 
     protected:
-
-        struct
-        {
-            /**
-             * Lines of history + current line
-             */
-            int height;
-        } m_Config;
-
-        Console& m_Console;
 
         /**
          * Console background image

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -15,26 +15,32 @@
 #include <utils/logger.h>
 #include <components/VobClasses.h>
 #include "DialogBox.h"
+#include "LoadingScreen.h"
 #include <logic/PlayerController.h>
 
 UI::Hud::Hud(Engine::BaseEngine& e) :
-        View(e),
-        m_Console(e)
+        View(e)
 {
     Textures::TextureAllocator& alloc = m_Engine.getEngineTextureAlloc();
 
     m_pHealthBar = new BarView(m_Engine);
     m_pManaBar = new BarView(m_Engine);
     m_pEnemyHealthBar = new BarView(m_Engine);
-    m_pClock = new TextView(m_Engine);
     m_pDialogBox = new DialogBox(m_Engine);
     m_pDialogBox->setHidden(true);
+    m_pClock = new TextView(m_Engine);
+    m_pLoadingScreen = new LoadingScreen(m_Engine);
+    m_pLoadingScreen->setHidden(true);
+    m_pConsoleBox = new ConsoleBox(m_Engine);
+    m_pConsoleBox->setHidden(true);
 
     addChild(m_pHealthBar);
     addChild(m_pManaBar);
     addChild(m_pEnemyHealthBar);
-    addChild(m_pClock);
     addChild(m_pDialogBox);
+    addChild(m_pClock);
+    addChild(m_pLoadingScreen);
+    addChild(m_pConsoleBox);
 
     // Initialize status bars
     {
@@ -90,16 +96,20 @@ UI::Hud::~Hud()
     removeChild(m_pHealthBar);
     removeChild(m_pManaBar);
     removeChild(m_pEnemyHealthBar);
-    removeChild(m_pClock);
     removeChild(m_pDialogBox);
+    removeChild(m_pClock);
+    removeChild(m_pLoadingScreen);
+    removeChild(m_pConsoleBox);
 
     popAllMenus();
 
-    delete m_pManaBar;
     delete m_pHealthBar;
+    delete m_pManaBar;
     delete m_pEnemyHealthBar;
-    delete m_pClock;
     delete m_pDialogBox;
+    delete m_pClock;
+    delete m_pLoadingScreen;
+    delete m_pConsoleBox;
 }
 
 void UI::Hud::update(double dt, Engine::Input::MouseState& mstate, Render::RenderConfig& config)
@@ -141,20 +151,19 @@ void UI::Hud::setDateTimeDisplay(const std::string &timeStr)
 
 void UI::Hud::onTextInput(const std::string& text)
 {
-    if(m_Console.isOpen())
-        m_Console.onTextInput(text);
+    if(m_Engine.getConsole().isOpen())
+        m_Engine.getConsole().onTextInput(text);
     else if(!m_MenuChain.empty())
         m_MenuChain.back()->onTextInput(text);
-
 }
 
 void UI::Hud::onInputAction(UI::EInputAction action)
 {
     auto& dialogManager = m_Engine.getMainWorld().get().getDialogManager();
-    if (m_Engine.getHud().getConsole().isOpen())
+    if (m_Engine.getConsole().isOpen())
     {
         if (action == IA_Close || action == IA_ToggleConsole)
-            m_Console.setOpen(false);
+            m_Engine.getConsole().setOpen(false);
         return;
     } else if(!m_MenuChain.empty())
     {
@@ -177,7 +186,7 @@ void UI::Hud::onInputAction(UI::EInputAction action)
             pushMenu<UI::Menu_Main>();
             return;
         case IA_ToggleConsole:
-            m_Engine.getHud().getConsole().setOpen(true);
+            m_Engine.getConsole().setOpen(true);
             return;
         case IA_ToggleStatusMenu:
         {

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -129,19 +129,19 @@ void UI::Hud::update(double dt, Engine::Input::MouseState& mstate, Render::Rende
     View::update(dt, mstate, config);
 }
 
-void UI::Hud::setHealth(float value)
+void UI::Hud::setHealth(int32_t value, int32_t maxValue)
 {
-    m_pHealthBar->setValue(value);
+    m_pHealthBar->setValue(value, maxValue);
 }
 
-void UI::Hud::setMana(float value)
+void UI::Hud::setMana(int32_t value, int32_t maxValue)
 {
-    m_pManaBar->setValue(value);
+    m_pManaBar->setValue(value, maxValue);
 }
 
-void UI::Hud::setEnemyHealth(float value)
+void UI::Hud::setEnemyHealth(int32_t value, int32_t maxValue)
 {
-    m_pEnemyHealthBar->setValue(value);
+    m_pEnemyHealthBar->setValue(value, maxValue);
 }
 
 void UI::Hud::setDateTimeDisplay(const std::string &timeStr)

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -159,7 +159,6 @@ void UI::Hud::onTextInput(const std::string& text)
 
 void UI::Hud::onInputAction(UI::EInputAction action)
 {
-    auto& dialogManager = m_Engine.getMainWorld().get().getDialogManager();
     if (m_Engine.getConsole().isOpen())
     {
         if (action == IA_Close || action == IA_ToggleConsole)
@@ -172,9 +171,9 @@ void UI::Hud::onInputAction(UI::EInputAction action)
         if (close)
             popMenu();
         return;
-    }else if(dialogManager.isDialogActive())
+    }else if(m_Engine.getMainWorld().isValid() && m_Engine.getMainWorld().get().getDialogManager().isDialogActive())
     {
-        dialogManager.onInputAction(action);
+        m_Engine.getMainWorld().get().getDialogManager().onInputAction(action);
         return;
     }
 

--- a/src/ui/Hud.h
+++ b/src/ui/Hud.h
@@ -41,19 +41,22 @@ namespace UI
         void update(double dt, Engine::Input::MouseState &mstate, Render::RenderConfig &config) override;
 
         /**
-         * @param value Value for health-bar in 0..1 range
+         * @param value for health-bar of current player
+         * @param maxValue for health-bar of current player
          */
-        void setHealth(float value);
+        void setHealth(int32_t value, int32_t maxValue);
 
         /**
-         * @param value Value for mana-bar in 0..1 range
+         * @param value for mana-bar of current player
+         * @param maxValue for mana-bar of current player
          */
-        void setMana(float value);
+        void setMana(int value, int maxValue);
 
         /**
-         * @param value Value for enemy health-bar in 0..1 range
+         * @param value for health-bar of enemy entity
+         * @param maxValue for health-bar of enemy entity
          */
-        void setEnemyHealth(float value);
+        void setEnemyHealth(int32_t value, int32_t maxValue);
 
         /**
          * @param timeStr Current time of day to be shown on the hud

--- a/src/ui/Hud.h
+++ b/src/ui/Hud.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Console.h"
+#include <logic/Console.h>
 #include "Menu.h"
 #include "View.h"
 #include <engine/BaseEngine.h>

--- a/src/ui/Hud.h
+++ b/src/ui/Hud.h
@@ -25,14 +25,13 @@ namespace UI
     class Menu_Settings;
     class Menu;
     class DialogBox;
+    class LoadingScreen;
 
     class Hud : public View
     {
     public:
         Hud(Engine::BaseEngine& e);
         ~Hud();
-
-
 
         /**
          * Updates/draws the UI-Views
@@ -74,14 +73,19 @@ namespace UI
         void onTextInput(const std::string& text);
 
         /**
-         * @return Games console
+         * @return Console-Box
          */
-        UI::Console& getConsole(){ return m_Console; }
+        UI::ConsoleBox& getConsoleBox(){ return *m_pConsoleBox; }
 
         /**
          * @return Dialog-box
          */
         DialogBox& getDialogBox(){ return *m_pDialogBox; }
+
+        /**
+         * LoadingScreen
+         */
+        LoadingScreen& getLoadingScreen(){ return *m_pLoadingScreen; }
 
         /**
          * Controls visibility of gameplay-hud
@@ -132,20 +136,8 @@ namespace UI
         BarView* m_pEnemyHealthBar;
         TextView* m_pClock;
         DialogBox* m_pDialogBox;
-
-        /**
-         * Console
-         */
-        UI::Console m_Console;
-
-        /**
-         * Menus
-         */
-        Menu_Status* m_pStatusMenu;
-        Menu_Main* m_pMainMenu;
-        Menu_Load* m_pMenuLoad;
-        Menu_Save* m_pMenuSave;
-        Menu_Settings* m_pMenuSettings;
+        LoadingScreen* m_pLoadingScreen;
+        ConsoleBox* m_pConsoleBox;
 
         /**
          * Chain of opened menus. Only the last one will be rendered and processed

--- a/src/ui/LoadingScreen.cpp
+++ b/src/ui/LoadingScreen.cpp
@@ -1,0 +1,21 @@
+//
+// Created by markusobi on 19.05.17.
+//
+
+#include "LoadingScreen.h"
+#include <engine/BaseEngine.h>
+#include <render/RenderSystem.h>
+
+UI::LoadingScreen::LoadingScreen(Engine::BaseEngine &e) : ImageView(e) {
+    Handle::TextureHandle bgr = e.getEngineTextureAlloc().loadTextureVDF("LOADING.TGA");
+    setImage(e.getEngineTextureAlloc().getTexture(bgr).m_TextureHandle);
+}
+
+UI::LoadingScreen::~LoadingScreen() {
+}
+
+void UI::LoadingScreen::update(double dt, Engine::Input::MouseState& mstate, Render::RenderConfig& config) {
+    m_ImageWidth = config.state.viewWidth;
+    m_ImageHeight = config.state.viewHeight;
+    ImageView::update(dt, mstate, config);
+}

--- a/src/ui/LoadingScreen.h
+++ b/src/ui/LoadingScreen.h
@@ -1,0 +1,25 @@
+//
+// Created by markusobi on 19.05.17.
+//
+#pragma once
+#include "ImageView.h"
+
+namespace UI
+{
+    class LoadingScreen : public ImageView
+    {
+    public:
+        LoadingScreen(Engine::BaseEngine& e);
+        ~LoadingScreen();
+
+        /**
+         * Updates/draws the UI-Views
+         * @param dt time since last frame
+         * @param mstate mouse-state
+         */
+        void update(double dt, Engine::Input::MouseState& mstate, Render::RenderConfig& config) override;
+
+    protected:
+    };
+}
+

--- a/src/ui/Menu.cpp
+++ b/src/ui/Menu.cpp
@@ -176,7 +176,7 @@ bool UI::Menu::loadMenuDAT()
 
     // Load DAT-File...
     m_pVM = new Daedalus::DaedalusVM(datFile);
-    Daedalus::registerGothicEngineClasses(*m_pVM, Daedalus::GameType::GT_Gothic2);
+    Daedalus::registerGothicEngineClasses(*m_pVM);
 
     return true;
 }

--- a/src/ui/Menu_Main.cpp
+++ b/src/ui/Menu_Main.cpp
@@ -46,7 +46,7 @@ void Menu_Main::onCustomAction(const std::string& action)
         if (worldHandle.isValid())
         {
             m_Engine.setMainWorld(worldHandle);
-            auto player = worldHandle.get().getScriptEngine().createDefaultPlayer("EBR_108_VELAYA");
+            auto player = worldHandle.get().getScriptEngine().createDefaultPlayer("PC_HERO");
             worldHandle.get().takeControlOver(player);
             // reset the clock to the default starting time
             m_Engine.getGameClock().resetNewGame();

--- a/src/ui/Menu_Main.cpp
+++ b/src/ui/Menu_Main.cpp
@@ -35,6 +35,7 @@ void Menu_Main::onCustomAction(const std::string& action)
 {
     if(action == "NEW_GAME")
     {
+        Engine::SavegameManager::invalidateCurrentSlotIndex();
         getHud().popMenu();
 
         LogInfo() << "Starting new game...";
@@ -44,6 +45,7 @@ void Menu_Main::onCustomAction(const std::string& action)
         if (worldHandle.isValid())
         {
             m_Engine.setMainWorld(worldHandle);
+            worldHandle.get().getScriptEngine().createDefaultPlayer();
             // reset the clock to the default starting time
             m_Engine.getGameClock().resetNewGame();
         } else

--- a/src/ui/Menu_Main.cpp
+++ b/src/ui/Menu_Main.cpp
@@ -43,7 +43,7 @@ void Menu_Main::onCustomAction(const std::string& action)
         if (worldHandle.isValid())
         {
             m_Engine.getSession().setMainWorld(worldHandle);
-            auto player = worldHandle.get().getScriptEngine().createDefaultPlayer("PC_HERO");
+            auto player = worldHandle.get().getScriptEngine().createDefaultPlayer(m_Engine.getEngineArgs().playerScriptname);
             worldHandle.get().takeControlOver(player);
         } else
         {

--- a/src/ui/Menu_Main.cpp
+++ b/src/ui/Menu_Main.cpp
@@ -38,18 +38,13 @@ void Menu_Main::onCustomAction(const std::string& action)
         LogInfo() << "Starting new game...";
         getHud().popMenu();
 
-        // TODO: extract method: clearSession(): invalidates slot index, remove active world, inactive worlds...
-        Engine::SavegameManager::invalidateCurrentSlotIndex();
-        m_Engine.removeAllWorlds();
-
-        Handle::WorldHandle worldHandle = m_Engine.loadWorld(m_Engine.getEngineArgs().startupZEN);
+        m_Engine.resetSession();
+        Handle::WorldHandle worldHandle = m_Engine.getSession().addWorld(m_Engine.getEngineArgs().startupZEN);
         if (worldHandle.isValid())
         {
-            m_Engine.setMainWorld(worldHandle);
+            m_Engine.getSession().setMainWorld(worldHandle);
             auto player = worldHandle.get().getScriptEngine().createDefaultPlayer("PC_HERO");
             worldHandle.get().takeControlOver(player);
-            // reset the clock to the default starting time
-            m_Engine.getGameClock().resetNewGame();
         } else
         {
             LogError() << "Failed to add given startup world, world handle is invalid!";

--- a/src/ui/Menu_Main.cpp
+++ b/src/ui/Menu_Main.cpp
@@ -45,7 +45,8 @@ void Menu_Main::onCustomAction(const std::string& action)
         if (worldHandle.isValid())
         {
             m_Engine.setMainWorld(worldHandle);
-            worldHandle.get().getScriptEngine().createDefaultPlayer();
+            auto player = worldHandle.get().getScriptEngine().createDefaultPlayer("EBR_108_VELAYA");
+            worldHandle.get().takeControlOver(player);
             // reset the clock to the default starting time
             m_Engine.getGameClock().resetNewGame();
         } else

--- a/src/ui/Menu_Main.cpp
+++ b/src/ui/Menu_Main.cpp
@@ -35,12 +35,13 @@ void Menu_Main::onCustomAction(const std::string& action)
 {
     if(action == "NEW_GAME")
     {
-        Engine::SavegameManager::invalidateCurrentSlotIndex();
+        LogInfo() << "Starting new game...";
         getHud().popMenu();
 
-        LogInfo() << "Starting new game...";
-
+        // TODO: extract method: clearSession(): invalidates slot index, remove active world, inactive worlds...
+        Engine::SavegameManager::invalidateCurrentSlotIndex();
         m_Engine.removeAllWorlds();
+
         Handle::WorldHandle worldHandle = m_Engine.loadWorld(m_Engine.getEngineArgs().startupZEN);
         if (worldHandle.isValid())
         {

--- a/src/ui/Menu_Main.cpp
+++ b/src/ui/Menu_Main.cpp
@@ -38,9 +38,18 @@ void Menu_Main::onCustomAction(const std::string& action)
         getHud().popMenu();
 
         LogInfo() << "Starting new game...";
-        m_Engine.loadWorld(m_Engine.getEngineArgs().startupZEN);
-        // reset the clock to the default starting time
-        m_Engine.getGameClock().resetNewGame();
+
+        m_Engine.removeAllWorlds();
+        Handle::WorldHandle worldHandle = m_Engine.loadWorld(m_Engine.getEngineArgs().startupZEN);
+        if (worldHandle.isValid())
+        {
+            m_Engine.setMainWorld(worldHandle);
+            // reset the clock to the default starting time
+            m_Engine.getGameClock().resetNewGame();
+        } else
+        {
+            LogError() << "Failed to add given startup world, world handle is invalid!";
+        }
 
     }else if(action == "MENU_SAVEGAME_LOAD")
     {
@@ -55,4 +64,9 @@ void Menu_Main::onCustomAction(const std::string& action)
     {
         Engine::Platform::setQuit(true);
     }
+}
+
+Daedalus::GameType Menu_Main::determineGameType() {
+    bool isGothic2 = m_pVM->getDATFile().hasSymbolName("C_Menu_Item.hideOnValue");
+    return isGothic2 ? Daedalus::GameType::GT_Gothic2 : Daedalus::GameType::GT_Gothic1;
 }

--- a/src/ui/Menu_Main.h
+++ b/src/ui/Menu_Main.h
@@ -29,6 +29,10 @@ namespace UI
          */
         static Menu_Main* create(Engine::BaseEngine& e);
 
+        /**
+         * @return the gametype of the Menu's VM (based on the existence of Gothic 2 specific symbols)
+         */
+        Daedalus::GameType determineGameType();
 
         virtual void onCustomAction(const std::string& action) override;
     protected:

--- a/src/ui/Menu_Save.cpp
+++ b/src/ui/Menu_Save.cpp
@@ -78,7 +78,7 @@ void Menu_Save::onCustomAction(const std::string& action)
 		else
 		{
 			m_isWaitingForSaveName = false;
-            Engine::SavegameManager::saveToSaveGameSlot(index, m_SaveName);
+            m_Engine.getSession().saveToSlot(index, m_SaveName);
             // close menus after saving
             getHud().popAllMenus();
 		}

--- a/src/ui/Menu_Save.cpp
+++ b/src/ui/Menu_Save.cpp
@@ -78,7 +78,7 @@ void Menu_Save::onCustomAction(const std::string& action)
 		else
 		{
 			m_isWaitingForSaveName = false;
-            m_Engine.getSession().saveToSlot(index, m_SaveName);
+            Engine::SavegameManager::saveToSlot(index, m_SaveName);
             // close menus after saving
             getHud().popAllMenus();
 		}

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -457,7 +457,8 @@ bool Utils::containsLike(const std::string& searchSpace, const std::string& part
 }
 
 
-UI::ConsoleCommand::Suggestion Utils::findSuggestion(const std::vector<UI::ConsoleCommand::Suggestion>& suggestions, const std::string& name){
+Logic::ConsoleCommand::Suggestion Utils::findSuggestion(const std::vector<Logic::ConsoleCommand::Suggestion>& suggestions,
+                                                        const std::string& name){
     for (auto& suggestion : suggestions)
     {
         auto& aliasList = suggestion->aliasList;

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -457,7 +457,7 @@ bool Utils::containsLike(const std::string& searchSpace, const std::string& part
 }
 
 
-Logic::ConsoleCommand::Suggestion Utils::findSuggestion(const std::vector<Logic::ConsoleCommand::Suggestion>& suggestions,
+Logic::Console::Suggestion Utils::findSuggestion(const std::vector<Logic::Console::Suggestion>& suggestions,
                                                         const std::string& name){
     for (auto& suggestion : suggestions)
     {

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -484,7 +484,7 @@ namespace Utils
      * @param suggestions suggestions to search in
      * @param name token to find
      */
-    Logic::ConsoleCommand::Suggestion findSuggestion(const std::vector<Logic::ConsoleCommand::Suggestion>& suggestions,
+    Logic::Console::Suggestion findSuggestion(const std::vector<Logic::Console::Suggestion>& suggestions,
                                                      const std::string& name);
 
     /**

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -14,7 +14,7 @@
 #include <memory>
 #include <chrono>
 #include <sstream>
-#include <ui/Console.h>
+#include <logic/Console.h>
 
 namespace Utils
 {
@@ -484,7 +484,8 @@ namespace Utils
      * @param suggestions suggestions to search in
      * @param name token to find
      */
-    UI::ConsoleCommand::Suggestion findSuggestion(const std::vector<UI::ConsoleCommand::Suggestion>& suggestions, const std::string& name);
+    Logic::ConsoleCommand::Suggestion findSuggestion(const std::vector<Logic::ConsoleCommand::Suggestion>& suggestions,
+                                                     const std::string& name);
 
     /**
      * performs case insensitive euqal check


### PR DESCRIPTION
- loading a game: player now looks in the correct direction
- new command: `control <npc>`. control any NPC (like gothic's "o" cheat). Currently crashes on monsters, due to animations not working. Works on humans & orcs.
- fixed command `switchlevel <zenfilename>`. Supposed to work like switching worlds when entering certain areas. The progress (npcknowsinfo, playerstats & inventory, scriptengine) the hero made so far should be 100% transfered. This means you can now get Ian's list in the oldmine and bring it to Diego. Startposition on levelswitch is not handled correctly atm.
- starting/loading a game now resets certain settings (game&clock speed)
- saving a game should now save all worlds.
- on world switch saved worlds are also retrieved if present
- the game now starts without any world loaded. "start new game" will start the world specified on the command line.
- fixed mana/health bar display if max value is 0
- fixed crash in handling message `ST_TurnToVob` / `ST_GotoVob`, if target entity was removed from the world in the meantime.
- fixed crash when parsing zenworld `orcgraveyard.zen`
- added autocomplete for `switchlevel` and `set clock`
- added REGoth command line option `-p`/`--player` to start as different NPC (default is `PC_HERO`)