### PR TITLE
allow building on/for macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
+cmake_policy(SET CMP0042 NEW)
 project(REGoth)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ if(ANDROID)
     include("src/android/Apk.cmake" REQUIRED)
 endif()
 
+if (APPLE)
+    ADD_DEFINITIONS(-DBGFX_CONFIG_MULTITHREADED=0)
+endif()
 
 if (CMAKE_COMPILER_IS_GNUCC)
     # add warning flags

--- a/src/engine/PlatformGLFW.cpp
+++ b/src/engine/PlatformGLFW.cpp
@@ -121,7 +121,9 @@ int32_t PlatformGLFW::run(int argc, char** argv)
     }
 
     /* Make the window's context current */
-    //glfwMakeContextCurrent(window);
+#ifdef BX_PLATFORM_OSX
+    glfwMakeContextCurrent(window);
+#endif
 
     // Initialize bgfx
     glfwSetWindow(window);

--- a/src/engine/PlatformGLFW.cpp
+++ b/src/engine/PlatformGLFW.cpp
@@ -4,7 +4,12 @@
 #if BX_PLATFORM_LINUX || BX_PLATFORM_OSX || BX_PLATFORM_WINDOWS || BX_PLATFORM_EMSCRIPTEN || BX_PLATFORM_BSD
 #include <thread>
 #include "PlatformGLFW.h"
-#include "utils/Utils.h"
+
+// #include "utils/Utils.h"
+namespace Utils
+{
+    void destroyFileReaderWriter();
+}
 
 #if defined(_glfw3_h_)
 // If GLFW/glfw3.h is included before bgfx/platform.h we can enable GLFW3


### PR DESCRIPTION
including utils/Utils.h pulled in HandleDef.h containing the Handle namespace.
glfw3native.h includes some macos headers though, which #define Handle.

As PlatformGLFW does not really need the entirety of utils/Utils.h I just forward declared the one function that is actually called.

This makes REGoth compilable on MacOS.
I still need to fix runtime issues though, but these fixes may happen in following pull requests :)