### PR TITLE
fixed incorrect creation of symlink for pre-commit hook

### DIFF
--- a/create_git_hooks.sh
+++ b/create_git_hooks.sh
@@ -9,6 +9,6 @@ do
     SYMLINK_HOOK=.git/$hook
     if [ -f $hook ] && [ ! -e "$SYMLINK_HOOK" ] && [ ! -L "$SYMLINK_HOOK" ]
     then
-        eval "ln -s $hook .git/hooks/"
+        ln -v -s "../../$hook" .git/hooks/
     fi
 done

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -168,7 +168,7 @@ exec <&-
 if echo "$answer" | grep -iq "^y" ;then
     formatted_files=$(lsdiff "$patch" --strip=1)
     echo "Applying formatting on files:"
-    echo "$formatted_files"
+    echo "$formatted_files" | sed 's/^/\t/'
     git apply $patch
     git add "$formatted_files"
     exit $EXIT_SUCCESS
@@ -177,7 +177,7 @@ elif echo "$answer" | grep -iq "^n" ;then
     exit $EXIT_SUCCESS
 else
     echo "Aborting commit"
-    printf "You may apply these changes manually with:\n\t git apply $patch\n"
+    printf "You may apply these changes manually with:\n git apply $patch\n"
     printf "(may need to be called from the root directory of your repository)\n"
     printf "(pre-commit can be disabled by committing with --no-verify)\n"
     exit $EXIT_ERROR

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # git pre-commit hook that runs an clang-format stylecheck.
 # Features:
@@ -32,7 +32,9 @@ PARSE_EXTS=true
 FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .m"
 
 ##################################################################
-# There should be no need to change anything below this line.
+# bash error codes
+EXIT_ERROR=1
+EXIT_SUCCESS=0
 
 # Reference: http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
 canonicalize_filename () {
@@ -90,7 +92,7 @@ fi
 if [ ! -x "$CLANG_FORMAT_BIN" ] ; then
     printf "Error: clang-format executable not found.\n"
     printf "Set the correct path in $(canonicalize_filename "$0").\n"
-    exit 1
+    exit $EXIT_ERROR
 fi
 
 # create a random filename to store our generated patch
@@ -110,6 +112,21 @@ do
         continue;
     fi
 
+    
+    # abort commit if staged file differs from workspace file
+    # need to unset bash error checking, because diff returns 1 if different
+    set +e
+    git show :"$file" | diff -u "$file" - >/dev/null
+    diff_return_code=$?
+    set -e
+    if [ $diff_return_code -eq 1 ];then
+        echo "Error: Cannot check/apply formatting. Staged files and workspace differ for file:"
+        printf "\t$file\n"
+        exit $EXIT_ERROR
+    elif [ $diff_return_code -eq 2 ];then
+        exit $EXIT_ERROR
+    fi
+
     # clang-format our sourcefile, create a patch with diff and append it to our $patch
     # The sed call is necessary to transform the patch from
     #    --- $file timestamp
@@ -125,18 +142,43 @@ done
 if [ ! -s "$patch" ] ; then
     printf "Files in this commit comply with the clang-format rules.\n"
     rm -f "$patch"
-    exit 0
+    exit $EXIT_SUCCESS
 fi
 
-# a patch has been created, notify the user and exit
-printf "\nThe following differences were found between the code to commit "
-printf "and the clang-format rules:\n\n"
+# some files are not properly formatted
+printf "\nThe following files do not match the clang-format rules:\n\n"
+lsdiff "$patch" --strip=1 | sed 's/^/\t/'
+printf "\nDifferences:\n\n"
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 cat "$patch"
+echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 
-printf "\nYou can apply these changes with:\n git apply $patch\n"
-printf "(may need to be called from the root directory of your repository)\n"
-printf "Aborting commit. Apply changes and commit again or skip checking with"
-printf " --no-verify (not recommended).\n"
+echo ""
+echo "Should the changes be added to the commit (y/n/abort)?"
+echo " - (y)es : apply formatting and proceed with commit"
+echo " - (n)o : proceed with commit (do not apply formatting)"
+echo " - (a)bort : abort commit"
 
-exit 1
+# Allows us to read user input below, assigns stdin to keyboard
+exec < /dev/tty
+read answer
+# close STDIN
+exec <&-
 
+if echo "$answer" | grep -iq "^y" ;then
+    formatted_files=$(lsdiff "$patch" --strip=1)
+    echo "Applying formatting on files:"
+    echo "$formatted_files"
+    git apply $patch
+    git add "$formatted_files"
+    exit $EXIT_SUCCESS
+elif echo "$answer" | grep -iq "^n" ;then
+    echo "No formatting applied. Proceeding with commit."
+    exit $EXIT_SUCCESS
+else
+    echo "Aborting commit"
+    printf "You may apply these changes manually with:\n\t git apply $patch\n"
+    printf "(may need to be called from the root directory of your repository)\n"
+    printf "(pre-commit can be disabled by committing with --no-verify)\n"
+    exit $EXIT_ERROR
+fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,8 +1,142 @@
 #!/bin/bash
 
-CXX_CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -Ee "\.(c|cpp|h)$" | paste -sd ' ')
+# git pre-commit hook that runs an clang-format stylecheck.
+# Features:
+#  - abort commit when commit does not comply with the style guidelines
+#  - create a patch of the proposed style changes
+
+# modifications for clang-format by rene.milk@wwu.de
+# This file is part of a set of unofficial pre-commit hooks available
+# at github.
+# Link:    https://github.com/githubbrowser/Pre-commit-hooks
+# Contact: David Martin, david.martin.mailbox@googlemail.com
+
+
+##################################################################
+# SETTINGS
+# set path to clang-format binary
 CLANG_FORMAT_BIN=$(command -v clang-format)
 
