### PR TITLE
fixed camera Keybindings + Third Person Camera Mouse control

### DIFF
--- a/src/components/VobClasses.cpp
+++ b/src/components/VobClasses.cpp
@@ -393,11 +393,9 @@ void VobTypes::Wld_RemoveNpc(World::WorldInstance& world, Handle::EntityHandle n
 {
     VobTypes::NpcVobInformation vob = VobTypes::asNpcVob(world, npc);
 
-    // if npc is the current controlled entity clear up bindings, "hero" and invalidate player entity
+    // clear script variable "hero" and invalidate player entity
     if (npc == world.getScriptEngine().getPlayerEntity())
     {
-        // clear key bindings
-        Engine::Input::clearActions();
         world.getScriptEngine().setPlayerEntity(Handle::EntityHandle::makeInvalidHandle());
         auto invalidHandle = Daedalus::GameState::NpcHandle();
         world.getScriptEngine().setInstanceNPC("hero", invalidHandle);

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -252,7 +252,9 @@ void BaseEngine::processMessageQueue()
 
 void BaseEngine::resetSession()
 {
+    // the order is important: first destroy old session
     // GameSession's destructor will clean up worlds
+    m_Session = nullptr;
     m_Session = std::make_unique<GameSession>(*this);
 }
 

--- a/src/engine/GameSession.cpp
+++ b/src/engine/GameSession.cpp
@@ -309,25 +309,56 @@ void GameSession::setupKeyBindings()
         }
     });
 
-    std::vector<ActionType> playerActions = {ActionType::PlayerDrawWeaponMelee,
-                                             ActionType::PlayerForward,
-                                             ActionType::PlayerBackward,
-                                             ActionType::PlayerTurnLeft,
-                                             ActionType::PlayerTurnRight,
-                                             ActionType::PlayerStrafeLeft,
-                                             ActionType::PlayerStrafeRight,
-                                             ActionType::DebugMoveSpeed,
-                                             ActionType::DebugMoveSpeed2,
-                                             ActionType::PlayerAction,
-                                             ActionType::PlayerRotate};
-
-    for (auto action : playerActions)
     {
-        Engine::Input::RegisterAction(action, [action, getPlayerVob](bool triggered, float intensity) {
-            auto vob = getPlayerVob();
-            if (!vob.isValid())
-                return;
-            vob.playerController->onAction(action, triggered, intensity);
+        // player actions
+        std::vector<ActionType> playerActions = {ActionType::PlayerDrawWeaponMelee,
+                                                 ActionType::PlayerForward,
+                                                 ActionType::PlayerBackward,
+                                                 ActionType::PlayerTurnLeft,
+                                                 ActionType::PlayerTurnRight,
+                                                 ActionType::PlayerStrafeLeft,
+                                                 ActionType::PlayerStrafeRight,
+                                                 ActionType::DebugMoveSpeed,
+                                                 ActionType::DebugMoveSpeed2,
+                                                 ActionType::PlayerAction,
+                                                 ActionType::PlayerRotate};
+
+        for (auto action : playerActions)
+        {
+            Engine::Input::RegisterAction(action, [action, getPlayerVob](bool triggered, float intensity) {
+                auto vob = getPlayerVob();
+                if (!vob.isValid())
+                    return;
+                vob.playerController->onAction(action, triggered, intensity);
+            });
+        }
+    }
+
+    {
+        // camera change actions
+        using ECameraMode = Logic::CameraController::ECameraMode;
+        std::vector<std::pair<Engine::ActionType, ECameraMode>> cameraModes = {
+            {Engine::ActionType::CameraFirstPerson, ECameraMode::FirstPerson},
+            {Engine::ActionType::CameraThirdPerson, ECameraMode::ThirdPerson},
+            {Engine::ActionType::CameraFree, ECameraMode::Free},
+            {Engine::ActionType::CameraViewer, ECameraMode::Viewer},
+        };
+
+        for (auto cameraMode : cameraModes)
+        {
+            Engine::Input::RegisterAction(cameraMode.first, [baseEngine, mode = cameraMode.second](bool triggered, float) {
+                if (triggered && baseEngine->getMainWorld().isValid())
+                {
+                    baseEngine->getMainWorld().get().getCameraController()->setCameraMode(mode);
+                }
+            });
+        }
+
+        Engine::Input::RegisterAction(Engine::ActionType::DebugMoveSpeed, [baseEngine](bool triggered, float intensity) {
+            if (baseEngine->getMainWorld().isValid())
+            {
+                baseEngine->getMainWorld().get().getCameraController()->setDebugMoveSpeed(triggered ? 5.0f : 1.0f);
+            }
         });
     }
 }

--- a/src/engine/GameSession.cpp
+++ b/src/engine/GameSession.cpp
@@ -271,7 +271,6 @@ void GameSession::startNewGame(const std::string& worldFile)
 
 void GameSession::setupKeyBindings()
 {
-    LogInfo() << "setupKeyBindings";
     using Engine::ActionType;
 
     auto baseEngine = &m_Engine;
@@ -319,15 +318,16 @@ void GameSession::setupKeyBindings()
                                              ActionType::PlayerStrafeRight,
                                              ActionType::DebugMoveSpeed,
                                              ActionType::DebugMoveSpeed2,
-                                             ActionType::PlayerAction};
+                                             ActionType::PlayerAction,
+                                             ActionType::PlayerRotate};
 
     for (auto action : playerActions)
     {
-        Engine::Input::RegisterAction(action, [action, getPlayerVob](bool triggered, float) {
+        Engine::Input::RegisterAction(action, [action, getPlayerVob](bool triggered, float intensity) {
             auto vob = getPlayerVob();
             if (!vob.isValid())
                 return;
-            vob.playerController->onAction(action, triggered);
+            vob.playerController->onAction(action, triggered, intensity);
         });
     }
 }

--- a/src/engine/GameSession.cpp
+++ b/src/engine/GameSession.cpp
@@ -21,7 +21,7 @@ GameSession::GameSession(BaseEngine& engine)
 
 GameSession::~GameSession()
 {
-    Engine::Input::clearActions();
+    clearBindings();
     removeAllWorlds();
 }
 
@@ -377,4 +377,10 @@ void GameSession::enablePlayerBindings(bool enabled)
     {
         managedBinding.getAction().setEnabled(enabled);
     }
+}
+
+void GameSession::clearBindings()
+{
+    m_ActionBindings.clear();
+    m_PlayerBindings.clear();
 }

--- a/src/engine/GameSession.cpp
+++ b/src/engine/GameSession.cpp
@@ -287,7 +287,11 @@ void GameSession::setupKeyBindings()
         return VobTypes::asNpcVob(worldHandle.get(), player);
     };
 
