### PR TITLE
Dialog fixes

### DIFF
--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -100,7 +100,7 @@ std::vector<ChoiceEntry> DialogManager::evaluateConditions(Daedalus::GameState::
             entry.info = infoHandle;
             entry.important = static_cast<bool>(info.important);
 
-            if(info.important)
+            if(entry.important)
             {
                 entry.text = "<important>";
             }
@@ -280,7 +280,15 @@ void DialogManager::assessTalk(Daedalus::GameState::NpcHandle target)
 
     LogInfo() << "Trying to talk to : " << VobTypes::getScriptObject(targetVob).name[0];
 
-    // TODO gothic1: check for monster without infos
+    // TODO use guild constants enum
+    const auto GIL_SEPERATOR_HUM = getVM().getDATFile().getSymbolByName("GIL_SEPERATOR_HUM").getInt();
+
+    // Exit-Condition for monsters without infos (missing in gothic1 B_AssessTalk)
+    if (getVM().getGameState().getNpc(target).guild > GIL_SEPERATOR_HUM)
+    {
+        if (!checkInfo(target, false) && !checkInfo(target, true))
+            return;
+    }
 
     getVM().setInstance("self", ZMemory::toBigHandle(targetVob.playerController->getScriptHandle()), Daedalus::IC_Npc);
     getVM().setInstance("other", ZMemory::toBigHandle(playerVob.playerController->getScriptHandle()), Daedalus::IC_Npc);

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -24,6 +24,7 @@ const char* OU_FILE_2 = "/_work/data/Scripts/content/CUTSCENE/OU.DAT";
 
 using namespace Logic;
 using ChoiceEntry = DialogManager::ChoiceEntry;
+using Daedalus::GameState::NpcHandle;
 
 DialogManager::DialogManager(World::WorldInstance& world) :
     m_World(world)
@@ -49,7 +50,7 @@ DialogManager::~DialogManager()
     m_ActiveSubtitleBox = nullptr;
 }
 
