### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,75 +1,16 @@
+---
 Language: Cpp
-AccessModifierOffset: -4
-AlignAfterOpenBracket: false
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: false
-AlignOperands: true
-AlignTrailingComments: false
-AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
-BinPackArguments: true
-BinPackParameters: true
-BraceWrapping:
-  AfterClass:      true
-  AfterControlStatement: true
-  AfterEnum:       true
-  AfterFunction:   true
-  AfterNamespace:  true
-  AfterObjCDeclaration: true
-  AfterStruct:     true
-  AfterUnion:      false
-  BeforeCatch:     true
-  BeforeElse:      true
-  IndentBraces:    false
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Allman
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-ColumnLimit: 0
-CommentPragmas: '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 0
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: false
-DisableFormat: false
-ExperimentalAutoDetectBinPacking: false
-ForEachMacros: [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IndentCaseLabels: true
+BasedOnStyle: Google
 IndentWidth: 4
-IndentWrappedFunctionNames: false
-KeepEmptyLinesAtTheStartOfBlocks: true
-MacroBlockBegin: ''
-MacroBlockEnd: ''
-MaxEmptyLinesToKeep: 2
-NamespaceIndentation: None
-PenaltyBreakBeforeFirstCallParameter: 100
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 10000
-PointerAlignment: Left
-ReflowComments: true
+# don't indent public, private and protected
+AccessModifierOffset: -4
+BreakBeforeBraces: Allman
+# respect user choice for line breaking
+ColumnLimit: 0
+BreakConstructorInitializersBeforeComma: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 SortIncludes: false
-SpaceAfterCStyleCast: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles: true
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard: Cpp11
-TabWidth: 4
-UseTab: Never
+PointerAlignment: Left
+NamespaceIndentation: All
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(BGFX_DEBUG 1)
 add_definitions(-D__STDC_CONSTANT_MACROS)
 add_definitions(-D__STDC_LIMIT_MACROS)
 
+# clang-format
+include(cmake/clang-format.cmake)
+
 if(EMSCRIPTEN)
 
     # cmake -DCMAKE_TOOLCHAIN_FILE="/usr/lib/emscripten/cmake/Modules/Platform/Emscripten.cmake" ..

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -7,7 +7,7 @@ find_program(CLANG_FORMAT "clang-format")
 if(CLANG_FORMAT)
   add_custom_target(
     clang-format
-    COMMAND echo
+    COMMAND ${CLANG_FORMAT}
     -i
     -style=file
     ${ALL_CXX_SOURCE_FILES}

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,13 +1,13 @@
 file(GLOB_RECURSE
      ALL_CXX_SOURCE_FILES
-     *.[chi]pp *.[chi]xx *.cc *.hh *.ii *.[CHI]
+     ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h
      )
 
 find_program(CLANG_FORMAT "clang-format")
 if(CLANG_FORMAT)
   add_custom_target(
     clang-format
-    COMMAND ${CLANG_FORMAT}
+    COMMAND echo
     -i
     -style=file
     ${ALL_CXX_SOURCE_FILES}

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,0 +1,15 @@
+file(GLOB_RECURSE
+     ALL_CXX_SOURCE_FILES
+     *.[chi]pp *.[chi]xx *.cc *.hh *.ii *.[CHI]
+     )
+
+find_program(CLANG_FORMAT "clang-format")
+if(CLANG_FORMAT)
+  add_custom_target(
+    clang-format
+    COMMAND ${CLANG_FORMAT}
+    -i
+    -style=file
+    ${ALL_CXX_SOURCE_FILES}
+    )
+endif()

--- a/create_git_hooks.sh
+++ b/create_git_hooks.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+GIT_REPO_DIR=$(git rev-parse --show-toplevel)
+
+cd "$GIT_REPO_DIR"
+
+for hook in hooks/*
+do
+    SYMLINK_HOOK=.git/$hook
+    if [ -f $hook ] && [ ! -e "$SYMLINK_HOOK" ] && [ ! -L "$SYMLINK_HOOK" ]
+    then
+        eval "ln -s $hook .git/hooks/"
+    fi
+done

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+CXX_CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -Ee "\.(c|cpp|h)$" | paste -sd ' ')
+CLANG_FORMAT_BIN=$(command -v clang-format)
+
+if [ $CLANG_FORMAT_BIN ] && [[ $CXX_CHANGED_FILES ]]; then
+    eval $CLANG_FORMAT_BIN -i -style=file "${CXX_CHANGED_FILES}"
+fi


### PR DESCRIPTION
This pull requests adds a make target that can be used for formatting every source file with:

`make clang-format`

Additionally I added a git pre-commit hook that runs clang-format on added/changed git files and a simple bash script that symlinks the hook to `.git/hooks/*`

Rational: #79