-if [ $CLANG_FORMAT_BIN ] && [[ $CXX_CHANGED_FILES ]]; then
-    eval $CLANG_FORMAT_BIN -i -style=file "${CXX_CHANGED_FILES}"
+# remove any older patches from previous commits. Set to true or false.
+# DELETE_OLD_PATCHES=false
+DELETE_OLD_PATCHES=false
+
+# only parse files with the extensions in FILE_EXTS. Set to true or false.
+# if false every changed file in the commit will be parsed with clang-format.
+# if true only files matching one of the extensions are parsed with clang-format.
+# PARSE_EXTS=true
+PARSE_EXTS=true
+
+# file types to parse. Only effective when PARSE_EXTS is true.
+# FILE_EXTS=".c .h .cpp .hpp"
+FILE_EXTS=".c .h .cpp .hpp .cc .hh .cxx .m"
+
+##################################################################
+# There should be no need to change anything below this line.
+
+# Reference: http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+canonicalize_filename () {
+    local target_file=$1
+    local physical_directory=""
+    local result=""
+
+    # Need to restore the working directory after work.
+    pushd `pwd` > /dev/null
+
+    cd "$(dirname "$target_file")"
+    target_file=`basename $target_file`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$target_file" ]
+    do
+        target_file=$(readlink "$target_file")
+        cd "$(dirname "$target_file")"
+        target_file=$(basename "$target_file")
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    physical_directory=`pwd -P`
+    result="$physical_directory"/"$target_file"
+
+    # restore the working directory after work.
+    popd > /dev/null
+
+    echo "$result"
+}
+
+# exit on error
+set -e
+
+# check whether the given file matches any of the set extensions
+matches_extension() {
+    local filename=$(basename "$1")
+    local extension=".${filename##*.}"
+    local ext
+
+    for ext in $FILE_EXTS; do [[ "$ext" == "$extension" ]] && return 0; done
+
+    return 1
+}
+
+# necessary check for initial commit
+if git rev-parse --verify HEAD >/dev/null 2>&1 ; then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
+
+if [ ! -x "$CLANG_FORMAT_BIN" ] ; then
+    printf "Error: clang-format executable not found.\n"
+    printf "Set the correct path in $(canonicalize_filename "$0").\n"
+    exit 1
+fi
+
+# create a random filename to store our generated patch
+prefix="pre-commit-clang-format"
+suffix="$(date +%s)"
+patch="/tmp/$prefix-$suffix.patch"
+
+# clean up any older clang-format patches
+$DELETE_OLD_PATCHES && rm -f /tmp/$prefix*.patch
+
+# create one patch containing all changes to the files
+git diff-index --cached --diff-filter=ACMR --name-only $against -- | while read file;
+do
+    # ignore file if we do check for file extensions and the file
+    # does not match any of the extensions specified in $FILE_EXTS
+    if $PARSE_EXTS && ! matches_extension "$file"; then
+        continue;
+    fi
+
+    # clang-format our sourcefile, create a patch with diff and append it to our $patch
+    # The sed call is necessary to transform the patch from
+    #    --- $file timestamp
+    #    +++ - timestamp
+    # to both lines working on the same file and having a a/ and b/ prefix.
+    # Else it can not be applied with 'git apply'.
+    "$CLANG_FORMAT_BIN" -style=file "$file" | \
+        diff -u "$file" - | \
+        sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
+done
+
+# if no patch has been generated all is ok, clean up the file stub and exit
+if [ ! -s "$patch" ] ; then
+    printf "Files in this commit comply with the clang-format rules.\n"
+    rm -f "$patch"
+    exit 0
+fi
+
+# a patch has been created, notify the user and exit
+printf "\nThe following differences were found between the code to commit "
+printf "and the clang-format rules:\n\n"
+cat "$patch"
+
+printf "\nYou can apply these changes with:\n git apply $patch\n"
+printf "(may need to be called from the root directory of your repository)\n"
+printf "Aborting commit. Apply changes and commit again or skip checking with"
+printf " --no-verify (not recommended).\n"
+
+exit 1
+


### PR DESCRIPTION
- the bash script `create_git_hooks.sh` will now work properly and creates the git hook.
- Replaced the pre-commit hook with a new version
- you got 3 choices:
  - yes: apply formatting & commit
  - no: commit without formatting
  - abort: abort commit

This is what it looks like now:
```
$git commit 

The following files do not match the clang-format rules:

	src/target/REGoth.cpp

Differences:

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
--- a/src/target/REGoth.cpp	2017-10-20 21:15:00.442098201 +0200
+++ b/src/target/REGoth.cpp	2017-10-20 21:15:07.622936504 +0200
@@ -294,7 +294,7 @@
     });
 
     console.registerCommand("foobar", [this](const std::vector<std::string>& args) -> std::string {
-    return "foobar!";
+        return "foobar!";
     });
 
     console.registerCommand("set day", [this](const std::vector<std::string>& args) -> std::string {
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

Should the changes be added to the commit (y/n/abort)?
 - (y)es : apply formatting and proceed with commit
 - (n)o : proceed with commit (do not apply formatting)
 - (a)bort : abort commit
y
Applying formatting on files:
	src/target/REGoth.cpp
[TestGitHook2 28ae2b3] asdsadasda
 1 file changed, 2 deletions(-)
```