-bool DialogManager::checkInfo(Daedalus::GameState::NpcHandle target, bool important)
+bool DialogManager::checkInfo(NpcHandle target, bool important)
 {
     VobTypes::NpcVobInformation playerVob = VobTypes::asNpcVob(m_World, m_World.getScriptEngine().getPlayerEntity());
     auto infos = m_ScriptDialogMananger->getInfos(target);
@@ -57,8 +58,8 @@ bool DialogManager::checkInfo(Daedalus::GameState::NpcHandle target, bool import
     return !list.empty();
 }
 
-std::vector<ChoiceEntry> DialogManager::evaluateConditions(Daedalus::GameState::NpcHandle player,
-                                                           Daedalus::GameState::NpcHandle target,
+std::vector<ChoiceEntry> DialogManager::evaluateConditions(NpcHandle player,
+                                                           NpcHandle target,
                                                            const std::vector<Daedalus::GameState::InfoHandle>& infos,
                                                            bool important, size_t maxInfos)
 {
@@ -110,7 +111,7 @@ std::vector<ChoiceEntry> DialogManager::evaluateConditions(Daedalus::GameState::
     return entries;
 }
 
-void DialogManager::onAIProcessInfos(Daedalus::GameState::NpcHandle target)
+void DialogManager::onAIProcessInfos(NpcHandle target)
 {
     auto infos = m_ScriptDialogMananger->getInfos(target);
 
@@ -136,7 +137,7 @@ void DialogManager::onAIProcessInfos(Daedalus::GameState::NpcHandle target)
     flushChoices();
 }
 
-void DialogManager::queueDialogEndEvent(Daedalus::GameState::NpcHandle target)
+void DialogManager::queueDialogEndEvent(NpcHandle target)
 {
     // Push the actual conversation-message
     EventMessages::ConversationMessage endDialogMessage;
@@ -150,8 +151,7 @@ void DialogManager::queueDialogEndEvent(Daedalus::GameState::NpcHandle target)
         queueVob.playerController->getEM().onMessage(endDialogMessage);
 }
 
-void DialogManager::onAIOutput(Daedalus::GameState::NpcHandle self, Daedalus::GameState::NpcHandle target,
-                               const ZenLoad::oCMsgConversationData& msg)
+void DialogManager::onAIOutput(NpcHandle self, NpcHandle target, const ZenLoad::oCMsgConversationData& msg)
 {
     LogInfo() << getGameState().getNpc(self).name[0] << ": " << msg.text;
     // Make a new message for the talking NPC
@@ -269,7 +269,7 @@ void DialogManager::performChoice(size_t choice)
     }
 }
 
-void DialogManager::assessTalk(Daedalus::GameState::NpcHandle target)
+void DialogManager::assessTalk(NpcHandle target)
 {
     if(m_DialogActive)
         return;
@@ -405,7 +405,7 @@ void DialogManager::flushChoices()
         m_World.getEngine()->getHud().getDialogBox().addChoice(e);
 }
 
-void DialogManager::updateChoices(Daedalus::GameState::NpcHandle target)
+void DialogManager::updateChoices(NpcHandle target)
 {
     if (!m_ProcessInfos)
         return;
@@ -472,7 +472,7 @@ void DialogManager::setCurrentMessage(std::shared_ptr<EventMessages::Conversatio
     m_Interaction.currentDialogMessage = message;
 }
 
-void DialogManager::startDialog(Daedalus::GameState::NpcHandle npc, Daedalus::GameState::NpcHandle player)
+void DialogManager::startDialog(NpcHandle npc, NpcHandle player)
 {
     LogInfo() << "Started talking with: " << getGameState().getNpc(npc).name[0];
     m_Interaction.importantKnown.clear();

--- a/src/logic/DialogManager.h
+++ b/src/logic/DialogManager.h
@@ -53,8 +53,7 @@ namespace Logic
         bool init();
 
         /**
-         * Updates the boxes according to the choices taken by the user
-         * @param dt time since last frame
+         * Currently no-op
          */
         void update(double dt);
 
@@ -65,9 +64,14 @@ namespace Logic
         void onInputAction(UI::EInputAction action);
 
         /**
+         * calls B_AssessTalk
+         */
+        void assessTalk(Daedalus::GameState::NpcHandle target);
+
+        /**
          * Start dialog
          */
-        void startDialog(Daedalus::GameState::NpcHandle target);
+        void startDialog(Daedalus::GameState::NpcHandle npc, Daedalus::GameState::NpcHandle player);
 
         /**
          * exit the dialog
@@ -113,12 +117,6 @@ namespace Logic
         void clearChoices();
 
         /**
-         * Adds a single choice to the box
-         * @param entry Choice entry.
-         */
-        void addChoice(ChoiceEntry& entry);
-
-        /**
          * Sets the current Dialog Message. To be able to cancel it
          */
         void setCurrentMessage(std::shared_ptr<EventMessages::ConversationMessage> message);
@@ -154,7 +152,7 @@ namespace Logic
 
         /**
          * Performs a choice selected by the user
-         * @param choice Choice index to perform (m_Interaction.infos)
+         * @param index of the choice to perform
          */
         void performChoice(size_t choice);
 
@@ -186,6 +184,8 @@ namespace Logic
          * @param infos List of choices the player has to select
          */
         void onAIProcessInfos(Daedalus::GameState::NpcHandle self, std::vector<Daedalus::GameState::InfoHandle> infos);
+
+        std::vector<ChoiceEntry> evaluateConditions(std::vector<Daedalus::GameState::InfoHandle> infos, bool important);
 
         /**
          * Currently active subtitle box
@@ -222,6 +222,9 @@ namespace Logic
              * Remember all already chosen important infos, for the current Dialog
              */
             std::set<Daedalus::GameState::InfoHandle> importantKnown;
+
+            bool autoPlayImportant;
+
         } m_Interaction;
 
         /**

--- a/src/logic/DialogManager.h
+++ b/src/logic/DialogManager.h
@@ -4,6 +4,7 @@
 #include <daedalus/DaedalusDialogManager.h>
 #include <json.hpp>
 #include <logic/messages/EventMessage.h>
+#include <limits>
 
 using json = nlohmann::json;
 
@@ -169,6 +170,13 @@ namespace Logic
          */
         void onAIOutput(Daedalus::GameState::NpcHandle self, Daedalus::GameState::NpcHandle target, const ZenLoad::oCMsgConversationData& msg);
 
+        /**
+         * evaluates all C_Info conditions and returns whether any important/non-important infos are available
+         * @param target
+         * @param important the type to check for
+         */
+        bool checkInfo(Daedalus::GameState::NpcHandle target, bool important);
+
     protected:
 
         /**
@@ -183,9 +191,12 @@ namespace Logic
          * @param self NPC who started the interaction
          * @param infos List of choices the player has to select
          */
-        void onAIProcessInfos(Daedalus::GameState::NpcHandle self, std::vector<Daedalus::GameState::InfoHandle> infos);
+        void onAIProcessInfos(Daedalus::GameState::NpcHandle self);
 
-        std::vector<ChoiceEntry> evaluateConditions(std::vector<Daedalus::GameState::InfoHandle> infos, bool important);
+        std::vector<ChoiceEntry> evaluateConditions(Daedalus::GameState::NpcHandle player,
+                                                    Daedalus::GameState::NpcHandle target,
+                                                    const std::vector<Daedalus::GameState::InfoHandle>& infos,
+                                                    bool important, size_t maxInfos = std::numeric_limits<size_t>::max());
 
         /**
          * Currently active subtitle box
@@ -206,7 +217,6 @@ namespace Logic
 
             Daedalus::GameState::NpcHandle player;
             Daedalus::GameState::NpcHandle target;
-            std::vector<Daedalus::GameState::InfoHandle> infos;
             /**
              * Handle to the the current Dialogoption
              * Used to identify which Subchoices to show or to check if there are any

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1661,6 +1661,9 @@ bool PlayerController::EV_Conversation(std::shared_ptr<EventMessages::Conversati
             return false;
         }
             break;
+        case ConversationMessage::ST_OutputEnd:
+            m_World.getDialogManager().updateChoices(getScriptHandle());
+            return true;
         case ConversationMessage::ST_Cutscene:
             break;
         case ConversationMessage::ST_WaitTillEnd:
@@ -2234,7 +2237,7 @@ void PlayerController::setupKeyBindings()
                 if(npc.playerController->getBodyState() == BS_STAND)
                 {
                     Daedalus::GameState::NpcHandle shnpc = VobTypes::getScriptHandle(npc);
-                    m_World.getDialogManager().startDialog(shnpc);
+                    m_World.getDialogManager().assessTalk(shnpc);
                 }else if(npc.playerController->getBodyState() == BS_UNCONSCIOUS
                         || npc.playerController->getBodyState() == BS_DEAD)
                 {

--- a/src/logic/messages/EventMessage.h
+++ b/src/logic/messages/EventMessage.h
@@ -509,6 +509,7 @@ namespace Logic
                 ST_LookAt,
                 ST_Output,
                 ST_OutputMonolog,
+                ST_OutputEnd,
                 ST_Cutscene,
                 ST_WaitTillEnd,
                 ST_Ask,

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -1174,7 +1174,8 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 
         NpcHandle hself = ZMemory::handleCast<NpcHandle>(vm.getDATFile().getSymbolByIndex(self).instanceDataHandle);
 
-        pWorld->getDialogManager().updateChoices(hself);
+        auto player = VobTypes::asNpcVob(engine->getMainWorld().get(), engine->getMainWorld().get().getScriptEngine().getPlayerEntity());
+        pWorld->getDialogManager().startDialog(hself, player.playerController->getScriptHandle());
     });
 
 

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -1134,12 +1134,12 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
     });
 
     vm->registerExternalFunction("wld_getguildattitude", [=](Daedalus::DaedalusVM& vm) {
-        int victim = vm.popDataValue();
-        int attacker = vm.popDataValue();
-        const size_t numGuilds = 16;
-        // attacker is row index, victim is column index
+        int32_t victimGuild = vm.popDataValue();
+        int32_t aggressorGuild = vm.popDataValue();
+        const uint32_t numGuilds = 16;
+        // aggressorGuild is the row index, victimGuild is the column index
         // TODO use copy of GIL_ATTITUDES Matrix instead
-        auto attitude = vm.getDATFile().getSymbolByName("GIL_ATTITUDES").getInt(attacker * numGuilds + victim);
+        auto attitude = vm.getDATFile().getSymbolByName("GIL_ATTITUDES").getInt(aggressorGuild * numGuilds + victimGuild);
         vm.setReturn(attitude);
     });
 

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -970,6 +970,15 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         pWorld->getDialogManager().queueDialogEndEvent(hself);
     });
 
+    vm->registerExternalFunction("npc_checkinfo", [=](Daedalus::DaedalusVM& vm) {
+        int important = vm.popDataValue();
+        int32_t npc = vm.popVar();
+        NpcHandle npcHandle = ZMemory::handleCast<NpcHandle>
+                (vm.getDATFile().getSymbolByIndex(npc).instanceDataHandle);
+        bool hasInfos = pWorld->getDialogManager().checkInfo(npcHandle, important);
+        vm.setReturn(hasInfos);
+    });
+
 	vm->registerExternalFunction("wld_insertnpc", [=](Daedalus::DaedalusVM& vm){
 		std::string spawnpoint = vm.popString();
 		uint32_t npcinstance = vm.popDataValue();
@@ -1122,6 +1131,16 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
     vm->registerExternalFunction("wld_getday", [=](Daedalus::DaedalusVM& vm) {
         if(verbose) LogInfo() << "wld_getday";
         vm.setReturn(pWorld->getEngine()->getGameClock().getDay());
+    });
+
+    vm->registerExternalFunction("wld_getguildattitude", [=](Daedalus::DaedalusVM& vm) {
+        int victim = vm.popDataValue();
+        int attacker = vm.popDataValue();
+        const size_t numGuilds = 16;
+        // attacker is row index, victim is column index
+        // TODO use copy of GIL_ATTITUDES Matrix instead
+        auto attitude = vm.getDATFile().getSymbolByName("GIL_ATTITUDES").getInt(attacker * numGuilds + victim);
+        vm.setReturn(attitude);
     });
 
     vm->registerExternalFunction("npc_hasequippedmeleeweapon", [=](Daedalus::DaedalusVM& vm) {

--- a/src/logic/scriptExternals/Stubs.cpp
+++ b/src/logic/scriptExternals/Stubs.cpp
@@ -191,14 +191,6 @@ void ::Logic::ScriptExternals::registerStubs(Daedalus::DaedalusVM& vm, bool verb
         vm.setReturn(0);
     });
 
-    vm.registerExternalFunction("npc_checkinfo", [=](Daedalus::DaedalusVM& vm) {
-        if(verbose) LogInfo() << "npc_checkinfo";
-        int important = vm.popDataValue(); if(verbose) LogInfo() << "important: " << important;
-        uint32_t arr_npc;
-        int32_t npc = vm.popVar(arr_npc); if(verbose) LogInfo() << "npc: " << npc;
-        vm.setReturn(0);
-    });
-
     vm.registerExternalFunction("npc_checkoffermission", [=](Daedalus::DaedalusVM& vm) {
         if(verbose) LogInfo() << "npc_checkoffermission";
         int important = vm.popDataValue(); if(verbose) LogInfo() << "important: " << important;
@@ -257,7 +249,7 @@ void ::Logic::ScriptExternals::registerStubs(Daedalus::DaedalusVM& vm, bool verb
         int32_t other = vm.popVar(arr_other); if(verbose) LogInfo() << "other: " << other;
         uint32_t arr_self;
         int32_t self = vm.popVar(arr_self); if(verbose) LogInfo() << "self: " << self;
-        vm.setReturn(0);
+        vm.setReturn(vm.getDATFile().getSymbolByName("ATT_NEUTRAL").getInt());
     });
 
     vm.registerExternalFunction("npc_getbodystate", [=](Daedalus::DaedalusVM& vm) {
@@ -280,7 +272,7 @@ void ::Logic::ScriptExternals::registerStubs(Daedalus::DaedalusVM& vm, bool verb
         int32_t npc2 = vm.popVar(arr_npc2); if(verbose) LogInfo() << "npc2: " << npc2;
         uint32_t arr_npc1;
         int32_t npc1 = vm.popVar(arr_npc1); if(verbose) LogInfo() << "npc1: " << npc1;
-        vm.setReturn(0);
+        vm.setReturn(vm.getDATFile().getSymbolByName("ATT_NEUTRAL").getInt());
     });
 
     vm.registerExternalFunction("npc_getheighttoitem", [=](Daedalus::DaedalusVM& vm) {
@@ -337,7 +329,7 @@ void ::Logic::ScriptExternals::registerStubs(Daedalus::DaedalusVM& vm, bool verb
         int32_t other = vm.popVar(arr_other); if(verbose) LogInfo() << "other: " << other;
         uint32_t arr_self;
         int32_t self = vm.popVar(arr_self); if(verbose) LogInfo() << "self: " << self;
-        vm.setReturn(0);
+        vm.setReturn(vm.getDATFile().getSymbolByName("ATT_NEUTRAL").getInt());
     });
 
     vm.registerExternalFunction("npc_getportalguild", [=](Daedalus::DaedalusVM& vm) {
@@ -838,7 +830,7 @@ void ::Logic::ScriptExternals::registerStubs(Daedalus::DaedalusVM& vm, bool verb
         if(verbose) LogInfo() << "wld_getguildattitude";
         int guild2 = vm.popDataValue(); if(verbose) LogInfo() << "guild2: " << guild2;
         int guild1 = vm.popDataValue(); if(verbose) LogInfo() << "guild1: " << guild1;
-        vm.setReturn(0);
+        vm.setReturn(vm.getDATFile().getSymbolByName("ATT_NEUTRAL").getInt());
     });
 
     vm.registerExternalFunction("wld_getmobstate", [=](Daedalus::DaedalusVM& vm) {


### PR DESCRIPTION
Dialog manager rework.
- fixes #213 
- Instead of starting `ZS_Talk`, `B_AssessTalk` is called, which handles all the checks/pre-dialog stuff.
- Monsters no longer get aligned to the player when trying to talk to them.
- "Not Now" voiceline is now functioning (handled by `B_AssessTalk`) when trying to start a dialog as controlled NPC .
- implemented external `Npc_CheckInfo`
- rudimentary implementation for `Wld_GetGuildAttitude`