-    Engine::Input::RegisterAction(ActionType::Quicksave, [baseEngine](bool triggered, float) {
+    auto registerAction = [this](ActionType actionType, auto functor){
+        m_ActionBindings.push_back(Engine::Input::RegisterAction(actionType, functor));
+    };
+
+    registerAction(ActionType::Quicksave, [baseEngine](bool triggered, float) {
         if (triggered)
         {
             bool forceQueue = true; // better do saving at frame end and not between entity updates
@@ -297,12 +301,12 @@ void GameSession::setupKeyBindings()
         }
     });
 
-    Engine::Input::RegisterAction(ActionType::Quickload, [baseEngine](bool triggered, float) {
+    registerAction(ActionType::Quickload, [baseEngine](bool triggered, float) {
         if (triggered)
             Engine::SavegameManager::loadSaveGameSlot(0);
     });
 
-    Engine::Input::RegisterAction(ActionType::PauseGame, [baseEngine](bool triggered, float) {
+    registerAction(ActionType::PauseGame, [baseEngine](bool triggered, float) {
         if (triggered && !baseEngine->getHud().isMenuActive())
         {
             baseEngine->togglePaused();
@@ -325,7 +329,7 @@ void GameSession::setupKeyBindings()
 
         for (auto action : playerActions)
         {
-            Engine::Input::RegisterAction(action, [action, getPlayerVob](bool triggered, float intensity) {
+            registerAction(action, [action, getPlayerVob](bool triggered, float intensity) {
                 auto vob = getPlayerVob();
                 if (!vob.isValid())
                     return;
@@ -346,7 +350,7 @@ void GameSession::setupKeyBindings()
 
         for (auto cameraMode : cameraModes)
         {
-            Engine::Input::RegisterAction(cameraMode.first, [baseEngine, mode = cameraMode.second](bool triggered, float) {
+            registerAction(cameraMode.first, [baseEngine, mode = cameraMode.second](bool triggered, float) {
                 if (triggered && baseEngine->getMainWorld().isValid())
                 {
                     baseEngine->getMainWorld().get().getCameraController()->setCameraMode(mode);
@@ -354,7 +358,7 @@ void GameSession::setupKeyBindings()
             });
         }
 
-        Engine::Input::RegisterAction(Engine::ActionType::DebugMoveSpeed, [baseEngine](bool triggered, float intensity) {
+        registerAction(Engine::ActionType::DebugMoveSpeed, [baseEngine](bool triggered, float intensity) {
             if (baseEngine->getMainWorld().isValid())
             {
                 baseEngine->getMainWorld().get().getCameraController()->setDebugMoveSpeed(triggered ? 5.0f : 1.0f);

--- a/src/engine/GameSession.cpp
+++ b/src/engine/GameSession.cpp
@@ -291,6 +291,10 @@ void GameSession::setupKeyBindings()
         m_ActionBindings.push_back(Engine::Input::RegisterAction(actionType, functor));
     };
 
+    auto registerPlayerAction = [this](ActionType actionType, auto functor){
+        m_PlayerBindings.push_back(Engine::Input::RegisterAction(actionType, functor));
+    };
+
     registerAction(ActionType::Quicksave, [baseEngine](bool triggered, float) {
         if (triggered)
         {
@@ -329,7 +333,7 @@ void GameSession::setupKeyBindings()
 
         for (auto action : playerActions)
         {
-            registerAction(action, [action, getPlayerVob](bool triggered, float intensity) {
+            registerPlayerAction(action, [action, getPlayerVob](bool triggered, float intensity) {
                 auto vob = getPlayerVob();
                 if (!vob.isValid())
                     return;
@@ -364,5 +368,13 @@ void GameSession::setupKeyBindings()
                 baseEngine->getMainWorld().get().getCameraController()->setDebugMoveSpeed(triggered ? 5.0f : 1.0f);
             }
         });
+    }
+}
+
+void GameSession::enablePlayerBindings(bool enabled)
+{
+    for (auto& managedBinding : m_PlayerBindings)
+    {
+        managedBinding.getAction().setEnabled(enabled);
     }
 }

--- a/src/engine/GameSession.h
+++ b/src/engine/GameSession.h
@@ -137,6 +137,10 @@ namespace Engine
 
         Logic::LogManager& getLogManager() { return m_LogManager; }
 
+        /**
+         * Enables/Disables bindings that control the player
+         */
+        void enablePlayerBindings(bool enabled);
 
     private:
         std::map<std::string, nlohmann::json> m_InactiveWorlds;
@@ -185,5 +189,10 @@ namespace Engine
          * stored bindings
          */
         std::vector<ManagedActionBinding> m_ActionBindings;
+
+        /**
+         * stored player bindings
+         */
+        std::vector<ManagedActionBinding> m_PlayerBindings;
     };
 }

--- a/src/engine/GameSession.h
+++ b/src/engine/GameSession.h
@@ -129,11 +129,15 @@ namespace Engine
          */
         void removeAllWorlds();
 
-
         /**
          * Registers all key bindings
          */
         void setupKeyBindings();
+
+        /**
+         * Un-registers all bindings
+         */
+        void clearBindings();
 
         Logic::LogManager& getLogManager() { return m_LogManager; }
 

--- a/src/engine/GameSession.h
+++ b/src/engine/GameSession.h
@@ -123,6 +123,11 @@ namespace Engine
          */
         void removeAllWorlds();
 
+        /**
+         * Registers all key bindings
+         */
+        void setupKeyBindings();
+
     private:
         std::map<std::string, nlohmann::json> m_InactiveWorlds;
 

--- a/src/engine/GameSession.h
+++ b/src/engine/GameSession.h
@@ -180,5 +180,10 @@ namespace Engine
          * reference to base engine
          */
         BaseEngine& m_Engine;
+
+        /**
+         * stored bindings
+         */
+        std::vector<ManagedActionBinding> m_ActionBindings;
     };
 }

--- a/src/engine/Input.cpp
+++ b/src/engine/Input.cpp
@@ -291,9 +291,9 @@ void Input::fireBindings()
         for (auto itAction = rangeIterators.first; itAction != rangeIterators.second; ++itAction)
             if (itAction->second.isEnabled)
                 itAction->second.function(triggerAction, intensity);
-
-        mouseAxisTriggered[mouseAxisIndex] = false;
     }
+    // This must be done after the loop, because multiple bindings to the same axis may occur
+    mouseAxisTriggered.reset();
 }
 
 void Input::setMouseLock(bool mouseLock)

--- a/src/engine/Input.cpp
+++ b/src/engine/Input.cpp
@@ -341,3 +341,43 @@ std::string Input::getFrameTextInput()
     frameTextInput.clear();
     return r;
 }
+
+ActionBindingAlive::ActionBindingAlive()
+    : action(nullptr)
+{
+}
+
+ActionBindingAlive::ActionBindingAlive(ActionBindingAlive&& other)
+    : ActionBindingAlive()
+{
+    swap(*this, other);
+}
+
+void ActionBindingAlive::swap(ActionBindingAlive& a, ActionBindingAlive& b)
+{
+    std::swap(a.actionType, b.actionType);
+    std::swap(a.action, b.action);
+}
+
+ActionBindingAlive::~ActionBindingAlive()
+{
+    if (action)
+        Input::RemoveAction(actionType, action);
+}
+
+ActionBindingAlive::ActionBindingAlive(Engine::ActionType actionType, Engine::Action* action)
+    : actionType(actionType)
+    , action(action)
+{
+}
+
+ActionBindingAlive& ActionBindingAlive::operator=(ActionBindingAlive&& other)
+{
+    {
+        // disposes *this first
+        ActionBindingAlive tempEmpty;
+        swap(*this, tempEmpty);
+    }
+    swap(*this, other);
+    return *this;
+}

--- a/src/engine/Input.cpp
+++ b/src/engine/Input.cpp
@@ -70,10 +70,10 @@ float Input::windowHalfHeight;
 float Input::windowHalfWidth;
 std::string Input::frameTextInput;
 
-Action* Input::RegisterAction(ActionType actionType, std::function<void(bool, float)> function)
+ManagedActionBinding Input::RegisterAction(ActionType actionType, std::function<void(bool, float)> function)
 {
-    // Returns pointer to inserted Action object
-    return &((*actionTypeToActionMap.insert(std::make_pair(actionType, Action(function)))).second);
+    auto it = actionTypeToActionMap.insert(std::make_pair(actionType, Action(function)));
+    return {it->first, &it->second};
 }
 
 void Input::clearActions()
@@ -342,40 +342,40 @@ std::string Input::getFrameTextInput()
     return r;
 }
 
-ActionBindingAlive::ActionBindingAlive()
+ManagedActionBinding::ManagedActionBinding()
     : action(nullptr)
 {
 }
 
-ActionBindingAlive::ActionBindingAlive(ActionBindingAlive&& other)
-    : ActionBindingAlive()
+ManagedActionBinding::ManagedActionBinding(ManagedActionBinding&& other)
+    : ManagedActionBinding()
 {
     swap(*this, other);
 }
 
-void ActionBindingAlive::swap(ActionBindingAlive& a, ActionBindingAlive& b)
+void ManagedActionBinding::swap(ManagedActionBinding& a, ManagedActionBinding& b)
 {
     std::swap(a.actionType, b.actionType);
     std::swap(a.action, b.action);
 }
 
-ActionBindingAlive::~ActionBindingAlive()
+ManagedActionBinding::~ManagedActionBinding()
 {
     if (action)
         Input::RemoveAction(actionType, action);
 }
 
-ActionBindingAlive::ActionBindingAlive(Engine::ActionType actionType, Engine::Action* action)
+ManagedActionBinding::ManagedActionBinding(Engine::ActionType actionType, Engine::Action* action)
     : actionType(actionType)
     , action(action)
 {
 }
 
-ActionBindingAlive& ActionBindingAlive::operator=(ActionBindingAlive&& other)
+ManagedActionBinding& ManagedActionBinding::operator=(ManagedActionBinding&& other)
 {
     {
         // disposes *this first
-        ActionBindingAlive tempEmpty;
+        ManagedActionBinding tempEmpty;
         swap(*this, tempEmpty);
     }
     swap(*this, other);

--- a/src/engine/Input.h
+++ b/src/engine/Input.h
@@ -100,20 +100,21 @@ namespace Engine
         std::function<void(bool /*triggered*/, float /*intensity*/)> function;
     };
 
-    class ActionBindingAlive
+    class ManagedActionBinding
     {
     public:
-        ActionBindingAlive();
-        ActionBindingAlive(Engine::ActionType actionType, Engine::Action* action);
-        ActionBindingAlive(ActionBindingAlive&& other);
-        ActionBindingAlive& operator= (ActionBindingAlive&& other);
+        ManagedActionBinding();
+        ManagedActionBinding(Engine::ActionType actionType, Engine::Action* action);
+        ManagedActionBinding(ManagedActionBinding&& other);
+        ManagedActionBinding& operator= (ManagedActionBinding&& other);
         // copying is forbidden
-        ActionBindingAlive(const ActionBindingAlive&) = delete;
-        ActionBindingAlive& operator= (const ActionBindingAlive&) = delete;
+        ManagedActionBinding(const ManagedActionBinding&) = delete;
+        ManagedActionBinding& operator= (const ManagedActionBinding&) = delete;
 
-        ~ActionBindingAlive();
-        static void swap(ActionBindingAlive& a, ActionBindingAlive& b);
-    private:
+        ~ManagedActionBinding();
+        static void swap(ManagedActionBinding& a, ManagedActionBinding& b);
+        Engine::Action& getAction() { return *action; }
+    protected:
         Engine::ActionType actionType;
         Engine::Action* action;
     };
@@ -145,7 +146,7 @@ namespace Engine
         };
 
     public:
-        static Action* RegisterAction(ActionType actionType, std::function<void(bool /*triggered*/, float /*intensity*/)> function);
+        static ManagedActionBinding RegisterAction(ActionType actionType, std::function<void(bool /*triggered*/, float /*intensity*/)> function);
         static bool RemoveAction(ActionType actionType, Action* action);
         static void clearActions();
         static void fireBindings();

--- a/src/engine/Input.h
+++ b/src/engine/Input.h
@@ -146,6 +146,12 @@ namespace Engine
         };
 
     public:
+        /**
+         * Registers a function to the given action
+         * Caution: The returned object must be stored somewhere.
+         * As soon as it goes out of scope, the binding is unregistered.
+         * @return An object on whose end of lifetime the binding is automatically unregistered
+         */
         static ManagedActionBinding RegisterAction(ActionType actionType, std::function<void(bool /*triggered*/, float /*intensity*/)> function);
         static bool RemoveAction(ActionType actionType, Action* action);
         static void clearActions();

--- a/src/engine/Input.h
+++ b/src/engine/Input.h
@@ -50,6 +50,7 @@ namespace Engine
         PlayerBackward,
         PlayerTurnLeft,
         PlayerTurnRight,
+        PlayerRotate,
         PlayerStrafeLeft,
         PlayerStrafeRight,
         PlayerDrawWeaponMelee,

--- a/src/engine/Input.h
+++ b/src/engine/Input.h
@@ -29,6 +29,9 @@ namespace Engine
         FirstPersonLookHorizontal,
         FirstPersonLookVertical,
 
+        ThirdPersonLookHorizontal,
+        ThirdPersonLookVertical,
+
         FreeMoveForward,
         FreeMoveRight,
         FreeMoveUp,

--- a/src/engine/Input.h
+++ b/src/engine/Input.h
@@ -100,6 +100,24 @@ namespace Engine
         std::function<void(bool /*triggered*/, float /*intensity*/)> function;
     };
 
+    class ActionBindingAlive
+    {
+    public:
+        ActionBindingAlive();
+        ActionBindingAlive(Engine::ActionType actionType, Engine::Action* action);
+        ActionBindingAlive(ActionBindingAlive&& other);
+        ActionBindingAlive& operator= (ActionBindingAlive&& other);
+        // copying is forbidden
+        ActionBindingAlive(const ActionBindingAlive&) = delete;
+        ActionBindingAlive& operator= (const ActionBindingAlive&) = delete;
+
+        ~ActionBindingAlive();
+        static void swap(ActionBindingAlive& a, ActionBindingAlive& b);
+    private:
+        Engine::ActionType actionType;
+        Engine::Action* action;
+    };
+
     class Input
     {
     public:

--- a/src/engine/Input.h
+++ b/src/engine/Input.h
@@ -31,6 +31,7 @@ namespace Engine
 
         ThirdPersonLookHorizontal,
         ThirdPersonLookVertical,
+        ThirdPersonMouseWheel,
 
         FreeMoveForward,
         FreeMoveRight,

--- a/src/engine/PlatformGLFW.cpp
+++ b/src/engine/PlatformGLFW.cpp
@@ -172,6 +172,10 @@ int32_t PlatformGLFW::run(int argc, char** argv)
     bindKey(GLFW_KEY_RIGHT, ActionType::FirstPersonLookHorizontal, true, false);
     bindKey(GLFW_KEY_LEFT, ActionType::FirstPersonLookHorizontal, true, true);
 
+    // ThirdPerson Camera Controller
+    bindMouseAxis(MouseAxis::CursorX, ActionType::ThirdPersonLookHorizontal, true, false);
+    bindMouseAxis(MouseAxis::CursorY, ActionType::ThirdPersonLookVertical, true, false);
+
     // Free Camera Controller
 
     bindKey(GLFW_KEY_W, ActionType::FreeMoveForward, true, false);

--- a/src/engine/PlatformGLFW.cpp
+++ b/src/engine/PlatformGLFW.cpp
@@ -152,20 +152,14 @@ int32_t PlatformGLFW::run(int argc, char** argv)
 
     std::cout << "Binding keys..." << std::endl;
 
-    bindKey(GLFW_KEY_F1, ActionType::CameraFirstPerson, false);
-    bindKey(GLFW_KEY_F2, ActionType::CameraThirdPerson, false);
+    bindKey(GLFW_KEY_F1, ActionType::CameraThirdPerson, false);
+    bindKey(GLFW_KEY_F2, ActionType::CameraFirstPerson, false);
     bindKey(GLFW_KEY_F3, ActionType::CameraFree, false);
     bindKey(GLFW_KEY_F4, ActionType::CameraViewer, false);
 
     // FirstPerson Camera Controller
-
-    bindKey(GLFW_KEY_W, ActionType::FirstPersonMoveForward, true, false);
-    bindKey(GLFW_KEY_S, ActionType::FirstPersonMoveForward, true, true);
-    bindKey(GLFW_KEY_D, ActionType::FirstPersonMoveRight, true, false);
-    bindKey(GLFW_KEY_A, ActionType::FirstPersonMoveRight, true, true);
-
     bindMouseAxis(MouseAxis::CursorX, ActionType::FirstPersonLookHorizontal, true, false);
-    bindMouseAxis(MouseAxis::CursorY, ActionType::FirstPersonLookVertical, true, true);
+    bindMouseAxis(MouseAxis::CursorY, ActionType::FirstPersonLookVertical, true, false);
 
     bindKey(GLFW_KEY_UP, ActionType::FirstPersonLookVertical, true, false);
     bindKey(GLFW_KEY_DOWN, ActionType::FirstPersonLookVertical, true, true);
@@ -178,7 +172,6 @@ int32_t PlatformGLFW::run(int argc, char** argv)
     bindMouseAxis(MouseAxis::ScrollY, ActionType::ThirdPersonMouseWheel, false);
 
     // Free Camera Controller
-
     bindKey(GLFW_KEY_W, ActionType::FreeMoveForward, true, false);
     bindKey(GLFW_KEY_S, ActionType::FreeMoveForward, true, true);
     bindKey(GLFW_KEY_D, ActionType::FreeMoveRight, true, false);

--- a/src/engine/PlatformGLFW.cpp
+++ b/src/engine/PlatformGLFW.cpp
@@ -175,6 +175,7 @@ int32_t PlatformGLFW::run(int argc, char** argv)
     // ThirdPerson Camera Controller
     bindMouseAxis(MouseAxis::CursorX, ActionType::ThirdPersonLookHorizontal, true, false);
     bindMouseAxis(MouseAxis::CursorY, ActionType::ThirdPersonLookVertical, true, false);
+    bindMouseAxis(MouseAxis::ScrollY, ActionType::ThirdPersonMouseWheel, false);
 
     // Free Camera Controller
 

--- a/src/engine/PlatformGLFW.cpp
+++ b/src/engine/PlatformGLFW.cpp
@@ -217,6 +217,8 @@ int32_t PlatformGLFW::run(int argc, char** argv)
     bindKey(GLFW_KEY_SPACE, ActionType::DebugMoveSpeed, true);
     bindKey(GLFW_KEY_LEFT_SHIFT, ActionType::DebugMoveSpeed2, true);
     bindKey(GLFW_KEY_LEFT_CONTROL, ActionType::PlayerAction, true);
+    bindMouseButton(GLFW_MOUSE_BUTTON_LEFT, ActionType::PlayerAction, true);
+    bindMouseAxis(MouseAxis::CursorX, ActionType::PlayerRotate, true, false);
 
     bindKey(GLFW_KEY_F5, ActionType::Quicksave, false);
     bindKey(GLFW_KEY_F9, ActionType::Quickload, false);

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -59,10 +59,13 @@ WorldInstance::WorldInstance(Engine::BaseEngine& engine)
 
 WorldInstance::~WorldInstance()
 {
-    // kick out player if he is still in this world (clears key bindings)
+    // kick out player if he is still in this world
+    /*
+    // FIXME currently crashes game if player is not PC_HERO
     auto player = getScriptEngine().getPlayerEntity();
-    if (player.isValid())
+    if (player.isValid() && false)
         VobTypes::Wld_RemoveNpc(*this, player);
+    */
 
     // Destroy all allocated components
     // Loop because some destructor may create more entities

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -949,13 +949,9 @@ void WorldInstance::exportControllers(Logic::Controller* logicController, Logic:
 
 void WorldInstance::takeControlOver(Handle::EntityHandle entityHandle)
 {
-    VobTypes::NpcVobInformation npcVob = VobTypes::asNpcVob(*this, entityHandle);
-
+    VobTypes::NpcVobInformation newPlayer = VobTypes::asNpcVob(*this, entityHandle);
     getScriptEngine().setPlayerEntity(entityHandle);
-    getScriptEngine().setInstanceNPC("hero", VobTypes::getScriptHandle(npcVob));
-    // reset bindings
-    Engine::Input::clearActions();
-    npcVob.playerController->setupKeyBindings();
+    getScriptEngine().setInstanceNPC("hero", VobTypes::getScriptHandle(newPlayer));
 }
 
 Handle::EntityHandle WorldInstance::importVobAndTakeControl(const json& j)

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -347,7 +347,7 @@ namespace World
         Handle::EntityHandle importVobAndTakeControl(const json& j);
 
         /**
-         * take control over the given entity (camera, movement(key bindings))
+         * sets the controlled entity
          */
         void takeControlOver(Handle::EntityHandle entityHandle);
 

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -72,7 +72,7 @@ Logic::CameraController::CameraController(World::WorldInstance& world, Handle::E
             if (triggered)
             {
                 auto& zoom = settings.zoomExponent;
-                zoom = Math::clamp(zoom - intensity / 8, 0.0f, 20.0f);
+                zoom = Math::clamp(zoom - intensity / 4, 0.0f, 15.0f);
             }
         });
 
@@ -82,7 +82,7 @@ Logic::CameraController::CameraController(World::WorldInstance& world, Handle::E
         });
 
         settings.actionLookHorizontal = Input::RegisterAction(ActionType::ThirdPersonLookHorizontal, [&settings](bool, float intensity) {
-            settings.deltaPhi += 0.02f * intensity; // TODO screen aspect ratio influences this???
+            settings.deltaPhi += 0.02f * intensity; // TODO window width influences this???
         });
     }
 
@@ -257,14 +257,16 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
 
             if (player.isValid())
             {
-                auto& deltaPhi = m_CameraSettings.thirdPersonCameraSettings.deltaPhi;
 
-                auto dir = player.playerController->getDirection();
-                dir = Math::Matrix::rotatedPointAroundLine(dir, {0, 0, 0}, player.playerController->getEntityTransform().Up(), deltaPhi);
-                player.playerController->setDirection(dir);
+                // TODO rotate camera instead
+                auto& deltaPhi = m_CameraSettings.thirdPersonCameraSettings.deltaPhi;
+                //auto dir = player.playerController->getDirection();
+                //dir = Math::Matrix::rotatedPointAroundLine(dir, {0, 0, 0}, player.playerController->getEntityTransform().Up(), deltaPhi);
+                //player.playerController->setDirection(dir);
                 deltaPhi = 0;
                 const float verticalFactor = std::sin(m_CameraSettings.thirdPersonCameraSettings.cameraElevation);
                 const float horizontalFactor = std::cos(m_CameraSettings.thirdPersonCameraSettings.cameraElevation);
+                // TODO use movestate direction instead? (swimming not tested)
                 Math::Matrix pTrans = player.playerController->getEntityTransformFacing();
                 Math::float3 pdir;
 

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -463,4 +463,7 @@ void Logic::CameraController::setCameraMode(Logic::CameraController::ECameraMode
             m_CameraSettings.thirdPersonCameraSettings.actionLookHorizontal->setEnabled(true);
             break;
     }
+    #ifndef NDEBUG
+    Engine::Input::setMouseLock(false);
+    #endif
 }

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -11,6 +11,7 @@
 #include <engine/World.h>
 #include <entry/input.h>
 #include <components/EntityActions.h>
+#include <engine/GameSession.h>
 
 const float CAMERA_SMOOTHING = 10.0f;
 
@@ -416,6 +417,8 @@ void Logic::CameraController::setCameraMode(Logic::CameraController::ECameraMode
             Engine::Input::setMouseLock(true);
             break;
     }
+    bool enablePlayerBindings = (mode == ECameraMode::FirstPerson) || (mode == ECameraMode::ThirdPerson);
+    m_World.getEngine()->getSession().enablePlayerBindings(enablePlayerBindings);
     #ifndef NDEBUG
     Engine::Input::setMouseLock(false);
     #endif

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -77,7 +77,7 @@ Logic::CameraController::CameraController(World::WorldInstance& world, Handle::E
 
         settings.actionLookVertical = Input::RegisterAction(ActionType::ThirdPersonLookVertical, [&settings](bool, float intensity) {
             settings.pitch += 0.02f * intensity;
-            settings.pitch =  Utils::fmod(settings.pitch, 2 * static_cast<float>(M_PI));
+            settings.pitch =  Utils::fmod(settings.pitch, 2 * ZMath::Pi);
         });
 
         settings.actionLookHorizontal = Input::RegisterAction(ActionType::ThirdPersonLookHorizontal, [&settings](bool, float intensity) {
@@ -310,7 +310,7 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
                     // case front view: flip view
                     pdir *= -1;
                     rotationAxisDir *= -1;
-                    angle = static_cast<float>(M_PI) - angle;
+                    angle = ZMath::Pi - angle;
                     // TODO maybe invert control inversion
                 }
 

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -78,7 +78,7 @@ Logic::CameraController::CameraController(World::WorldInstance& world, Handle::E
 
         settings.actionLookVertical = Input::RegisterAction(ActionType::ThirdPersonLookVertical, [&settings](bool, float intensity) {
             settings.pitch += 0.02f * intensity;
-            settings.pitch =  Utils::fmod(settings.pitch, 2 * ZMath::Pi);
+            settings.pitch =  Utils::fmod(settings.pitch, 2 * Math::PI);
         });
 
         settings.actionLookHorizontal = Input::RegisterAction(ActionType::ThirdPersonLookHorizontal, [&settings](bool, float intensity) {
@@ -311,7 +311,7 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
                     // case front view: flip view
                     pdir *= -1;
                     rotationAxisDir *= -1;
-                    angle = ZMath::Pi - angle;
+                    angle = Math::PI - angle;
                 }
 
                 // cardinalPoint around which the camera will rotate vertically

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -450,15 +450,7 @@ void Logic::CameraController::setCameraMode(Logic::CameraController::ECameraMode
 
 void Logic::CameraController::clearBindings()
 {
-    for (const auto& camMode : m_KeyBindings)
-    {
-        for (const auto& pair : camMode.second)
-        {
-            Engine::Input::RemoveAction(pair.first, pair.second);
-        }
-    }
-    m_KeyBindings.clear();
-
+    m_ActionBindings.clear();
 }
 
 Logic::CameraController::~CameraController()

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -296,7 +296,7 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
                 const auto& height = playerSize.y;
                 const auto& length = playerSize.z;
                 float playerDimension = (width + height + length) / 3;
-                LogInfo() << playerDimension << "   " << height;
+
                 const auto& playerCenter = pTrans.Translation();
 
                 const Math::float3 up = Math::float3(0.0f, 1.0f, 0.0f);

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -416,3 +416,8 @@ void Logic::CameraController::clearBindings()
 {
     m_ActionBindings.clear();
 }
+
+Logic::CameraController::~CameraController()
+{
+    clearBindings();
+}

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -201,28 +201,13 @@ Logic::CameraController::CameraController(World::WorldInstance& world, Handle::E
 void Logic::CameraController::disableActions()
 {
     Engine::Input::setMouseLock(false);
-    m_CameraSettings.firstPersonCameraSettings.actionMoveForward->setEnabled(false);
-    m_CameraSettings.firstPersonCameraSettings.actionMoveRight->setEnabled(false);
-    m_CameraSettings.firstPersonCameraSettings.actionLookHorizontal->setEnabled(false);
-    m_CameraSettings.firstPersonCameraSettings.actionLookVertical->setEnabled(false);
-
-    m_CameraSettings.thirdPersonCameraSettings.actionWheel->setEnabled(false);
-    m_CameraSettings.thirdPersonCameraSettings.actionLookVertical->setEnabled(false);
-    m_CameraSettings.thirdPersonCameraSettings.actionLookHorizontal->setEnabled(false);
-
-    m_CameraSettings.freeCameraSettings.actionMoveForward->setEnabled(false);
-    m_CameraSettings.freeCameraSettings.actionMoveRight->setEnabled(false);
-    m_CameraSettings.freeCameraSettings.actionMoveUp->setEnabled(false);
-    m_CameraSettings.freeCameraSettings.actionLookHorizontal->setEnabled(false);
-    m_CameraSettings.freeCameraSettings.actionLookVertical->setEnabled(false);
-
-    m_CameraSettings.viewerCameraSettings.actionViewHorizontal->setEnabled(false);
-    m_CameraSettings.viewerCameraSettings.actionViewVertical->setEnabled(false);
-    m_CameraSettings.viewerCameraSettings.actionPan->setEnabled(false);
-    m_CameraSettings.viewerCameraSettings.actionZoom->setEnabled(false);
-    m_CameraSettings.viewerCameraSettings.actionRotate->setEnabled(false);
-    m_CameraSettings.viewerCameraSettings.actionClick->setEnabled(false);
-    m_CameraSettings.viewerCameraSettings.actionWheel->setEnabled(false);
+    for (auto& pair : m_ActionBindings)
+    {
+        for (auto& managedBinding : pair.second)
+        {
+            managedBinding.getAction().setEnabled(false);
+        }
+    }
 }
 
 void Logic::CameraController::onUpdateExplicit(float deltaTime)
@@ -408,39 +393,27 @@ void Logic::CameraController::setTransforms(const Math::float3& position, float 
 void Logic::CameraController::setCameraMode(Logic::CameraController::ECameraMode mode)
 {
     m_CameraMode = mode;
-    disableActions();
+    for (auto& pair : m_ActionBindings)
+    {
+        bool enabled = pair.first == mode;
+        for (auto& managedBinding : pair.second)
+        {
+            managedBinding.getAction().setEnabled(enabled);
+        }
+    }
     switch (mode)
     {
         case ECameraMode::FirstPerson:
             Engine::Input::setMouseLock(true);
-            m_CameraSettings.firstPersonCameraSettings.actionMoveForward->setEnabled(true);
-            m_CameraSettings.firstPersonCameraSettings.actionMoveRight->setEnabled(true);
-            m_CameraSettings.firstPersonCameraSettings.actionLookHorizontal->setEnabled(true);
-            m_CameraSettings.firstPersonCameraSettings.actionLookVertical->setEnabled(true);
             break;
         case ECameraMode::Free:
             Engine::Input::setMouseLock(true);
-            m_CameraSettings.freeCameraSettings.actionMoveForward->setEnabled(true);
-            m_CameraSettings.freeCameraSettings.actionMoveRight->setEnabled(true);
-            m_CameraSettings.freeCameraSettings.actionMoveUp->setEnabled(true);
-            m_CameraSettings.freeCameraSettings.actionLookHorizontal->setEnabled(true);
-            m_CameraSettings.freeCameraSettings.actionLookVertical->setEnabled(true);
             break;
         case ECameraMode::Viewer:
             Engine::Input::setMouseLock(false);
-            m_CameraSettings.viewerCameraSettings.actionViewHorizontal->setEnabled(true);
-            m_CameraSettings.viewerCameraSettings.actionViewVertical->setEnabled(true);
-            m_CameraSettings.viewerCameraSettings.actionPan->setEnabled(true);
-            m_CameraSettings.viewerCameraSettings.actionZoom->setEnabled(true);
-            m_CameraSettings.viewerCameraSettings.actionRotate->setEnabled(true);
-            m_CameraSettings.viewerCameraSettings.actionClick->setEnabled(true);
-            m_CameraSettings.viewerCameraSettings.actionWheel->setEnabled(true);
             break;
         case ECameraMode::ThirdPerson:
             Engine::Input::setMouseLock(true);
-            m_CameraSettings.thirdPersonCameraSettings.actionWheel->setEnabled(true);
-            m_CameraSettings.thirdPersonCameraSettings.actionLookVertical->setEnabled(true);
-            m_CameraSettings.thirdPersonCameraSettings.actionLookHorizontal->setEnabled(true);
             break;
     }
     #ifndef NDEBUG
@@ -451,9 +424,4 @@ void Logic::CameraController::setCameraMode(Logic::CameraController::ECameraMode
 void Logic::CameraController::clearBindings()
 {
     m_ActionBindings.clear();
-}
-
-Logic::CameraController::~CameraController()
-{
-    clearBindings();
 }

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -39,7 +39,8 @@ Logic::CameraController::CameraController(World::WorldInstance& world, Handle::E
     m_CameraSettings.thirdPersonCameraSettings.currentLookAt = Math::float3(0, 0, 0);
     m_CameraSettings.thirdPersonCameraSettings.zoomExponent = 3.2f; // initial zoom pos, feel free to modify
     m_CameraSettings.thirdPersonCameraSettings.pitch = Math::degreeToRadians(20.0f); // initial camera angle, feel free to modify
-    m_CameraSettings.thirdPersonCameraSettings.cameraElevation = Math::degreeToRadians(25.0f); // feel free to modify
+    // if you want to see more of the hero's legs, decrease this value
+    m_CameraSettings.thirdPersonCameraSettings.cameraElevation = Math::degreeToRadians(25.0f);
     m_CameraSettings.thirdPersonCameraSettings.deltaPhi = 0;
 
     // FirstPerson action
@@ -305,17 +306,16 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
                 auto actualCameraAngle = Math::radiansToDegree(angle + m_CameraSettings.thirdPersonCameraSettings.cameraElevation);
 
                 auto rotationAxisDir = pTrans.Left();
-                if (Math::radiansToDegree(angle) > 90 && Math::radiansToDegree(angle) < 270)
+                if (m_CameraSettings.thirdPersonCameraSettings.isFrontView())
                 {
                     // case front view: flip view
                     pdir *= -1;
                     rotationAxisDir *= -1;
                     angle = ZMath::Pi - angle;
-                    // TODO maybe invert control inversion
                 }
 
                 // cardinalPoint around which the camera will rotate vertically
-                auto cameraRotationCenter = playerCenter - length * pdir - height / 2 * up;
+                auto cameraRotationCenter = playerCenter;
                 const auto& zoomExponent = m_CameraSettings.thirdPersonCameraSettings.zoomExponent;
                 float zoom = std::exp(zoomExponent * playerDimension);
 

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -7,6 +7,8 @@ namespace Logic
     class CameraController : public Controller
     {
     public:
+        ~CameraController();
+
         enum class ECameraMode
         {
             Free = 0,

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -59,6 +59,12 @@ namespace Logic
                 float cameraElevation;
                 // rotation around vertical axis (y) to be done on next camera update
                 float deltaPhi;
+                bool isFrontView() const
+                {
+                    const auto& angle = pitch;
+                    // if angle is between 90 and 270 degree
+                    return angle > ZMath::Pi / 2 && angle < (3.0f / 2) * ZMath::Pi;
+                }
             } thirdPersonCameraSettings;
 
             struct

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -35,10 +35,10 @@ namespace Logic
              */
             struct
             {
-                Engine::Action* actionMoveForward;
-                Engine::Action* actionMoveRight;
                 Engine::Action* actionLookHorizontal;
                 Engine::Action* actionLookVertical;
+
+                float yaw, pitch;
             } firstPersonCameraSettings;
 
             /**

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -152,9 +152,9 @@ namespace Logic
         template <class Functor>
         Engine::Action* registerBinding(ECameraMode cameraMode, Engine::ActionType actionType, Functor functor)
         {
-            auto action = Engine::Input::RegisterAction(actionType, functor);
-            m_KeyBindings[cameraMode].push_back(std::make_pair(actionType, action));
-            return action;
+            auto managedBinding = Engine::Input::RegisterAction(actionType, functor);
+            m_ActionBindings[cameraMode].push_back(std::move(managedBinding));
+            return &m_ActionBindings[cameraMode].back().getAction();
         }
 
         /**
@@ -193,7 +193,7 @@ namespace Logic
         /**
          * stored bindings
          */
-        std::map<ECameraMode, std::vector<std::pair<Engine::ActionType, Engine::Action*>>> m_KeyBindings;
+        std::map<ECameraMode, std::vector<Engine::ManagedActionBinding>> m_ActionBindings;
 
         /**
          * Current view-matrix

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -7,6 +7,8 @@ namespace Logic
     class CameraController : public Controller
     {
     public:
+        ~CameraController();
+
         enum class ECameraMode
         {
             Free = 0,
@@ -59,12 +61,6 @@ namespace Logic
                 float cameraElevation;
                 // rotation around vertical axis (y) to be done on next camera update
                 float deltaPhi;
-                bool isFrontView() const
-                {
-                    const auto& angle = pitch;
-                    // if angle is between 90 and 270 degree
-                    return angle > Math::PI / 2 && angle < (3.0f / 2) * Math::PI;
-                }
             } thirdPersonCameraSettings;
 
             struct
@@ -147,7 +143,25 @@ namespace Logic
          */
         void setTransforms(const Math::float3& position, float yaw = 0.0f, float pitch = 0.0f);
 
+        void setDebugMoveSpeed(float moveSpeedMultiplier) { m_moveSpeedMultiplier = moveSpeedMultiplier; }
+
     protected:
+        /**
+         * registers a binding
+         */
+        template <class Functor>
+        Engine::Action* registerBinding(ECameraMode cameraMode, Engine::ActionType actionType, Functor functor)
+        {
+            auto action = Engine::Input::RegisterAction(actionType, functor);
+            m_KeyBindings[cameraMode].push_back(std::make_pair(actionType, action));
+            return action;
+        }
+
+        /**
+         * clears all bindings for camera steering
+         */
+        void clearBindings();
+
         /**
          * Transforms the given yaw/pitch into the corresponding direction vectors
          * @return pair of (forward, right)
@@ -175,6 +189,11 @@ namespace Logic
          * Settings for the different camera modes
          */
         CameraSettings m_CameraSettings;
+
+        /**
+         * stored bindings
+         */
+        std::map<ECameraMode, std::vector<std::pair<Engine::ActionType, Engine::Action*>>> m_KeyBindings;
 
         /**
          * Current view-matrix

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -63,7 +63,7 @@ namespace Logic
                 {
                     const auto& angle = pitch;
                     // if angle is between 90 and 270 degree
-                    return angle > ZMath::Pi / 2 && angle < (3.0f / 2) * ZMath::Pi;
+                    return angle > Math::PI / 2 && angle < (3.0f / 2) * Math::PI;
                 }
             } thirdPersonCameraSettings;
 

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -7,8 +7,6 @@ namespace Logic
     class CameraController : public Controller
     {
     public:
-        ~CameraController();
-
         enum class ECameraMode
         {
             Free = 0,

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -11,12 +11,12 @@ namespace Logic
 
         enum class ECameraMode
         {
-            Free = 0,
-            Static = 1,
-            FirstPerson = 2,
-            ThirdPerson = 3,
+            ThirdPerson,
+            FirstPerson,
+            Free,
+            Viewer, // name is open to change
+            Static,
             KeyedAnimation,
-            Viewer // name is open to change
         };
 
         struct CameraSettings
@@ -195,8 +195,6 @@ namespace Logic
          * @return pair of (forward, right)
          */
         std::pair<Math::float3, Math::float3> getDirectionVectors(float yaw, float pitch);
-
-
 
         /**
          * Whether this controller should read player input

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -46,8 +46,19 @@ namespace Logic
              */
             struct
             {
+                Engine::Action* actionWheel;
+                Engine::Action* actionLookVertical;
+                Engine::Action* actionLookHorizontal;
+
                 Math::float3 currentLookAt;
                 Math::float3 currentOffsetDirection;
+                float zoomExponent;
+                // vertical angle of the camera: 0° = behind player horizontal. 90° = looking from above (-y direction)
+                float pitch;
+                // angle between camera's look-at-point and rotation center. 0° = camera looks at rotation center
+                float cameraElevation;
+                // rotation around vertical axis (y) to be done on next camera update
+                float deltaPhi;
             } thirdPersonCameraSettings;
 
             struct
@@ -99,10 +110,7 @@ namespace Logic
         /**
          * @brief Sets how the camera should behave
          */
-        void setCameraMode(ECameraMode mode)
-        {
-            m_CameraMode = mode;
-        }
+        void setCameraMode(ECameraMode mode);
 
         /**
          * @brief Sets whether this controller should read input

--- a/src/logic/Controller.cpp
+++ b/src/logic/Controller.cpp
@@ -34,7 +34,7 @@ void Logic::Controller::onUpdate(float deltaTime)
 Math::Matrix Logic::Controller::getEntityTransformFacing()
 {
     Math::Matrix copy = getEntityTransform();
-    return copy.RotatedAroundLine(copy.Translation(), getEntityTransform().Up(), ZMath::Pi);
+    return copy.RotatedAroundLine(copy.Translation(), getEntityTransform().Up(), Math::PI);
 }
 
 void Logic::Controller::exportObject(json& j)

--- a/src/logic/Controller.cpp
+++ b/src/logic/Controller.cpp
@@ -34,7 +34,7 @@ void Logic::Controller::onUpdate(float deltaTime)
 Math::Matrix Logic::Controller::getEntityTransformFacing()
 {
     Math::Matrix copy = getEntityTransform();
-    return copy.RotatedAroundLine(copy.Translation(), getEntityTransform().Up(), M_PI);
+    return copy.RotatedAroundLine(copy.Translation(), getEntityTransform().Up(), ZMath::Pi);
 }
 
 void Logic::Controller::exportObject(json& j)

--- a/src/logic/Controller.cpp
+++ b/src/logic/Controller.cpp
@@ -31,6 +31,12 @@ void Logic::Controller::onUpdate(float deltaTime)
 {
 }
 
+Math::Matrix Logic::Controller::getEntityTransformFacing()
+{
+    Math::Matrix copy = getEntityTransform();
+    return copy.RotatedAroundLine(copy.Translation(), getEntityTransform().Up(), M_PI);
+}
+
 void Logic::Controller::exportObject(json& j)
 {
     exportPart(j);

--- a/src/logic/Controller.h
+++ b/src/logic/Controller.h
@@ -63,6 +63,12 @@ namespace Logic
         Math::Matrix& getEntityTransform();
 
         /**
+         * @return The current transform of the underlaying entity
+         * where Forward/Left/Right matches the perspective of the player model
+         */
+        Math::Matrix getEntityTransformFacing();
+
+        /**
          * @brief Called when something else modified the transform of the underlaying entity
          */
         virtual void onTransformChanged(){};

--- a/src/logic/MobController.cpp
+++ b/src/logic/MobController.cpp
@@ -510,7 +510,7 @@ void MobController::setIdealPosition(Handle::EntityHandle npc)
     else
     {
         nv.playerController->teleportToPosition(getEntityTransform() * p->transform.Translation());
-        nv.playerController->setDirection(getEntityTransform() * p->transform.Forward() - getEntityTransform().Translation());
+        nv.playerController->setDirection(getEntityTransform() * (-1.0f * p->transform.Forward()) - getEntityTransform().Translation());
 
         // Just look at the mob for now //TODO: Implement the transform-stuff
         //nv.playerController->setDirection((getEntityTransform().Translation()

--- a/src/logic/MobController.cpp
+++ b/src/logic/MobController.cpp
@@ -510,7 +510,7 @@ void MobController::setIdealPosition(Handle::EntityHandle npc)
     else
     {
         nv.playerController->teleportToPosition(getEntityTransform() * p->transform.Translation());
-        nv.playerController->setDirection(getEntityTransform() * (-1.0f * p->transform.Forward()) - getEntityTransform().Translation());
+        nv.playerController->setDirection(getEntityTransform() * p->transform.Forward() - getEntityTransform().Translation());
 
         // Just look at the mob for now //TODO: Implement the transform-stuff
         //nv.playerController->setDirection((getEntityTransform().Translation()

--- a/src/logic/NpcAIHandler.cpp
+++ b/src/logic/NpcAIHandler.cpp
@@ -299,52 +299,43 @@ void NpcAIHandler::playerUpdate(float deltaTime)
     resetKeyStates();
 }
 
-void NpcAIHandler::bindKeys()
+void NpcAIHandler::onAction(Engine::ActionType actionType, bool triggered)
 {
-    m_MovementState.actionForward = Engine::Input::RegisterAction(Engine::ActionType::PlayerForward, [this](bool triggered, float) {
-        m_MovementState.isForward = m_MovementState.isForward || triggered;
-    });
-
-    m_MovementState.actionBackward = Engine::Input::RegisterAction(Engine::ActionType::PlayerBackward, [this](bool triggered, float) {
-        m_MovementState.isBackward = m_MovementState.isBackward || triggered;
-    });
-
-    m_MovementState.actionStrafeLeft = Engine::Input::RegisterAction(Engine::ActionType::PlayerStrafeLeft, [this](bool triggered, float) {
-        m_MovementState.isStrafeLeft = m_MovementState.isStrafeLeft || triggered;
-    });
-
-    m_MovementState.actionStrafeRight = Engine::Input::RegisterAction(Engine::ActionType::PlayerStrafeRight, [this](bool triggered, float) {
-        m_MovementState.isStrafeRight = m_MovementState.isStrafeRight || triggered;
-    });
-
-    m_MovementState.actionTurnRight = Engine::Input::RegisterAction(Engine::ActionType::PlayerTurnRight, [this](bool triggered, float) {
-        m_MovementState.isTurnRight = m_MovementState.isTurnRight || triggered;
-    });
-
-    m_MovementState.actionTurnRight = Engine::Input::RegisterAction(Engine::ActionType::PlayerTurnLeft, [this](bool triggered, float) {
-        m_MovementState.isTurnLeft = m_MovementState.isTurnLeft || triggered;
-    });
-
-    m_MovementState.actionTurnRight = Engine::Input::RegisterAction(Engine::ActionType::PlayerDrawWeaponMelee, [this](bool triggered, float) {
-        m_MovementState.isLastWeaponKey = m_MovementState.isLastWeaponKey || triggered;
-    });
-
-    m_MovementState.actionAction = Engine::Input::RegisterAction(Engine::ActionType::PlayerAction, [this](bool triggered, float) {
-        m_MovementState.isAction = m_MovementState.isAction || triggered;
-    });
+    // TODO remove this? and replace by Playercontroller isForward...?
+    using Engine::ActionType;
+    switch (actionType)
+    {
+        case ActionType::PlayerForward:
+            m_MovementState.isForward = m_MovementState.isForward || triggered;
+            break;
+        case ActionType::PlayerBackward:
+            m_MovementState.isBackward = m_MovementState.isBackward || triggered;
+            break;
+        case ActionType::PlayerStrafeLeft:
+            m_MovementState.isStrafeLeft = m_MovementState.isStrafeLeft || triggered;
+            break;
+        case ActionType::PlayerStrafeRight:
+            m_MovementState.isStrafeRight = m_MovementState.isStrafeRight || triggered;
+            break;
+        case ActionType::PlayerTurnRight:
+            m_MovementState.isTurnRight = m_MovementState.isTurnRight || triggered;
+            break;
+        case ActionType::PlayerTurnLeft:
+            m_MovementState.isTurnLeft = m_MovementState.isTurnLeft || triggered;
+            break;
+        case ActionType::PlayerDrawWeaponMelee:
+            m_MovementState.isLastWeaponKey = m_MovementState.isLastWeaponKey || triggered;
+            break;
+        case ActionType::PlayerAction:
+            m_MovementState.isAction = m_MovementState.isAction || triggered;
+            break;
+        default:
+            break;
+    }
 }
 
 void NpcAIHandler::unbindKeys()
 {
-    Engine::Input::RemoveAction(Engine::ActionType::PlayerForward, m_MovementState.actionForward);
-    Engine::Input::RemoveAction(Engine::ActionType::PlayerBackward, m_MovementState.actionBackward);
-    Engine::Input::RemoveAction(Engine::ActionType::PlayerStrafeLeft, m_MovementState.actionStrafeLeft);
-    Engine::Input::RemoveAction(Engine::ActionType::PlayerStrafeRight, m_MovementState.actionStrafeRight);
-    Engine::Input::RemoveAction(Engine::ActionType::PlayerTurnLeft, m_MovementState.actionTurnLeft);
-    Engine::Input::RemoveAction(Engine::ActionType::PlayerTurnRight, m_MovementState.actionTurnRight);
-    Engine::Input::RemoveAction(Engine::ActionType::PlayerDrawWeaponMelee, m_MovementState.actionLastWeapon);
-    Engine::Input::RemoveAction(Engine::ActionType::PlayerAction, m_MovementState.actionAction);
-
     // Zero out everything
     m_MovementState = {};
 }

--- a/src/logic/NpcAIHandler.h
+++ b/src/logic/NpcAIHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <handle/HandleDef.h>
+#include <engine/Input.h>
 
 namespace World
 {
@@ -60,9 +61,9 @@ namespace Logic
         void standup();
 
         /**
-         * Sets up keybindings for this handler
+         * Handles key event
          */
-        void bindKeys();
+        void onAction(Engine::ActionType actionType, bool triggered);
         void unbindKeys();
 
         /**
@@ -94,17 +95,6 @@ namespace Logic
             bool isStrafeRight = false;
             bool isLastWeaponKey = false;
             bool isAction = false;
-            /**
-             * All bound actions. Stored so we can unbind them later
-             */
-            Engine::Action* actionForward = nullptr;
-            Engine::Action* actionBackward = nullptr;
-            Engine::Action* actionTurnLeft = nullptr;
-            Engine::Action* actionTurnRight = nullptr;
-            Engine::Action* actionStrafeLeft = nullptr;
-            Engine::Action* actionStrafeRight = nullptr;
-            Engine::Action* actionLastWeapon = nullptr;
-            Engine::Action* actionAction = nullptr;
         } m_MovementState;
 
         /**

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2458,7 +2458,7 @@ void PlayerController::AniEvent_Tag(const ZenLoad::zCModelScriptEventTag& tag)
     //if(tag.m_Tag == )
 }
 
-void PlayerController::onAction(Engine::ActionType actionType, bool triggered)
+void PlayerController::onAction(Engine::ActionType actionType, bool triggered, float intensity)
 {
     using Engine::ActionType;
 
@@ -2530,6 +2530,14 @@ void PlayerController::onAction(Engine::ActionType actionType, bool triggered)
             break;
         case ActionType::DebugMoveSpeed2:
             m_MoveSpeed2 = m_MoveSpeed2 || triggered;
+            break;
+        case ActionType::PlayerRotate:
+        {
+            auto dir = getDirection();
+            auto deltaPhi = 0.02f * intensity; // TODO window width influences this???
+            dir = Math::Matrix::rotatedPointAroundLine(dir, {0, 0, 0}, getEntityTransform().Up(), deltaPhi);
+            setDirection(dir);
+        }
             break;
         case ActionType::PlayerAction:
         {

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2063,258 +2063,6 @@ void PlayerController::changeAttribute(Daedalus::GEngineClasses::C_Npc::EAttribu
     }
 }
 
-void PlayerController::setupKeyBindings()
-{
-    // Engine::Input::clearActions();
-    m_AIHandler.bindKeys();
-
-    Engine::Input::RegisterAction(Engine::ActionType::Quicksave, [this](bool triggered, float) {
-        if (triggered)
-        {
-            bool forceQueue = true; // better do saving at frame end and not between entity updates
-            m_World.getEngine()->executeInMainThread([](Engine::BaseEngine* engine){
-                Engine::SavegameManager::saveToSlot(0, "");
-            }, forceQueue);
-        }
-    });
-
-    Engine::Input::RegisterAction(Engine::ActionType::Quickload, [this](bool triggered, float) {
-        if (triggered)
-            Engine::SavegameManager::loadSaveGameSlot(0);
-    });
-
-    Engine::Input::RegisterAction(Engine::ActionType::PauseGame, [this](bool triggered, float) {
-        if (triggered && !m_World.getEngine()->getHud().isMenuActive())
-        {
-            m_World.getEngine()->togglePaused();
-        }
-    });
-
-    Engine::Input::RegisterAction(Engine::ActionType::PlayerDrawWeaponMelee, [this](bool triggered, float) {
-        m_isDrawWeaponMelee = triggered;
-    });
-    Engine::Input::RegisterAction(Engine::ActionType::PlayerForward, [this](bool triggered, float) {
-
-        // Increment state, if currently using a mob
-        if (getUsedMob().isValid() && triggered)
-        {
-            if (getEM().isEmpty())
-            {
-                VobTypes::MobVobInformation mob = VobTypes::asMobVob(m_World, getUsedMob());
-                if (mob.isValid())
-                {
-                    LogInfo() << getScriptInstance().name[0] << ": Incrementing state on mob: "
-                              << mob.mobController->getFocusName();
-                    mob.mobController->useMobIncState(m_Entity, MobController::D_Forward);
-                }
-            }
-        }
-        else
-        {
-            m_isForward = m_isForward || triggered;
-        }
-    });
-    Engine::Input::RegisterAction(Engine::ActionType::PlayerBackward, [this](bool triggered, float) {
-
-        // Increment state, if currently using a mob
-        if (getUsedMob().isValid() && triggered)
-        {
-            if (getEM().isEmpty())
-            {
-                VobTypes::MobVobInformation mob = VobTypes::asMobVob(m_World, getUsedMob());
-                if (mob.isValid())
-                {
-                    LogInfo() << getScriptInstance().name[0] << ": Decrementing state on mob: "
-                              << mob.mobController->getFocusName();
-                    mob.mobController->useMobIncState(m_Entity, MobController::D_Backward);
-                }
-            }
-        }
-        else
-        {
-            m_isBackward = m_isBackward || triggered;
-        }
-    });
-    Engine::Input::RegisterAction(Engine::ActionType::PlayerTurnLeft, [this](bool triggered, float) {
-        m_isTurnLeft = m_isTurnLeft || triggered;
-    });
-    Engine::Input::RegisterAction(Engine::ActionType::PlayerTurnRight, [this](bool triggered, float) {
-        m_isTurnRight = m_isTurnRight || triggered;
-    });
-    Engine::Input::RegisterAction(Engine::ActionType::PlayerStrafeLeft, [this](bool triggered, float) {
-        m_isStrafeLeft = m_isStrafeLeft || triggered;
-    });
-    Engine::Input::RegisterAction(Engine::ActionType::PlayerStrafeRight, [this](bool triggered, float) {
-        m_isStrafeRight = m_isStrafeRight || triggered;
-    });
-
-    Engine::Input::RegisterAction(Engine::ActionType::DebugMoveSpeed, [this](bool triggered, float intensity) {
-        m_MoveSpeed1 = m_MoveSpeed1 || triggered;
-    });
-
-    Engine::Input::RegisterAction(Engine::ActionType::DebugMoveSpeed2, [this](bool triggered, float intensity) {
-        m_MoveSpeed2 = m_MoveSpeed2 || triggered;
-    });
-
-    Engine::Input::RegisterAction(Engine::ActionType::PlayerAction, [this](bool triggered, float intensity) {
-        static bool s_triggered = false;
-
-        if (s_triggered && !triggered)
-            s_triggered = false;
-        else if (!s_triggered && triggered)
-        {
-            s_triggered = true;
-
-            if (m_World.getDialogManager().isDialogActive())
-                return;
-
-            if (getWeaponMode() != EWeaponMode::WeaponNone)
-                return;
-
-            // ----- ITEMS -----
-            Handle::EntityHandle nearestItem;
-            float shortestDistItem = 5.0f;
-            const std::set<Handle::EntityHandle>& items = m_World.getScriptEngine().getWorldItems();
-            for (Handle::EntityHandle h : items)
-            {
-                Math::Matrix& m = m_World.getEntity<Components::PositionComponent>(h).m_WorldMatrix;
-
-                float dist = (m.Translation() -
-                              getEntityTransform().Translation())
-                                 .lengthSquared();
-                if (dist < shortestDistItem && dist < 10.0f * 10.0f)
-                {
-                    nearestItem = h;
-                    shortestDistItem = dist;
-                }
-            }
-
-            std::set<Handle::EntityHandle> nearNPCs = m_World.getScriptEngine().getNPCsInRadius(
-                getEntityTransform().Translation(), 5.0f);
-
-            // Talk to the nearest NPC other than the current player, of course
-            Handle::EntityHandle nearestNPC;
-            float shortestDistNPC = 5.0f;
-            for (const Handle::EntityHandle& h : nearNPCs)
-            {
-                if (h != m_World.getScriptEngine().getPlayerEntity())
-                {
-                    VobTypes::NpcVobInformation npc = VobTypes::asNpcVob(m_World, h);
-
-                    float dist = (Vob::getTransform(npc).Translation() -
-                                  getEntityTransform().Translation())
-                                     .lengthSquared();
-                    if (dist < shortestDistNPC)
-                    {
-                        nearestNPC = h;
-                        shortestDistNPC = dist;
-                    }
-                }
-            }
-
-            std::set<Handle::EntityHandle> mobs = m_World.getScriptEngine().getWorldMobs();
-
-            // Use the nearest mob
-            Handle::EntityHandle nearestMob;
-            float shortestDistMob = 5.0f;
-            for (const Handle::EntityHandle& h : mobs)
-            {
-                VobTypes::MobVobInformation vob = VobTypes::asMobVob(m_World, h);
-
-                float dist = (Vob::getTransform(vob).Translation() -
-                              getEntityTransform().Translation())
-                                 .lengthSquared();
-
-                if (dist < shortestDistMob)
-                {
-                    nearestMob = h;
-                    shortestDistMob = dist;
-                }
-            }
-
-            int nearest = 0;
-
-            if (shortestDistItem < shortestDistMob && shortestDistItem < shortestDistNPC)
-                nearest = 1;
-
-            if (shortestDistMob < shortestDistItem && shortestDistMob < shortestDistNPC)
-                nearest = 3;
-
-            if (shortestDistNPC < shortestDistItem && shortestDistNPC < shortestDistMob)
-                nearest = 2;
-
-            if (nearest == 1 && nearestItem.isValid())
-            {
-                // Pick it up
-                VobTypes::ItemVobInformation item = VobTypes::asItemVob(m_World, nearestItem);
-                item.itemController->pickUp(m_Entity);
-
-                getEM().onMessage(EventMessages::ConversationMessage::playAnimation("c_Stand_2_IGet_1"));
-                getEM().onMessage(EventMessages::ConversationMessage::playAnimation("c_IGet_2_Stand_1"));
-
-                return;
-            }
-
-            // ----- TALKING ----
-
-            if (nearest == 2 && nearestNPC.isValid())
-            {
-                VobTypes::NpcVobInformation npc = VobTypes::asNpcVob(m_World, nearestNPC);
-
-                if (npc.playerController->getBodyState() == BS_STAND)
-                {
-                    Daedalus::GameState::NpcHandle shnpc = VobTypes::getScriptHandle(npc);
-                    m_World.getDialogManager().assessTalk(shnpc);
-                }
-                else if (npc.playerController->getBodyState() == BS_UNCONSCIOUS || npc.playerController->getBodyState() == BS_DEAD)
-                {
-                    // Take all his items
-                    auto& inv = npc.playerController->getInventory();
-                    for (auto h : inv.getItems())
-                    {
-                        unsigned int cnt = inv.getItemCount(h);
-                        size_t itm = inv.getItem(h).instanceSymbol;
-
-                        getInventory().addItem(itm, cnt);
-                    }
-
-                    inv.clear();
-                }
-
-                return;
-            }
-
-            if (nearest == 3 && nearestMob.isValid())
-            {
-                VobTypes::MobVobInformation vob = VobTypes::asMobVob(m_World, nearestMob);
-
-                LogInfo() << "Using mob: " << vob.mobController->getFocusName();
-
-                vob.mobController->useMobToState(m_Entity, 1);
-                return;
-            }
-
-            /*size_t targetWP = World::Waynet::findNearestWaypointTo(m_World.getWaynet(), getEntityTransform().Translation());
-                Handle::EntityHandle h = VobTypes::Wld_InsertNpc(m_World, "VLK_574_Mud", m_World.getWaynet().waypoints[targetWP].name);
-                VobTypes::NpcVobInformation vob = VobTypes::asNpcVob(m_World, h);
-
-                vob.playerController->changeRoutine("");
-                vob.playerController->teleportToWaypoint(targetWP);*/
-
-            // Use item last picked up
-            if (!getInventory().getItems().empty())
-            {
-                Daedalus::GameState::ItemHandle lastItem = getInventory().getItems().back();
-                if (lastItem.isValid())
-                {
-                    if (useItem(lastItem))
-                        getInventory().removeItem(lastItem);
-                }
-            }
-        }
-    });
-}
-
 void PlayerController::giveItem(const std::string& instanceName, unsigned int count)
 {
     size_t symIdx = m_World.getScriptEngine().getSymbolIndexByName(instanceName);
@@ -2403,9 +2151,9 @@ void PlayerController::importObject(const json& j, bool noTransform)
         // Teleport to position
         {
             // need to copy since changing position sets the direction of the transform matrix
-            auto transformMatrixCopy = getEntityTransform();
-            teleportToPosition(transformMatrixCopy.Translation());
-            setDirection(-1.0f * transformMatrixCopy.Forward());
+            auto forward = getEntityTransform().Forward();
+            teleportToPosition(getEntityTransform().Translation());
+            setDirection(-1.0f * forward);
         }
     }
 
@@ -2778,4 +2526,242 @@ void PlayerController::AniEvent_SFXGround(const ZenLoad::zCModelScriptEventSfx& 
 void PlayerController::AniEvent_Tag(const ZenLoad::zCModelScriptEventTag& tag)
 {
     //if(tag.m_Tag == )
+}
+
+void PlayerController::onAction(Engine::ActionType actionType, bool triggered)
+{
+    using Engine::ActionType;
+
+    m_AIHandler.onAction(actionType, triggered);
+
+    switch (actionType)
+    {
+        case ActionType::PlayerDrawWeaponMelee:
+            m_isDrawWeaponMelee = triggered;
+            break;
+        case ActionType::PlayerForward:
+        {
+            // Increment state, if currently using a mob
+            if (getUsedMob().isValid() && triggered)
+            {
+                if (getEM().isEmpty())
+                {
+                    VobTypes::MobVobInformation mob = VobTypes::asMobVob(m_World, getUsedMob());
+                    if (mob.isValid())
+                    {
+                        LogInfo() << getScriptInstance().name[0] << ": Incrementing state on mob: "
+                                  << mob.mobController->getFocusName();
+                        mob.mobController->useMobIncState(m_Entity, MobController::D_Forward);
+                    }
+                }
+            }
+            else
+            {
+                m_isForward = m_isForward || triggered;
+            }
+        }
+            break;
+        case ActionType::PlayerBackward:
+        {
+            // Increment state, if currently using a mob
+            if (getUsedMob().isValid() && triggered)
+            {
+                if (getEM().isEmpty())
+                {
+                    VobTypes::MobVobInformation mob = VobTypes::asMobVob(m_World, getUsedMob());
+                    if (mob.isValid())
+                    {
+                        LogInfo() << getScriptInstance().name[0] << ": Decrementing state on mob: "
+                                  << mob.mobController->getFocusName();
+                        mob.mobController->useMobIncState(m_Entity, MobController::D_Backward);
+                    }
+                }
+            }
+            else
+            {
+                m_isBackward = m_isBackward || triggered;
+            }
+        }
+            break;
+        case ActionType::PlayerTurnLeft:
+            m_isTurnLeft = m_isTurnLeft || triggered;
+            break;
+        case ActionType::PlayerTurnRight:
+            m_isTurnRight = m_isTurnRight || triggered;
+            break;
+        case ActionType::PlayerStrafeLeft:
+            m_isStrafeLeft = m_isStrafeLeft || triggered;
+            break;
+        case ActionType::PlayerStrafeRight:
+            m_isStrafeRight = m_isStrafeRight || triggered;
+            break;
+        case ActionType::DebugMoveSpeed:
+            m_MoveSpeed1 = m_MoveSpeed1 || triggered;
+            break;
+        case ActionType::DebugMoveSpeed2:
+            m_MoveSpeed2 = m_MoveSpeed2 || triggered;
+            break;
+        case ActionType::PlayerAction:
+        {
+            static bool s_triggered = false;
+
+            if (s_triggered && !triggered)
+                s_triggered = false;
+            else if (!s_triggered && triggered)
+            {
+                s_triggered = true;
+
+                if (m_World.getDialogManager().isDialogActive())
+                    return;
+
+                if (getWeaponMode() != EWeaponMode::WeaponNone)
+                    return;
+
+                // ----- ITEMS -----
+                Handle::EntityHandle nearestItem;
+                float shortestDistItem = 5.0f;
+                const std::set<Handle::EntityHandle>& items = m_World.getScriptEngine().getWorldItems();
+                for (Handle::EntityHandle h : items)
+                {
+                    Math::Matrix& m = m_World.getEntity<Components::PositionComponent>(h).m_WorldMatrix;
+
+                    float dist = (m.Translation() -
+                        getEntityTransform().Translation())
+                        .lengthSquared();
+                    if (dist < shortestDistItem && dist < 10.0f * 10.0f)
+                    {
+                        nearestItem = h;
+                        shortestDistItem = dist;
+                    }
+                }
+
+                std::set<Handle::EntityHandle> nearNPCs = m_World.getScriptEngine().getNPCsInRadius(
+                    getEntityTransform().Translation(), 5.0f);
+
+                // Talk to the nearest NPC other than the current player, of course
+                Handle::EntityHandle nearestNPC;
+                float shortestDistNPC = 5.0f;
+                for (const Handle::EntityHandle& h : nearNPCs)
+                {
+                    if (h != m_World.getScriptEngine().getPlayerEntity())
+                    {
+                        VobTypes::NpcVobInformation npc = VobTypes::asNpcVob(m_World, h);
+
+                        float dist = (Vob::getTransform(npc).Translation() -
+                            getEntityTransform().Translation())
+                            .lengthSquared();
+                        if (dist < shortestDistNPC)
+                        {
+                            nearestNPC = h;
+                            shortestDistNPC = dist;
+                        }
+                    }
+                }
+
+                std::set<Handle::EntityHandle> mobs = m_World.getScriptEngine().getWorldMobs();
+
+                // Use the nearest mob
+                Handle::EntityHandle nearestMob;
+                float shortestDistMob = 5.0f;
+                for (const Handle::EntityHandle& h : mobs)
+                {
+                    VobTypes::MobVobInformation vob = VobTypes::asMobVob(m_World, h);
+
+                    float dist = (Vob::getTransform(vob).Translation() -
+                        getEntityTransform().Translation())
+                        .lengthSquared();
+
+                    if (dist < shortestDistMob)
+                    {
+                        nearestMob = h;
+                        shortestDistMob = dist;
+                    }
+                }
+
+                int nearest = 0;
+
+                if (shortestDistItem < shortestDistMob && shortestDistItem < shortestDistNPC)
+                    nearest = 1;
+
+                if (shortestDistMob < shortestDistItem && shortestDistMob < shortestDistNPC)
+                    nearest = 3;
+
+                if (shortestDistNPC < shortestDistItem && shortestDistNPC < shortestDistMob)
+                    nearest = 2;
+
+                if (nearest == 1 && nearestItem.isValid())
+                {
+                    // Pick it up
+                    VobTypes::ItemVobInformation item = VobTypes::asItemVob(m_World, nearestItem);
+                    item.itemController->pickUp(m_Entity);
+
+                    getEM().onMessage(EventMessages::ConversationMessage::playAnimation("c_Stand_2_IGet_1"));
+                    getEM().onMessage(EventMessages::ConversationMessage::playAnimation("c_IGet_2_Stand_1"));
+
+                    return;
+                }
+
+                // ----- TALKING ----
+
+                if (nearest == 2 && nearestNPC.isValid())
+                {
+                    VobTypes::NpcVobInformation npc = VobTypes::asNpcVob(m_World, nearestNPC);
+
+                    if (npc.playerController->getBodyState() == BS_STAND)
+                    {
+                        Daedalus::GameState::NpcHandle shnpc = VobTypes::getScriptHandle(npc);
+                        m_World.getDialogManager().assessTalk(shnpc);
+                    }
+                    else if (npc.playerController->getBodyState() == BS_UNCONSCIOUS || npc.playerController->getBodyState() == BS_DEAD)
+                    {
+                        // Take all his items
+                        auto& inv = npc.playerController->getInventory();
+                        for (auto h : inv.getItems())
+                        {
+                            unsigned int cnt = inv.getItemCount(h);
+                            size_t itm = inv.getItem(h).instanceSymbol;
+
+                            getInventory().addItem(itm, cnt);
+                        }
+
+                        inv.clear();
+                    }
+
+                    return;
+                }
+
+                if (nearest == 3 && nearestMob.isValid())
+                {
+                    VobTypes::MobVobInformation vob = VobTypes::asMobVob(m_World, nearestMob);
+
+                    LogInfo() << "Using mob: " << vob.mobController->getFocusName();
+
+                    vob.mobController->useMobToState(m_Entity, 1);
+                    return;
+                }
+
+                /*size_t targetWP = World::Waynet::findNearestWaypointTo(m_World.getWaynet(), getEntityTransform().Translation());
+                    Handle::EntityHandle h = VobTypes::Wld_InsertNpc(m_World, "VLK_574_Mud", m_World.getWaynet().waypoints[targetWP].name);
+                    VobTypes::NpcVobInformation vob = VobTypes::asNpcVob(m_World, h);
+
+                    vob.playerController->changeRoutine("");
+                    vob.playerController->teleportToWaypoint(targetWP);*/
+
+                // Use item last picked up
+                if (!getInventory().getItems().empty())
+                {
+                    Daedalus::GameState::ItemHandle lastItem = getInventory().getItems().back();
+                    if (lastItem.isValid())
+                    {
+                        if (useItem(lastItem))
+                            getInventory().removeItem(lastItem);
+                    }
+                }
+            }
+        }
+            break;
+        default:
+            assert(false);
+            break;
+    }
 }

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -387,10 +387,11 @@ namespace Logic
          * @return Waypoint the NPC is currently going to
          */
         size_t getTargetWaypoint() { return m_AIState.targetWaypoint; }
+
         /**
-         * Sets up the bindings for this playercontroller // TODO: REMOVE THIS AND DO IT OUTSIDE OF THE PLAYERCONTROLLER
+         * Handles actions, that affect this NPC
          */
-        void setupKeyBindings();
+        void onAction(Engine::ActionType actionType, bool triggered);
 
         /**
          * Updates the given status-screen once with the current attributes
@@ -640,7 +641,7 @@ namespace Logic
         void resetKeyStates();
 
         // FIXME: Hack for as long as animation-flags are not implemented
-        // Turns of modifying the root postion from the animation
+        // Turns of modifying the root position from the animation
         bool m_NoAniRootPosHack;
         size_t m_LastAniRootPosUpdatedAniHash;
 

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -371,7 +371,7 @@ namespace Logic
         /**
          * Handles actions, that affect this NPC
          */
-        void onAction(Engine::ActionType actionType, bool triggered);
+        void onAction(Engine::ActionType actionType, bool triggered, float intensity);
 
         /**
          * Updates the given status-screen once with the current attributes

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -275,7 +275,7 @@ int Engine::SavegameManager::maxSlots()
 
 void Engine::SavegameManager::saveToSlot(int index, std::string savegameName)
 {
-    if (gameEngine->getMainWorld().get().getDialogManager().isDialogActive())
+    if (!gameEngine->getMainWorld().isValid() || gameEngine->getMainWorld().get().getDialogManager().isDialogActive())
         return; // only save while not in Dialog
 
     ExcludeFrameTime exclude(*gameEngine);

--- a/src/math/mathlib.cpp
+++ b/src/math/mathlib.cpp
@@ -32,3 +32,13 @@ std::ostream& Math::operator<<(std::ostream& out, Math::Matrix& m)
     out << "]";
     return out;
 }
+
+float Math::degreeToRadians(float degree)
+{
+    return glm::radians(degree);
+}
+
+float ::Math::radiansToDegree(float radians)
+{
+    return glm::degrees(radians);
+}

--- a/src/math/mathlib.h
+++ b/src/math/mathlib.h
@@ -11,6 +11,16 @@ namespace Math
 {
     static const float PI = glm::pi<float>();
 
+    /**
+     * converts angle in unit degree to unit radians
+     */
+    float degreeToRadians(float degree);
+
+    /**
+     * converts angle in unit radians to unit degree
+     */
+    float radiansToDegree(float radians);
+
     constexpr int64_t ipow(int64_t base, int exp, int64_t result = 1)
     {
         return exp < 1 ? result : ipow(base * base, exp / 2, (exp % 2) ? result * base : result);
@@ -524,7 +534,7 @@ namespace Math
             _43 = v.z;
         }
 
-        Matrix Rotation()
+        Matrix Rotation() const
         {
             Matrix m = *this;
             m.Translation(Math::float3(0, 0, 0));
@@ -540,6 +550,26 @@ namespace Math
 
             return tmp;
         }
+
+        /**
+         * apply a rotation by angle around the specifed line (axis) and returns the result
+         */
+        Matrix RotatedAroundLine(const float3& linePoint, const float3& lineDirection, float angle) const
+        {
+            auto rotationMatrix = Math::Matrix::CreateFromAxisAngle(lineDirection, angle);
+            auto result = rotationMatrix * this->Rotation();
+            auto newTranslation = rotatedPointAroundLine(this->Translation(), linePoint, lineDirection, angle);
+            result.Translation(newTranslation);
+            return result;
+        }
+
+        static float3 rotatedPointAroundLine(Math::float3 point, Math::float3 linePoint, Math::float3 lineDirection, float angle)
+        {
+            point -= linePoint;
+            auto rotationMatrix = Math::Matrix::CreateFromAxisAngle(lineDirection, angle);
+            return rotationMatrix * point + linePoint;
+        };
+
 
         float Determinant() const { return glm::determinant(_glmMatrix); }
         static Matrix CreateIdentity() { return Matrix(glm::mat4(1.0)); }

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -491,3 +491,13 @@ bool Utils::endsWith(const std::string& searchSpace, const std::string& end)
     auto pos = searchSpace.size() - end.size();
     return end.size() <= searchSpace.size() && searchSpace.find(end, pos) != std::string::npos;
 }
+
+float Utils::fmod(float a, float b)
+{
+    return std::fmod(std::fmod(a, b) + b, b);
+}
+
+double Utils::fmod(double a, double b)
+{
+    return std::fmod(std::fmod(a, b) + b, b);
+}

--- a/src/utils/Utils.h
+++ b/src/utils/Utils.h
@@ -178,7 +178,7 @@ namespace Utils
     }
 
     /**
-     * Modulo-operation which works for negative numbers as well
+     * Modulo-operation for integral types which works for negative numbers as well
      * @return a mod b
      */
     template <typename T>
@@ -186,6 +186,13 @@ namespace Utils
     {
         return (a % b + b) % b;
     }
+
+    /**
+     * fmod-operation for floating point types which works for negative numbers as well
+     * @return a mod b
+     */
+    float fmod(float a, float b);
+    double fmod(double a, double b);
 
     /**
      * Converts ISO-8859-1 to UTF-8


### PR DESCRIPTION
- added mouse control for Third Person Camera (x/y-axis + mousewheel zoom)
- Moved the registering of the bindings out of the PlayerController.
- Camera Hotkeys F1-F4 should work again now