### PR TITLE
Npc movement

### DIFF
--- a/src/components/Entities.h
+++ b/src/components/Entities.h
@@ -52,6 +52,11 @@ namespace Components
      */
     struct EntityComponent : public Component
     {
+        enum
+        {
+            MASK = 1 << 1
+        };
+
         ComponentMask m_ComponentMask;
 
         // Handle of this entity-component
@@ -66,7 +71,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 1
+            MASK = 1 << 2
         };
         Math::Matrix m_WorldMatrix;
 
@@ -90,7 +95,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 2
+            MASK = 1 << 3
         };
 
         std::vector<Utils::BBox3D> m_BBox3D;
@@ -107,7 +112,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 3
+            MASK = 1 << 4
         };
 
         Utils::BBox3D m_BBox3D;
@@ -128,7 +133,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 4
+            MASK = 1 << 5
         };
 
         /**
@@ -166,7 +171,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 5
+            MASK = 1 << 6
         };
 
         /**
@@ -187,7 +192,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 6
+            MASK = 1 << 7
         };
 
         /**
@@ -208,7 +213,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 7
+            MASK = 1 << 8
         };
 
         /**
@@ -232,7 +237,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 8
+            MASK = 1 << 9
         };
 
         enum EObjectType
@@ -272,7 +277,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 9
+            MASK = 1 << 10
         };
 
         /**
@@ -300,7 +305,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 10
+            MASK = 1 << 11
         };
 
         /**
@@ -323,7 +328,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 11
+            MASK = 1 << 12
         };
 
         /**
@@ -346,7 +351,7 @@ namespace Components
     {
         enum
         {
-            MASK = 1 << 12
+            MASK = 1 << 13
         };
 
         /**

--- a/src/components/EntityActions.cpp
+++ b/src/components/EntityActions.cpp
@@ -5,20 +5,26 @@
 void ::Components::Actions::Logic::destroyLogicComponent(Components::LogicComponent& c)
 {
     delete c.m_pLogicController;
+    c.m_pLogicController = nullptr;
 }
 
 void ::Components::Actions::Logic::destroyVisualComponent(VisualComponent& c)
 {
     delete c.m_pVisualController;
+    c.m_pVisualController = nullptr;
 }
 
 void ::Components::Actions::Logic::destroyPfxComponent(Components::PfxComponent& c)
 {
     if (bgfx::isValid(c.m_ParticleVB))
+    {
         bgfx::destroyDynamicVertexBuffer(c.m_ParticleVB);
+        c.m_ParticleVB = BGFX_INVALID_HANDLE;
+    }
 }
 
 void ::Components::Actions::Animation::destroyAnimationComponent(AnimationComponent& c)
 {
     delete c.m_AnimHandler;
+    c.m_AnimHandler = nullptr;
 }

--- a/src/components/EntityActions.h
+++ b/src/components/EntityActions.h
@@ -188,8 +188,15 @@ namespace Components
                                      F f)
         {
             std::tuple<ALL_COMPONENTS> t;
+            Components::EntityComponent entityComponent = alloc.getElement<Components::EntityComponent>(e);
+
+
             Utils::for_each_in_tuple(t, [&](auto& v) {
-                f(alloc.getElement<typename std::remove_reference<decltype(v)>::type>(e));
+
+                if(Components::hasComponent<typename std::decay<decltype(v)>::type>(entityComponent))
+                {
+                    f(alloc.getElement<typename std::remove_reference<decltype(v)>::type>(e));
+                }
             });
         }
     }

--- a/src/components/Vob.cpp
+++ b/src/components/Vob.cpp
@@ -19,20 +19,15 @@ Handle::EntityHandle Vob::constructVob(World::WorldInstance& world)
     Components::EntityComponent& entity = world.getEntity<Components::EntityComponent>(e);
 
     // Add components
-    Components::addComponent<Components::LogicComponent>(entity);
     Components::Actions::initComponent<Components::LogicComponent>(world.getComponentAllocator(), e);
 
-    Components::addComponent<Components::VisualComponent>(entity);
     Components::Actions::initComponent<Components::VisualComponent>(world.getComponentAllocator(), e);
 
-    Components::addComponent<Components::BBoxComponent>(entity);
     Components::Actions::initComponent<Components::BBoxComponent>(world.getComponentAllocator(), e);
 
-    Components::addComponent<Components::ObjectComponent>(entity);
     Components::ObjectComponent& obj = Components::Actions::initComponent<Components::ObjectComponent>(world.getComponentAllocator(), e);
     obj.m_Type = Components::ObjectComponent::Other;
 
-    Components::addComponent<Components::PositionComponent>(entity);
     Components::Actions::initComponent<Components::PositionComponent>(world.getComponentAllocator(), e);
 
     //Components::addComponent<Components::PhysicsComponent>(entity);
@@ -104,13 +99,13 @@ void ::Vob::setVisual(VobInformation& vob, const std::string& _visual)
     if (vob.visual && vob.visual->getName() == visual)
         return;
 
-    // Clear old visual
-    delete vob.visual;
-
     Logic::VisualController** ppVisual = &vob.world->getComponentAllocator().getElement<Components::VisualComponent>(vob.entity).m_pVisualController;
 
-    vob.visual = nullptr;
+    // Clear old visual
+    delete *ppVisual;
+
     *ppVisual = nullptr;
+    vob.visual = nullptr;
 
     // Check type of visual
     if (visual.find(".3DS") != std::string::npos || visual.find(".MMB") != std::string::npos || visual.find(".MMS") != std::string::npos || visual.find(".MDMS") != std::string::npos)

--- a/src/content/ContentLoad.cpp
+++ b/src/content/ContentLoad.cpp
@@ -4,6 +4,7 @@
 
 #include "ContentLoad.h"
 #include <engine/World.h>
+#include <components/EntityActions.h>
 
 Handle::EntityHandle Content::Wrap::createEntity(World::WorldInstance& world, Components::ComponentMask mask)
 {
@@ -20,7 +21,7 @@ Components::CompoundComponent& Content::Wrap::getCompoundComponent(World::WorldI
                                                                    Handle::EntityHandle e)
 {
     // Make sure the component is enabled
-    Components::addComponent<Components::CompoundComponent>(world.getEntity<Components::EntityComponent>(e));
+    Components::Actions::initComponent<Components::CompoundComponent>(world.getComponentAllocator(), e);
 
     return world.getEntity<Components::CompoundComponent>(e);
 }

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -666,6 +666,12 @@ void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, co
     m_pEngine->getHud().setDateTimeDisplay(m_pEngine->getGameClock().getDateTimeFormatted());
 
     m_BspTree.debugDraw();
+
+    for(const auto& fp : m_FreePoints)
+    {
+        Math::float3 fpPosition = getEntity<Components::PositionComponent>(fp.second).m_WorldMatrix.Translation();
+        ddDrawAxis(fpPosition.x, fpPosition.y, fpPosition.z, 0.5f);
+    }
 }
 
 void WorldInstance::removeEntity(Handle::EntityHandle h)

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -351,9 +351,9 @@ bool WorldInstance::init(const std::string& zen,
                     if (v.objectClass == "zCVobSpot:zCVob")
                     {
                         // Register freepoint
-                        Handle::EntityHandle h = addEntity(Components::ObjectComponent::MASK | Components::SpotComponent::MASK | Components::PositionComponent::MASK);
-                        getEntity<Components::ObjectComponent>(h).m_Name = v.vobName;
-                        m_FreePoints[v.vobName] = h;
+                        Components::SpotComponent& spot = Components::Actions::initComponent<Components::SpotComponent>(getComponentAllocator(), vob.entity);
+
+                        m_FreePoints[v.vobName] = vob.entity;
                     }
                 }
                 else

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -759,8 +759,7 @@ WorldInstance::getFreepointsInRange(const Math::float3& center, float distance, 
         Components::SpotComponent& sp = getEntity<Components::SpotComponent>(fp);
         Components::PositionComponent& pos = getEntity<Components::PositionComponent>(fp);
 
-        if ((!sp.m_UsingEntity.isValid() || sp.m_UseEndTime < getEngine()->getGameClock().getTime()) &&
-            (!inst.isValid() || sp.m_UsingEntity != inst))
+        if (!isFreepointOccupied(fp))
         {
             float fpd2 = (center - pos.m_WorldMatrix.Translation()).lengthSquared();
             if (fpd2 < distance2)
@@ -802,6 +801,29 @@ std::vector<Handle::EntityHandle> WorldInstance::getFreepoints(const std::string
     m_FreePointTagCache[tag] = mp;
 
     return mp;
+}
+
+void WorldInstance::markFreepointOccupied(Handle::EntityHandle freepoint, Handle::EntityHandle usingEntity,
+                                      float occupiedForSeconds)
+{
+    using namespace Components;
+
+    assert(hasComponent<SpotComponent>(getEntity<EntityComponent>(freepoint)));
+
+    Components::SpotComponent& sp = getEntity<Components::SpotComponent>(freepoint);
+    sp.m_UsingEntity = usingEntity;
+    sp.m_UseEndTime = getEngine()->getGameClock().getTotalSeconds() + occupiedForSeconds;
+}
+
+bool WorldInstance::isFreepointOccupied(Handle::EntityHandle freepoint)
+{
+    using namespace Components;
+
+    assert(hasComponent<SpotComponent>(getEntity<EntityComponent>(freepoint)));
+
+    Components::SpotComponent& sp = getEntity<Components::SpotComponent>(freepoint);
+
+    return sp.m_UsingEntity.isValid() && sp.m_UseEndTime > getEngine()->getGameClock().getTotalSeconds();
 }
 
 Daedalus::GameType WorldInstance::getBasicGameType()
@@ -1003,3 +1025,7 @@ UI::PrintScreenMessages& WorldInstance::getPrintScreenManager()
 {
     return m_pEngine->getHud().getPrintScreenManager();
 }
+
+
+
+

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -436,6 +436,13 @@ namespace World
         std::map<std::string, Handle::EntityHandle> m_FreePoints;
 
         /**
+         * Usually freepoints are named like "FP_GUARD_XXX", where "FP_GUARD" is the 'tag' of
+         * a freepoint. To save us from going through the whole freepoint list every time we need a
+         * freepoint with a specific tag, we cache the searches here
+         */
+        std::map<std::string, std::vector<Handle::EntityHandle>> m_FreePointTagCache;
+
+        /**
          * NPCs in this world
          */
         std::set<Handle::EntityHandle> m_NPCEntities;

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -300,6 +300,16 @@ namespace World
                                                                Handle::EntityHandle inst = Handle::EntityHandle::makeInvalidHandle());
 
         /**
+         * Marks the given Freepoint as "occupied" for the next occupiedForSeconds
+         */
+        void markFreepointOccupied(Handle::EntityHandle freepoint, Handle::EntityHandle usingEntity, float occupiedForSeconds);
+
+        /**
+         * @return Whether the freepoint is currently occupied
+         */
+        bool isFreepointOccupied(Handle::EntityHandle freepoint);
+
+        /**
          * Exports this world into a json-object
          * @param j json-object to write into
          * @param skip entities which shall be excluded from export

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -277,7 +277,7 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
 
                 m_CameraSettings.thirdPersonCameraSettings.currentOffsetDirection = Math::float3::lerp(m_CameraSettings.thirdPersonCameraSettings.currentOffsetDirection,
                                                                                                        pdir,
-                                                                                                       CAMERA_SMOOTHING * deltaTime);
+                                                                                                       std::min(1.0f, CAMERA_SMOOTHING * deltaTime));
 
                 pdir = m_CameraSettings.thirdPersonCameraSettings.currentOffsetDirection;
 
@@ -292,11 +292,11 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
 
                 Math::float3 camPos = getEntityTransform().Translation();
 
-                ppos = Math::float3::lerp(camPos, ppos, CAMERA_SMOOTHING * deltaTime);
+                ppos = Math::float3::lerp(camPos, ppos, std::min(1.0f, CAMERA_SMOOTHING * deltaTime));
 
                 m_CameraSettings.thirdPersonCameraSettings.currentLookAt = Math::float3::lerp(m_CameraSettings.thirdPersonCameraSettings.currentLookAt,
                                                                                               ptrans.Translation() + targetOffset,
-                                                                                              CAMERA_SMOOTHING * deltaTime);
+                                                                                              std::min(1.0f, CAMERA_SMOOTHING * deltaTime));
 
                 m_ViewMatrix = Math::Matrix::CreateLookAt(ppos,
                                                           m_CameraSettings.thirdPersonCameraSettings.currentLookAt,

--- a/src/logic/NpcAIHandler.cpp
+++ b/src/logic/NpcAIHandler.cpp
@@ -39,9 +39,6 @@ void NpcAIHandler::playerUpdate(float deltaTime)
         return;
     }
 
-    if (m_MovementState.isAction)
-        bgfx::dbgTextPrintf(0, 6, 0x4, "Action");
-
     switch (m_ActiveMovementState)
     {
         case EMovementState::None:
@@ -101,7 +98,6 @@ void NpcAIHandler::playerUpdate(float deltaTime)
             break;
 
         case EMovementState::Forward:
-            bgfx::dbgTextPrintf(0, 5, 0x4, "Forward");
             if (m_MovementState.isForward)
             {
                 // Forward-key still pressed, keep going
@@ -133,7 +129,6 @@ void NpcAIHandler::playerUpdate(float deltaTime)
             break;
 
         case EMovementState::Backward:
-            bgfx::dbgTextPrintf(0, 5, 0x4, "Backward");
             if (m_MovementState.isBackward)
             {
                 // Backward-key still pressed, keep going

--- a/src/logic/NpcAIHandler.cpp
+++ b/src/logic/NpcAIHandler.cpp
@@ -373,3 +373,182 @@ NpcAnimationHandler& NpcAIHandler::getNpcAnimationHandler() const
 {
     return getController().getNpcAnimationHandler();
 }
+
+void NpcAIHandler::setTargetMovementState(EMovementState state)
+{
+    m_TargetMovementState = state;
+}
+
+void NpcAIHandler::npcUpdate(float deltaTime)
+{
+    switch (m_ActiveMovementState)
+    {
+        case EMovementState::None:
+
+            getNpcAnimationHandler().Action_Stand(false, false);
+
+            // Only allow changing states when the character is standing (ie. not playing transition animations)
+            if (getNpcAnimationHandler().isStanding(true))
+            {
+                if (m_TargetMovementState == EMovementState::DrawWeapon)
+                {
+                    if (getController().getWeaponMode() == EWeaponMode::WeaponNone)
+                    {
+                        getController().drawWeaponMelee();
+                        m_ActiveMovementState = EMovementState::DrawWeapon;
+                    }
+                }
+                else if (m_TargetMovementState == EMovementState::UndrawWeapon)
+                {
+                    if (getController().getWeaponMode() != EWeaponMode::WeaponNone)
+                    {
+                        getController().undrawWeapon();
+                        m_ActiveMovementState = EMovementState::UndrawWeapon;
+                    }
+                }
+                else if (m_TargetMovementState == EMovementState::Forward)
+                {
+                    m_ActiveMovementState = EMovementState::Forward;
+                }
+                else if (m_TargetMovementState == EMovementState::Backward)
+                {
+                    m_ActiveMovementState = EMovementState::Backward;
+                }
+                else if (m_TargetMovementState == EMovementState::StrafeLeft)
+                {
+                    m_ActiveMovementState = EMovementState::StrafeLeft;
+                }
+                else if (m_TargetMovementState == EMovementState::StrafeRight)
+                {
+                    m_ActiveMovementState = EMovementState::StrafeRight;
+                }else
+                {
+                    m_ActiveMovementState = EMovementState::None;
+                }
+            }
+            break;
+
+        case EMovementState::Forward:
+            if (m_TargetMovementState == EMovementState::Forward)
+            {
+                // Forward-key still pressed, keep going
+                if (!getNpcAnimationHandler().Action_GoForward())
+                {
+                    // No Space, go back to "standing"
+                    m_ActiveMovementState = EMovementState::None;
+                    getNpcAnimationHandler().Action_Stand();
+                }
+
+                // TODO: Implement AI-based turning
+            }
+            else
+            {
+                // Forward-key not pressed anymore, go back to "standing"
+                m_ActiveMovementState = EMovementState::None;
+                getNpcAnimationHandler().Action_Stand();  // FIXME: Shouldn't need to force stand here (and in the other states)
+            }
+            break;
+
+        case EMovementState::Backward:
+            if (m_TargetMovementState == EMovementState::Backward)
+            {
+                // Backward-key still pressed, keep going
+                getNpcAnimationHandler().Action_GoBackward();
+            }
+            else
+            {
+                // Backward-key not pressed anymore, go back to "standing"
+                m_ActiveMovementState = EMovementState::None;
+                getNpcAnimationHandler().Action_Stand();
+            }
+            break;
+
+        case EMovementState::StrafeLeft:
+            if (m_TargetMovementState == EMovementState::StrafeLeft)
+            {
+                // Strafe-key still pressed, keep going
+                getNpcAnimationHandler().Action_StrafeLeft();
+
+                // And check for turns
+                if (m_MovementState.isTurnLeft)
+                {
+                    getNpcAnimationHandler().Action_TurnLeft();
+                }
+                else if (m_MovementState.isTurnRight)
+                {
+                    getNpcAnimationHandler().Action_TurnRight();
+                }
+            }
+            else
+            {
+                // Strafe-key not pressed anymore, go back to "standing"
+                m_ActiveMovementState = EMovementState::None;
+                getNpcAnimationHandler().Action_Stand();
+            }
+            break;
+
+        case EMovementState::StrafeRight:
+            if (m_TargetMovementState == EMovementState::StrafeRight)
+            {
+                // Strafe-key still pressed, keep going
+                getNpcAnimationHandler().Action_StrafeRight();
+
+                // And check for turns
+                if (m_MovementState.isTurnLeft)
+                {
+                    getNpcAnimationHandler().Action_TurnLeft();
+                }
+                else if (m_MovementState.isTurnRight)
+                {
+                    getNpcAnimationHandler().Action_TurnRight();
+                }
+            }
+            else
+            {
+                // Strafe-key not pressed anymore, go back to "standing"
+                m_ActiveMovementState = EMovementState::None;
+                getNpcAnimationHandler().Action_Stand();
+            }
+            break;
+
+        case EMovementState::DrawWeapon:
+            getNpcAnimationHandler().Action_DrawWeapon(0);
+
+            if (getNpcAnimationHandler().isStanding(true))
+            {
+                // Wait until the drawing-animation is over, then go to standing state
+                m_ActiveMovementState = EMovementState::None;
+            }
+            break;
+
+        case EMovementState::UndrawWeapon:
+            getNpcAnimationHandler().Action_UndrawWeapon();
+
+            if (getNpcAnimationHandler().isStanding(true))
+            {
+                // Wait until the undrawing-animation is over, then go to standing state
+                m_ActiveMovementState = EMovementState::None;
+
+                // Actually undraw the weapon and go back to normal state
+                getController().undrawWeapon();
+            }
+            break;
+
+        case EMovementState::FightForward:
+            if (m_TargetMovementState == EMovementState::FightForward)
+            {
+                getNpcAnimationHandler().Action_FightForward();
+            }
+            else
+            {
+                // FIXME: Find out when the animation actually ended
+                getNpcAnimationHandler().Action_Stand(true);
+            }
+
+            if (getNpcAnimationHandler().isStanding(true))
+            {
+                m_ActiveMovementState = EMovementState::None;
+            }
+            break;
+    }
+}

--- a/src/logic/NpcAIHandler.h
+++ b/src/logic/NpcAIHandler.h
@@ -55,6 +55,12 @@ namespace Logic
         void playerUpdate(float deltaTime);
 
         /**
+         * Frame update for non-player-characters
+         * @param deltaTime Time since last frame
+         */
+        void npcUpdate(float deltaTime);
+
+        /**
          * Moves the player back to the usual-standing state
          */
         void standup();
@@ -64,6 +70,11 @@ namespace Logic
          */
         void bindKeys();
         void unbindKeys();
+
+        /**
+         * @param state Movementstate to set for AI
+         */
+        void setTargetMovementState(EMovementState state);
 
         /**
          * @return Controller this is attached to
@@ -121,5 +132,6 @@ namespace Logic
          * Current movment state
          */
         EMovementState m_ActiveMovementState;
+        EMovementState m_TargetMovementState;
     };
 }

--- a/src/logic/NpcScriptState.cpp
+++ b/src/logic/NpcScriptState.cpp
@@ -73,7 +73,7 @@ bool Logic::NpcScriptState::startAIState(size_t symIdx, bool endOldState, bool i
         symIdx = dat.getSymbolIndexByName(s_PRGStates[symIdx]);
     }
 
-    //LogInfo() << "AISTATE-START: " << m_NextState.name << " on NPC: " << VobTypes::getScriptObject(vob).name[0] << " (WP: " << VobTypes::getScriptObject(vob).wp << ")";
+    LogInfo() << "AISTATE-START: " << m_NextState.name << " on NPC: " << VobTypes::getScriptObject(vob).name[0] << " (WP: " << VobTypes::getScriptObject(vob).wp << ")";
 
     // Check if this is just a usual action (ZS = German "Zustand" = State, B = German "Befehl" = Instruction)
     if (m_NextState.name.substr(0, 3) != "ZS_")

--- a/src/logic/Pathfinder.cpp
+++ b/src/logic/Pathfinder.cpp
@@ -244,7 +244,7 @@ void Pathfinder::startNewRouteTo(const Math::float3& positionNow, const Math::fl
         return;
     }
 
-    Waynet::WaypointIndex nearestWpToTarget = Waynet::findNearestWaypointTo(m_World.getWaynet(), getTargetEntityPosition());
+    Waynet::WaypointIndex nearestWpToTarget = Waynet::findNearestWaypointTo(m_World.getWaynet(), position);
     Waynet::WaypointIndex nearestWpToStart = Waynet::findNearestWaypointTo(m_World.getWaynet(), positionNow);
 
     std::vector<Waynet::WaypointIndex> path = Waynet::findWay(m_World.getWaynet(), nearestWpToStart, nearestWpToTarget);

--- a/src/logic/Pathfinder.cpp
+++ b/src/logic/Pathfinder.cpp
@@ -1,0 +1,261 @@
+//
+// Created by desktop on 08.09.17.
+//
+
+#include "Pathfinder.h"
+#include <engine/World.h>
+
+using namespace Logic;
+
+static const float MAX_SIDE_DIFFERENCE_TO_REACH_POSITION   = 0.5f; // Meters
+static const float MAX_HEIGHT_DIFFERENCE_TO_REACH_POSITION = 0.5f; // Meters
+
+
+Pathfinder::Pathfinder(World::WorldInstance& world)
+    : m_World(world)
+{
+
+}
+
+
+Pathfinder::~Pathfinder()
+{
+
+}
+
+
+Pathfinder::MovementReport Pathfinder::checkMoveToLocation(const Math::float3& from, const Math::float3& to)
+{
+    MovementReport report;
+    Math::float3 fromGround = from - Math::float3(0, m_UserConfiguration.height, 0);
+    Math::float3 toGround = to - Math::float3(0, m_UserConfiguration.height, 0);
+
+    report.lowerThanStepHeight = (to.y - from.y) < -m_UserConfiguration.stepHeight;
+    report.higherThanStepHeight = (to.y - from.y) > m_UserConfiguration.stepHeight;
+
+    report.ceilingTooLow = findCeilingHeightAtPosition(toGround) > m_UserConfiguration.height;
+
+    Physics::RayTestResult hit = m_World.getPhysicsSystem().raytrace(from, to);
+    report.hardCollision = hit.hasHit;
+
+    size_t destGroundTriangle = getGroundTriangleIndexAt(to);
+
+    if(destGroundTriangle != (size_t)-1)
+    {
+        Math::float3 vertices[3];
+        uint8_t matGroup;
+        m_World.getWorldMesh().getTriangle(destGroundTriangle, vertices, matGroup);
+
+        Math::float3 normal = (vertices[0] - vertices[1]).cross(vertices[0] - vertices[2]).normalize();
+
+        float slope = calculateSlopeFromNormal(normal);
+
+        bool goingUp = (to - from).dot(normal) < 0.0f;
+
+        if(fabs(slope) > m_UserConfiguration.maxSlopeAngle)
+        {
+            if(goingUp)  report.tooSteepUp = true;
+            if(!goingUp) report.tooSteepDown = true;
+        }
+    } else
+    {
+        report.lowerThanStepHeight = true;
+    }
+
+
+    return report;
+}
+
+
+float Pathfinder::findCeilingHeightAtPosition(const Math::float3& position)
+{
+    Math::float3 worldTop = Math::float3(position.x, FLT_MAX, position.y);
+    Physics::RayTestResult hit = m_World.getPhysicsSystem().raytrace(position, worldTop);
+
+    if(!hit.hasHit)
+        return FLT_MAX;
+
+    return (position - hit.hitPosition).length();
+}
+
+
+size_t Pathfinder::getGroundTriangleIndexAt(const Math::float3& position)
+{
+    Math::float3 worldBottom = Math::float3(position.x, FLT_MIN, position.y);
+    Physics::RayTestResult hit = m_World.getPhysicsSystem().raytrace(position, worldBottom, Physics::CollisionShape::CT_WorldMesh);
+
+    if(!hit.hasHit)
+        return (size_t)-1;
+
+    return hit.hitTriangleIndex;
+}
+
+float Pathfinder::calculateSlopeFromNormal(const Math::float3& normal)
+{
+    return acos(normal.y);
+}
+
+
+World::Waynet::WaypointIndex Pathfinder::findNextVisibleWaypoint(const Math::float3& from)
+{
+    // TODO: Check for obstructions
+    return World::Waynet::findNearestWaypointTo(m_World.getWaynet(), from);
+}
+
+
+bool Pathfinder::hasActiveRouteBeenCompleted(const Math::float3& positionNow)
+{
+    if(!m_ActiveRoute.targetEntity.isValid())
+        return m_ActiveRoute.positionsToGo.empty(); // FIXME: This goes wrong if an npc ever gets stuck or the heights don't match
+
+    return hasTargetEntityBeenReached(positionNow);
+}
+
+
+bool Pathfinder::isTargetReachedByPosition(const Math::float3& position, const Math::float3& target)
+{
+    float diffHeight = fabs(position.y - target.y);
+    float diffSide   =  Math::float2(position.x - target.x, position.z - target.z).length();
+
+    return diffSide < MAX_SIDE_DIFFERENCE_TO_REACH_POSITION && diffHeight < MAX_HEIGHT_DIFFERENCE_TO_REACH_POSITION;
+}
+
+
+Pathfinder::Instruction Pathfinder::updateToNextInstructionToTarget(const Math::float3& positionNow)
+{
+    Instruction inst;
+
+    if(hasActiveRouteBeenCompleted(positionNow))
+    {
+        inst.targetPosition = positionNow;
+        return inst;
+    }
+
+    if(hasNextRouteTargetBeenReached(positionNow))
+    {
+        if(!m_ActiveRoute.positionsToGo.empty())
+        {
+            m_ActiveRoute.positionsToGo.pop_front();
+        }
+    }
+
+    inst.targetPosition = getCurrentTargetPosition();
+
+    return inst;
+}
+
+
+bool Pathfinder::hasNextRouteTargetBeenReached(const Math::float3& positionNow)
+{
+    if(m_ActiveRoute.positionsToGo.empty())
+    {
+        return isTargetAnEntity() && hasTargetEntityBeenReached(positionNow);
+    }
+
+    return isTargetReachedByPosition(positionNow, m_ActiveRoute.positionsToGo.front());
+}
+
+
+bool Pathfinder::hasTargetEntityBeenReached(const Math::float3& positionNow)
+{
+    if(!isTargetAnEntity())
+        return false;
+
+    Math::float3 targetEntityPosition = getTargetEntityPosition();
+
+    return isTargetReachedByPosition(positionNow, targetEntityPosition);
+}
+
+
+Math::float3 Pathfinder::getTargetEntityPosition()
+{
+    if(!m_ActiveRoute.targetEntity.isValid())
+        return Math::float3(0,0,0);
+
+    Vob::VobInformation vob = Vob::asVob(m_World, m_ActiveRoute.targetEntity);
+    assert(vob.isValid());
+
+    return vob.position->m_WorldMatrix.Translation();
+}
+
+
+bool Pathfinder::isTargetAnEntity()
+{
+    return m_ActiveRoute.targetEntity.isValid();
+}
+
+
+Math::float3 Pathfinder::getCurrentTargetPosition()
+{
+    if(m_ActiveRoute.positionsToGo.empty())
+    {
+        return getTargetEntityPosition();
+    }else
+    {
+        return m_ActiveRoute.positionsToGo.front();
+    }
+}
+
+
+void Pathfinder::startNewRouteTo(const Math::float3& positionNow, Handle::EntityHandle entity)
+{
+    using namespace World;
+
+    // TODO: Should be re-evaluated every once in a while, since the entity could be moving
+    startNewRouteTo(positionNow, getTargetEntityPosition());
+
+    // startNewRouteTo appends the position to go to if it's off the waynet, we can't have that
+    // when the target could be moving
+    if(!m_ActiveRoute.positionsToGo.empty())
+        m_ActiveRoute.positionsToGo.pop_back();
+
+    m_ActiveRoute.targetEntity = entity;
+}
+
+
+void Pathfinder::startNewRouteTo(const Math::float3& positionNow, World::Waynet::WaypointIndex waypoint)
+{
+    Math::float3 waypointPosition = m_World.getWaynet().waypoints[waypoint].position;
+    startNewRouteTo(positionNow, waypointPosition);
+}
+
+
+void Pathfinder::startNewRouteTo(const Math::float3& positionNow, const Math::float3& position)
+{
+    using namespace World;
+
+    m_ActiveRoute.positionsToGo.clear();
+    m_ActiveRoute.lastKnownPosition = positionNow;
+    m_ActiveRoute.targetEntity.invalidate();
+
+    if(isTargetReachedByPosition(positionNow, position))
+        return;
+
+    if(canDirectlyMovetoLocation(positionNow, position))
+    {
+        m_ActiveRoute.positionsToGo.push_back(position);
+        return;
+    }
+
+    Waynet::WaypointIndex nearestWpToTarget = Waynet::findNearestWaypointTo(m_World.getWaynet(), getTargetEntityPosition());
+    Waynet::WaypointIndex nearestWpToStart = Waynet::findNearestWaypointTo(m_World.getWaynet(), positionNow);
+
+    std::vector<Waynet::WaypointIndex> path = Waynet::findWay(m_World.getWaynet(), nearestWpToStart, nearestWpToTarget);
+
+    for(Waynet::WaypointIndex i : path)
+    {
+        const Math::float3 wpPosition = m_World.getWaynet().waypoints[i].position;
+        m_ActiveRoute.positionsToGo.push_back(wpPosition);
+    }
+
+    // If the last position is off the waynet, add it as well
+    if(m_ActiveRoute.positionsToGo.empty() || !isTargetReachedByPosition(m_ActiveRoute.positionsToGo.back(), position))
+        m_ActiveRoute.positionsToGo.push_back(position);
+}
+
+bool Pathfinder::canDirectlyMovetoLocation(const Math::float3& from, const Math::float3& to)
+{
+    Physics::RayTestResult hit = m_World.getPhysicsSystem().raytrace(from, to);
+
+    return !hit.hasHit; // FIXME: This breaks when the creature should go down a slope but is standing on the top of it right now
+}

--- a/src/logic/Pathfinder.cpp
+++ b/src/logic/Pathfinder.cpp
@@ -143,6 +143,11 @@ Pathfinder::Instruction Pathfinder::updateToNextInstructionToTarget(const Math::
 
     inst.targetPosition = getCurrentTargetPosition();
 
+    debugDrawRoute(positionNow);
+    ddSetColor(0xFF00FFFF);
+    ddMoveTo(positionNow.v);
+    ddLineTo(inst.targetPosition.v);
+
     return inst;
 }
 
@@ -260,4 +265,27 @@ bool Pathfinder::canDirectlyMovetoLocation(const Math::float3& from, const Math:
     Physics::RayTestResult hit = m_World.getPhysicsSystem().raytrace(from, to);
 
     return !hit.hasHit; // FIXME: This breaks when the creature should go down a slope but is standing on the top of it right now
+}
+
+void Pathfinder::debugDrawRoute(const Math::float3& positionNow)
+{
+    size_t seed = reinterpret_cast<size_t>(this); // Need some variation here and this is an easy way
+
+    int prevSeed = rand();
+    srand(seed);
+    uint8_t r = rand() % 256;
+    uint8_t g = rand() % 256;
+    uint8_t b = rand() % 256;
+
+    uint32_t color = 0xFF000000 | (b << 24) | (g << 16) | (r << 8);
+
+    srand(prevSeed);
+
+    ddSetColor(color);
+    ddMoveTo(positionNow.v);
+    for(Math::float3 p : m_ActiveRoute.positionsToGo)
+    {
+        ddLineTo(p.v);
+        ddMoveTo(p.v);
+    }
 }

--- a/src/logic/Pathfinder.cpp
+++ b/src/logic/Pathfinder.cpp
@@ -4,11 +4,13 @@
 
 #include "Pathfinder.h"
 #include <engine/World.h>
+#include <debugdraw/debugdraw.h>
+#include <stdlib.h>
 
 using namespace Logic;
 
 static const float MAX_SIDE_DIFFERENCE_TO_REACH_POSITION   = 0.5f; // Meters
-static const float MAX_HEIGHT_DIFFERENCE_TO_REACH_POSITION = 0.5f; // Meters
+static const float MAX_HEIGHT_DIFFERENCE_TO_REACH_POSITION = 2.0f; // Meters
 
 
 Pathfinder::Pathfinder(World::WorldInstance& world)

--- a/src/logic/Pathfinder.h
+++ b/src/logic/Pathfinder.h
@@ -49,6 +49,11 @@ namespace Logic
             // If this is valid, the Creature will move to this entity, once it has been to
             // all positions it had to go to or has a direct line of sight to it
             Handle::EntityHandle targetEntity;
+
+            // Position the target entity was at when we started the route.
+            // This must be saved so we can perform a re-route if the target moves too far from the spot
+            // the route goes to
+            Math::float3 targetEntityPositionOnStart;
         };
 
         Pathfinder(World::WorldInstance& world);
@@ -155,12 +160,36 @@ namespace Logic
          * @return Position of the route to go to right now
          *         Note: Result is undefined when the target has been reached and there is no entity-target.
          */
-        Math::float3 getCurrentTargetPosition();
+        Math::float3 getCurrentTargetPosition(const Math::float3& positionNow);
 
         /**
          * Draws lines on where to go to
          */
         void debugDrawRoute(const Math::float3& positionNow);
+
+        /**
+         * @return Whether the target entity has moved too far from the spot it was when we started the route
+         */
+        bool hasTargetEntityMovedTooFar();
+
+        /**
+         * Sometimes, the waynet isn't exactly detailed and NPCs take some weird looking detours instead of
+         * going straight. This function uses raytraces to check which points on the route can be erased because
+         * there are not obstacles on the way to them
+         */
+        void cleanupRoute();
+
+        /**
+         * @return Whether the route-position on the given iterator can be removed. See cleanupRoute().
+         */
+        bool canRoutePositionBeRemoved(std::list<Math::float3>::iterator it);
+
+        /**
+         * @return Whether the currently active route is considered not up-to-date and should be redone.
+         *         This happens for example, when a target entity moved too far or something is blocking
+         *         the way now.
+         */
+        bool shouldReRoute(const Math::float3& positionNow);
 
         /**
          * Information about the creature using this pathfinder

--- a/src/logic/Pathfinder.h
+++ b/src/logic/Pathfinder.h
@@ -1,0 +1,175 @@
+//
+// Created by desktop on 08.09.17.
+//
+
+#pragma once
+
+#include <math/mathlib.h>
+#include <handle/HandleDef.h>
+#include <engine/Waynet.h>
+#include <list>
+
+namespace World
+{
+    class WorldInstance;
+}
+
+namespace Logic
+{
+    /**
+     * Wrapper around the waynet. Can find paths to certain locations and give instructions onto how to get there
+     * from a given point.
+     */
+    class Pathfinder
+    {
+    public:
+
+        /**
+         * The next point on the route to go to in order to reach the final destination.
+         */
+        struct Instruction
+        {
+            Math::float3 targetPosition;
+        };
+
+        struct UserConfiguration
+        {
+            float height;
+            float radius;
+            float stepHeight;
+            float maxSlopeAngle;
+        };
+
+        struct Route
+        {
+            Math::float3 lastKnownPosition;
+
+            std::list<Math::float3> positionsToGo;
+
+            // If this is valid, the Creature will move to this entity, once it has been to
+            // all positions it had to go to or has a direct line of sight to it
+            Handle::EntityHandle targetEntity;
+        };
+
+        Pathfinder(World::WorldInstance& world);
+        virtual ~Pathfinder();
+
+        void startNewRouteTo(const Math::float3& positionNow, const Math::float3& target);
+        void startNewRouteTo(const Math::float3& positionNow, World::Waynet::WaypointIndex waypoint);
+        void startNewRouteTo(const Math::float3& positionNow, Handle::EntityHandle entity);
+
+        /**
+         * @return The next target position on the way to the location set via startNewRouteTo.
+         *         If the target has been reached, positionNow is returned, so you should always check
+         *         whether the route has been completed first.
+         */
+        Instruction updateToNextInstructionToTarget(const Math::float3& positionNow);
+
+        /**
+         * @return Whether the active route has been completed.
+         */
+        bool hasActiveRouteBeenCompleted(const Math::float3& positionNow);
+
+        /**
+         * Information about the creature using this pathfinder
+         */
+        void setConfiguration(const UserConfiguration& configuration) { m_UserConfiguration = configuration; }
+        const UserConfiguration& getConfiguration() { return m_UserConfiguration; }
+
+        /**
+         * @return Whether the Pathfinder thinks the given targetposition has been reached
+         */
+        static bool isTargetReachedByPosition(const Math::float3& position, const Math::float3& target);
+    private:
+
+
+        struct MovementReport
+        {
+            bool lowerThanStepHeight;
+            bool higherThanStepHeight;
+
+            bool tooSteepDown;
+            bool tooSteepUp;
+            bool ceilingTooLow;
+            bool hardCollision;
+
+            //Handle::EntityHandle hitVob; // TODO: This could be useful
+        };
+
+        /**
+         * Gives information about what would happen if an NPC moved to a certain location.
+         * @param from Source location. Expected to be at (Groundlevel + Height) of the creature
+         * @param to   Destination. Expected to be at (Groundlevel + Height) of the creature
+         */
+        MovementReport checkMoveToLocation(const Math::float3& from, const Math::float3& to);
+
+        /**
+         * Performs a series of checks on whether the creature could directly walk to the given
+         * location
+         */
+        bool canDirectlyMovetoLocation(const Math::float3& from, const Math::float3& to);
+
+        /**
+         * @return height of the ceiling at the given position
+         */
+        float findCeilingHeightAtPosition(const Math::float3& floorposition);
+
+        /**
+         * Traces down to find the ground poly at the given location
+         * @return Triangle-index of the world-mesh. (-1 if none)
+         */
+        size_t getGroundTriangleIndexAt(const Math::float3& position);
+
+        /**
+         * @return Slope angle in radians
+         */
+        float calculateSlopeFromNormal(const Math::float3& normal);
+
+        /**
+         * Finds the next visible waypoint from the given location. The
+         * @param from
+         */
+        World::Waynet::WaypointIndex findNextVisibleWaypoint(const Math::float3& from);
+
+        /**
+         * @return Whether the next position on the route has been reached
+         */
+        bool hasNextRouteTargetBeenReached(const Math::float3& positionNow);
+
+        /**
+         * @return Whether the entity given in the active route has been reached. False if none was specified there.
+         */
+        bool hasTargetEntityBeenReached(const Math::float3& positionNow);
+
+        /**
+         * @return Position of the entity to go to stored in the active route. Undefined if none was specified there.
+         */
+        Math::float3 getTargetEntityPosition();
+
+        /**
+         * @return Whether the Target specified in the active route is an entity
+         */
+        bool isTargetAnEntity();
+
+        /**
+         * @return Position of the route to go to right now
+         *         Note: Result is undefined when the target has been reached and there is no entity-target.
+         */
+        Math::float3 getCurrentTargetPosition();
+
+        /**
+         * Information about the creature using this pathfinder
+         */
+        UserConfiguration m_UserConfiguration;
+
+        /**
+         * The currently ran route. The Creature will report it's poisition and get a new target
+         * location, until it reaches the destination.
+         */
+        Route m_ActiveRoute;
+
+        World::WorldInstance& m_World;
+    };
+}
+
+

--- a/src/logic/Pathfinder.h
+++ b/src/logic/Pathfinder.h
@@ -158,6 +158,11 @@ namespace Logic
         Math::float3 getCurrentTargetPosition();
 
         /**
+         * Draws lines on where to go to
+         */
+        void debugDrawRoute(const Math::float3& positionNow);
+
+        /**
          * Information about the creature using this pathfinder
          */
         UserConfiguration m_UserConfiguration;

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -68,10 +68,8 @@ PlayerController::PlayerController(World::WorldInstance& world,
     , m_AIStateMachine(world, entity)
     , m_NPCAnimationHandler(world, entity)
     , m_AIHandler(world, entity)
+    , m_PathFinder(world)
 {
-    m_RoutineState.routineTarget = static_cast<size_t>(-1);
-    m_RoutineState.routineActive = true;
-
     m_AIState.closestWaypoint = 0;
     m_MoveState.currentPathPerc = 0;
     m_NPCProperties.moveSpeed = 7.0f;
@@ -110,6 +108,10 @@ PlayerController::PlayerController(World::WorldInstance& world,
 
 void PlayerController::onUpdate(float deltaTime)
 {
+    // If anything wants this to be modified, it as to keep it up to date
+    // It is important that the update-method is called last in this update-handler
+    m_AIHandler.setTargetMovementState(EMovementState::None);
+
     m_RefuseTalkTime -= deltaTime;
 
     m_AIStateMachine.doAIState(deltaTime);
@@ -128,25 +130,15 @@ void PlayerController::onUpdate(float deltaTime)
         // FIXME: Doing this every frame is too often
         size_t targetWP = World::Waynet::findNearestWaypointTo(m_World.getWaynet(), targetPos);
 
-        setDailyRoutine({});
         gotoWaypoint(targetWP);
     }
-    m_NoAniRootPosHack = !m_MoveState.currentPath.empty();  // NPCs are already moved in travelPath
+    m_NoAniRootPosHack = false;
 
-    if (!m_MoveState.currentPath.empty() || !m_RoutineState.routineWaypoints.empty())
+    // Do waypoint-actions
+    if(!m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation()))
     {
-        // Do waypoint-actions
-        if (travelPath(deltaTime))
-        {
-            m_NoAniRootPosHack = true;
-
-            // Path done, stop animation
-            //if (model)
-            //    model->setAnimation(ModelVisual::Idle);
-
-            if (m_RoutineState.routineActive)
-                continueRoutine();
-        }
+        travelPath(deltaTime);
+        //m_NoAniRootPosHack = true;
     }
 
     if (model)
@@ -198,25 +190,10 @@ void PlayerController::onUpdate(float deltaTime)
     if (isPlayerControlled())
     {
         onUpdateForPlayer(deltaTime);
+    }else
+    {
+        m_AIHandler.npcUpdate(deltaTime);
     }
-}
-
-void PlayerController::continueRoutine()
-{
-    if (m_RoutineState.routineWaypoints.empty())
-        return;
-
-    // Start next route
-    if (m_RoutineState.routineTarget == static_cast<size_t>(-1))
-        m_RoutineState.routineTarget = 0;  // Start routing. Could let the integer overflow do this, but this is better.
-    else
-        m_RoutineState.routineTarget++;
-
-    // Start over, if done
-    if (m_RoutineState.routineTarget + 1 >= m_RoutineState.routineWaypoints.size())
-        m_RoutineState.routineTarget = 0;
-
-    gotoWaypoint(m_RoutineState.routineWaypoints[m_RoutineState.routineTarget]);
 }
 
 void PlayerController::teleportToWaypoint(size_t wp)
@@ -241,93 +218,39 @@ void PlayerController::teleportToPosition(const Math::float3& pos)
     //getModelVisual()->setAnimation(ModelVisual::Idle);
 }
 
-void PlayerController::gotoWaypoint(size_t wp)
+
+void PlayerController::gotoWaypoint(World::Waynet::WaypointIndex wp)
 {
-    if (wp == m_AIState.targetWaypoint)
-        return;
-
-    // Set our current target as closest so we don't move back if we are following an entity
-    if (m_AIState.targetWaypoint != World::Waynet::INVALID_WAYPOINT)
-        m_AIState.closestWaypoint = m_AIState.targetWaypoint;
-    else
-        m_AIState.closestWaypoint = World::Waynet::findNearestWaypointTo(m_World.getWaynet(),
-                                                                         getEntityTransform().Translation());
-
-    if (m_AIState.closestWaypoint == World::Waynet::INVALID_WAYPOINT)
-        m_AIState.closestWaypoint = wp;  // Something bad happened...
-
-    m_AIState.targetWaypoint = wp;
-
-    // Route is most likely outdated, make a new one
-    rebuildRoute();
+    m_PathFinder.startNewRouteTo(getEntityTransform().Translation(), wp);
 }
 
-void PlayerController::rebuildRoute()
+
+void PlayerController::gotoVob(Handle::EntityHandle vob)
 {
-    m_MoveState.currentPath = World::Waynet::findWay(m_World.getWaynet(),
-                                                     m_AIState.closestWaypoint,
-                                                     m_AIState.targetWaypoint);
-
-    m_MoveState.currentPathPerc = 0.0f;
-    m_MoveState.currentRouteLength = World::Waynet::getPathLength(m_World.getWaynet(), m_MoveState.currentPath);
-    m_MoveState.targetNode = 0;
-
-    // Update script-instance with target waypoint
-    getScriptInstance().wp = m_World.getWaynet().waypoints[m_AIState.targetWaypoint].name;
+    m_PathFinder.startNewRouteTo(getEntityTransform().Translation(), vob);
 }
 
-bool PlayerController::travelPath(float deltaTime)
+void PlayerController::gotoPosition(const Math::float3& position)
 {
-    if (m_MoveState.currentPath.empty())
-        return true;
+    m_PathFinder.startNewRouteTo(getEntityTransform().Translation(), position);
+}
 
-    Math::float3 targetPosition = m_World.getWaynet().waypoints[m_MoveState.currentPath[m_MoveState.targetNode]].position;
+void PlayerController::travelPath(float deltaTime)
+{
+    Math::float3 positionNow = getEntityTransform().Translation();
 
-    Math::float3 currentPosition = getEntityTransform().Translation();
-    Math::float3 differenceXZ = targetPosition - currentPosition;
+    Pathfinder::Instruction inst = m_PathFinder.updateToNextInstructionToTarget(positionNow);
 
-    // Remove angle
-    differenceXZ.y = 0.0f;
-    if (differenceXZ.lengthSquared() > 0.0f)
+    if(!m_PathFinder.isTargetReachedByPosition(positionNow, inst.targetPosition))
     {
-        Math::float3 direction = differenceXZ;
-        direction.normalize();
-
-        m_MoveState.direction = direction;
-
-        // FIXME: This is right, but somehow NPCs don't appear where they belong
-        //m_NPCProperties.moveSpeed = getModelVisual()->getAnimationHandler().getRootNodeVelocity().length();
-
-        direction *= deltaTime * m_NPCProperties.moveSpeed;
-        m_MoveState.position = currentPosition + direction;
-
-        // Move
-        setEntityTransform(Math::Matrix::CreateLookAt(currentPosition + direction,
-                                                      currentPosition + direction * 2,
-                                                      Math::float3(0, 1, 0))
-                               .Invert());
+        // Turn towards target
+        setDirection(inst.targetPosition - positionNow);
     }
 
-    // Set run animation
-    getModelVisual()->setAnimation(ModelVisual::Run);
-
-    if (differenceXZ.lengthSquared() < 0.5f)  // TODO: Find a nice setting for this
-    {
-        //if(abs(currentPosition.y - targetPosition.y) < 2.0f)
-        {
-            m_AIState.closestWaypoint = m_MoveState.currentPath[m_MoveState.targetNode];
-            m_MoveState.targetNode++;
-
-            if (m_MoveState.targetNode >= m_MoveState.currentPath.size())
-            {
-                m_MoveState.currentPath.clear();
-                return true;
-            }
-        }
-    }
-
-    return false;
+    // Start running
+    m_AIHandler.setTargetMovementState(EMovementState::Forward);
 }
+
 
 void PlayerController::onDebugDraw()
 {
@@ -903,8 +826,6 @@ void PlayerController::onUpdateByInput(float deltaTime)
         {
             VobTypes::NpcVobInformation npc = VobTypes::asNpcVob(m_World, h);
             VobTypes::NPC_DrawMeleeWeapon(npc);
-
-            npc.playerController->setDailyRoutine({}); // FIXME: Idle-animation from routine finish overwriting other animations!
         }
     });
 
@@ -1265,7 +1186,7 @@ bool PlayerController::EV_Movement(std::shared_ptr<EventMessages::MovementMessag
             break;
         case EventMessages::MovementMessage::ST_GotoFP:
         {
-            if (!message.targetVob.isValid())
+            if(message.isFirstRun)
             {
                 std::vector<Handle::EntityHandle> fp = m_World.getFreepointsInRange(getEntityTransform().Translation(),
                                                                                     100.0f, message.targetVobName, true,
@@ -1277,93 +1198,55 @@ bool PlayerController::EV_Movement(std::shared_ptr<EventMessages::MovementMessag
                 Components::PositionComponent& pos = m_World.getEntity<Components::PositionComponent>(fp.front());
                 message.targetPosition = pos.m_WorldMatrix.Translation();
 
-                // Find closest position from the waynet
-                World::Waynet::WaypointIndex wp = World::Waynet::findNearestWaypointTo(m_World.getWaynet(),
-                                                                                       message.targetPosition);
-
-                if (wp != World::Waynet::INVALID_WAYPOINT)
-                    gotoWaypoint(wp);
+                gotoPosition(pos.m_WorldMatrix.Translation());
             }
 
-            if (m_MoveState.currentPath.empty())
-            {
-                // Just teleport to position // TODO: Implement properly
-                teleportToPosition(message.targetPosition);
-
-                // Back to idle-animation when done
-                getModelVisual()->setAnimation(ModelVisual::Idle);
-                return true;
-            }
-
-            return false;
+            return m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation());
         }
         break;
 
         case EventMessages::MovementMessage::ST_GotoVob:
         {
-            Math::float3 pos;
-
-            // Find a waypoint with that name
-            World::Waynet::WaypointIndex wp = World::Waynet::getWaypointIndex(m_World.getWaynet(),
-                                                                              message.targetVobName);
-
-            if (wp != World::Waynet::INVALID_WAYPOINT)
+            if(message.isFirstRun)
             {
-                gotoWaypoint(wp);
+                Math::float3 pos;
 
-                if (m_MoveState.currentPath.empty())
+                // Find a waypoint with that name
+                World::Waynet::WaypointIndex wp = World::Waynet::getWaypointIndex(m_World.getWaynet(),
+                                                                                  message.targetVobName);
+
+                if (wp != World::Waynet::INVALID_WAYPOINT)
                 {
-                    // Back to idle-animation when done
-                    getModelVisual()->setAnimation(ModelVisual::Idle);
-                    return true;
-                }
-
-                return false;
-            }
-            else
-            {
-                // This must be an actual vob
-                Handle::EntityHandle v = message.targetVob;
-
-                if (!v.isValid())
+                    gotoWaypoint(wp);
+                } else
                 {
-                    v = m_World.getVobEntityByName(message.targetVobName);
-                }
+                    // This must be an actual vob
+                    Handle::EntityHandle v = message.targetVob;
 
-                // isEntityValid can be false if the npc entity was removed from this world while this message was queued
-                if (v.isValid() && m_World.isEntityValid(v))
-                {
-                    Vob::VobInformation vob = Vob::asVob(m_World, v);
-                    message.targetPosition = Vob::getTransform(vob).Translation();
+                    if (!v.isValid())
+                    {
+                        v = m_World.getVobEntityByName(message.targetVobName);
+                    }
 
-                    // Fall through to ST_GotoPos
-                }
-                else
-                {
-                    return true;
+                    // isEntityValid can be false if the npc entity was removed from this world while this message was queued
+                    if (v.isValid() && m_World.isEntityValid(v))
+                    {
+                        gotoVob(v);
+                    }
                 }
             }
+            return m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation());
         }
+        break;
 
         case EventMessages::MovementMessage::ST_GotoPos:
         {
-            // Move to nearest waypoint for now
-            // TODO: Implement moving to arbitrary positions
-
-            World::Waynet::WaypointIndex wp = World::Waynet::findNearestWaypointTo(m_World.getWaynet(),
-                                                                                   message.targetPosition);
-
-            if (wp != World::Waynet::INVALID_WAYPOINT)
-                gotoWaypoint(wp);
-
-            if (m_MoveState.currentPath.empty())
+            if(message.isFirstRun)
             {
-                // Back to idle-animation when done
-                getModelVisual()->setAnimation(ModelVisual::Idle);
-                return true;
+                gotoPosition(message.targetPosition);
             }
 
-            return false;
+            return m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation());
         }
         break;
 
@@ -1634,9 +1517,6 @@ bool PlayerController::EV_Conversation(std::shared_ptr<EventMessages::Conversati
             {
                 message.status = ConversationMessage::Status::PLAYING;
 
-                // Don't let the routine overwrite our animations
-                setDailyRoutine({});
-
                 // Play the random dialog gesture
                 startDialogAnimation();
                 // Play sound of this conv-message
@@ -1806,7 +1686,6 @@ void PlayerController::interrupt()
     undrawWeapon(true);
 
     getEM().clear();
-    stopRoute();
 }
 
 bool PlayerController::canSee(Handle::EntityHandle entity, bool ignoreAngles)
@@ -1868,8 +1747,6 @@ float PlayerController::getAngleTo(const Math::float3& pos)
 
 void PlayerController::standUp(bool walkingAllowed, bool startAniTransition)
 {
-    stopRoute();
-
     setBodyState(BS_STAND);
 
     if (!startAniTransition)
@@ -1884,7 +1761,6 @@ void PlayerController::standUp(bool walkingAllowed, bool startAniTransition)
 void PlayerController::stopRoute()
 {
     m_MoveState.currentPath.clear();
-    m_RoutineState.routineActive = false;
     m_RoutineState.entityTarget.invalidate();
 }
 
@@ -2776,3 +2652,6 @@ void PlayerController::AniEvent_Tag(const ZenLoad::zCModelScriptEventTag& tag)
 {
     //if(tag.m_Tag == )
 }
+
+
+

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -2652,10 +2652,16 @@ void PlayerController::AniEvent_SFX(const ZenLoad::zCModelScriptEventSfx& sfx)
         }
     }
 
+    if(!sfx.m_EmptySlot && m_World.getAudioWorld().soundIsPlaying(m_MainNoiseSoundSlot))
+    {
+        // If emptyslot is not set, the currently played sound shall be stopped
+        m_World.getAudioWorld().stopSound(m_MainNoiseSoundSlot);
+    }
+
     // Play sound specified in the event
     float range = sfx.m_Range != 0.0f ? sfx.m_Range : DEFAULT_CHARACTER_SOUND_RANGE;
 
-    m_World.getAudioWorld().playSound(sfx.m_Name, getEntityTransform().Translation(), range);
+    m_MainNoiseSoundSlot = m_World.getAudioWorld().playSound(sfx.m_Name, getEntityTransform().Translation(), range);
 }
 
 void PlayerController::AniEvent_SFXGround(const ZenLoad::zCModelScriptEventSfx& sfx)
@@ -2666,8 +2672,16 @@ void PlayerController::AniEvent_SFXGround(const ZenLoad::zCModelScriptEventSfx& 
         ZenLoad::MaterialGroup mat = getMaterial(m_MoveState.ground.triangleIndex);
 
         float range = sfx.m_Range != 0.0f ? sfx.m_Range : DEFAULT_CHARACTER_SOUND_RANGE;
-        m_World.getAudioWorld().playSoundVariantRandom(sfx.m_Name + "_" + ZenLoad::zCMaterial::getMatGroupString(mat),
-                                                       getEntityTransform().Translation(), range);
+
+        std::string soundfile = sfx.m_Name + "_" + ZenLoad::zCMaterial::getMatGroupString(mat);
+
+        if(!sfx.m_EmptySlot && m_World.getAudioWorld().soundIsPlaying(m_MainNoiseSoundSlot))
+        {
+            // If emptyslot is not set, the currently played sound shall be stopped
+            m_World.getAudioWorld().stopSound(m_MainNoiseSoundSlot);
+        }
+
+        m_MainNoiseSoundSlot = m_World.getAudioWorld().playSoundVariantRandom(soundfile, getEntityTransform().Translation(), range);
     }
 }
 

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1540,7 +1540,7 @@ bool PlayerController::EV_Conversation(std::shared_ptr<EventMessages::Conversati
                 // Play the random dialog gesture
                 startDialogAnimation();
                 // Play sound of this conv-message
-                message.soundTicket = m_World.getAudioWorld().playSound(message.name, getEntityTransform().Translation());
+                message.soundTicket = m_World.getAudioWorld().playSound(message.name, getEntityTransform().Translation(), DEFAULT_CHARACTER_SOUND_RANGE);
                 if (!isMonolog)
                 {
                     m_World.getDialogManager().setCurrentMessage(sharedMessage);

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -134,13 +134,6 @@ void PlayerController::onUpdate(float deltaTime)
     }
     m_NoAniRootPosHack = false;
 
-    // Do waypoint-actions
-    if(!m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation()))
-    {
-        travelPath(deltaTime);
-        //m_NoAniRootPosHack = true;
-    }
-
     if (model)
     {
         // Make sure the idle-animation is running
@@ -235,7 +228,7 @@ void PlayerController::gotoPosition(const Math::float3& position)
     m_PathFinder.startNewRouteTo(getEntityTransform().Translation(), position);
 }
 
-void PlayerController::travelPath(float deltaTime)
+void PlayerController::travelPath()
 {
     Math::float3 positionNow = getEntityTransform().Translation();
 
@@ -1200,6 +1193,13 @@ bool PlayerController::EV_Movement(std::shared_ptr<EventMessages::MovementMessag
 
                 gotoPosition(pos.m_WorldMatrix.Translation());
             }
+            else
+            {
+                if(!m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation()))
+                {
+                    travelPath();
+                }
+            }
 
             return m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation());
         }
@@ -1235,6 +1235,14 @@ bool PlayerController::EV_Movement(std::shared_ptr<EventMessages::MovementMessag
                     }
                 }
             }
+            else
+            {
+                if(!m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation()))
+                {
+                    travelPath();
+                }
+            }
+
             return m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation());
         }
         break;
@@ -1244,6 +1252,13 @@ bool PlayerController::EV_Movement(std::shared_ptr<EventMessages::MovementMessag
             if(message.isFirstRun)
             {
                 gotoPosition(message.targetPosition);
+            }
+            else
+            {
+                if(!m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation()))
+                {
+                    travelPath();
+                }
             }
 
             return m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation());

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -48,6 +48,11 @@ namespace BodyNodes
     const char* NPC_NODE_TORSO = "ZS_TORSO";
 }
 
+/**
+ * Default soundrange for SFX which doesn't specify a range. Gothic uses a default value of 35 meters.
+ */
+static const float DEFAULT_CHARACTER_SOUND_RANGE = 35; // Meters
+
 #define SINGLE_ACTION_KEY(key, fn)               \
     {                                            \
         static bool last = false;                \
@@ -2648,7 +2653,9 @@ void PlayerController::AniEvent_SFX(const ZenLoad::zCModelScriptEventSfx& sfx)
     }
 
     // Play sound specified in the event
-    m_World.getAudioWorld().playSound(sfx.m_Name, getEntityTransform().Translation());
+    float range = sfx.m_Range != 0.0f ? sfx.m_Range : DEFAULT_CHARACTER_SOUND_RANGE;
+
+    m_World.getAudioWorld().playSound(sfx.m_Name, getEntityTransform().Translation(), range);
 }
 
 void PlayerController::AniEvent_SFXGround(const ZenLoad::zCModelScriptEventSfx& sfx)
@@ -2658,8 +2665,9 @@ void PlayerController::AniEvent_SFXGround(const ZenLoad::zCModelScriptEventSfx& 
         // Play sound depending on ground type
         ZenLoad::MaterialGroup mat = getMaterial(m_MoveState.ground.triangleIndex);
 
+        float range = sfx.m_Range != 0.0f ? sfx.m_Range : DEFAULT_CHARACTER_SOUND_RANGE;
         m_World.getAudioWorld().playSoundVariantRandom(sfx.m_Name + "_" + ZenLoad::zCMaterial::getMatGroupString(mat),
-                                                       getEntityTransform().Translation());
+                                                       getEntityTransform().Translation(), range);
     }
 }
 

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1246,6 +1246,10 @@ bool PlayerController::EV_Movement(std::shared_ptr<EventMessages::MovementMessag
                 gotoPosition(message.targetPosition);
             }
 
+            ddSetColor(0xFFFFFFFF);
+            ddMoveTo(getEntityTransform().Translation().v);
+            ddLineTo(message.targetPosition.v);
+
             return m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation());
         }
         break;

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1246,10 +1246,6 @@ bool PlayerController::EV_Movement(std::shared_ptr<EventMessages::MovementMessag
                 gotoPosition(message.targetPosition);
             }
 
-            ddSetColor(0xFFFFFFFF);
-            ddMoveTo(getEntityTransform().Translation().v);
-            ddLineTo(message.targetPosition.v);
-
             return m_PathFinder.hasActiveRouteBeenCompleted(getEntityTransform().Translation());
         }
         break;

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -463,7 +463,7 @@ namespace Logic
         /**
          * Moves the NPC to the next waypoint of the current path
          */
-        void travelPath(float deltaTime);
+        void travelPath();
 
         /**
          * Current routine state

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -7,6 +7,7 @@
 #include "NpcAIHandler.h"
 #include "NpcAnimationHandler.h"
 #include "NpcScriptState.h"
+#include "Pathfinder.h"
 #include <daedalus/DaedalusGameState.h>
 
 namespace UI
@@ -87,22 +88,9 @@ namespace Logic
          * @return The type of this class. If you are adding a new base controller, be sure to add it to ControllerTypes.h
          */
         virtual EControllerType getControllerType() override { return EControllerType::PlayerController; }
-        /**
-         * Sets the daily routine for this.
-         * TODO: Add timing for these // TODO: Done, now remove this
-         *
-         * @param wps List of waypoints the NPC should visit, in order
-         */
-        void setDailyRoutine(const std::vector<size_t>& wps)
-        {
-            m_RoutineState.routineWaypoints = wps;
-        }
-        void addRoutineWaypoint(size_t wp)
-        {
-            m_RoutineState.routineWaypoints.push_back(wp);
-        }
 
         void setFollowTarget(Handle::EntityHandle e) { m_RoutineState.entityTarget = e; }
+
         /**
          * Called when the models visual changed
          */
@@ -137,19 +125,11 @@ namespace Logic
         void onDebugDraw() override;
 
         /**
-         * Lets the controller move the entity to the next routine target
-         */
-        void continueRoutine();
-
-        /**
          * Calculates a route and begins to move the NPC to the given waypoint
          */
-        void gotoWaypoint(size_t wp);
-
-        /**
-         * Recalculates the current route
-         */
-        void rebuildRoute();
+        void gotoWaypoint(World::Waynet::WaypointIndex wp);
+        void gotoVob(Handle::EntityHandle vob);
+        void gotoPosition(const Math::float3& position);
 
         /**
          * Stops going along the current route
@@ -482,27 +462,14 @@ namespace Logic
 
         /**
          * Moves the NPC to the next waypoint of the current path
-         * @return true, if the current paths destination was reached
          */
-        bool travelPath(float deltaTime);
+        void travelPath(float deltaTime);
 
         /**
          * Current routine state
          */
         struct
         {
-            // Route-Waypoint index to got to
-            size_t routineTarget;
-
-            // If this is false, the NPC won't do it's routine after finishing moving to the current target
-            bool routineActive;
-
-            /**
-             * List of waypoints to move to on this AIs daily routine
-             * TODO: Implement timing for these
-             */
-            std::vector<size_t> routineWaypoints;
-
             /**
              * Target of where the NPC should keep trying to go to
              */
@@ -618,6 +585,9 @@ namespace Logic
          * AI/Input handler
          */
         NpcAIHandler m_AIHandler;
+
+        // Route-information
+        Pathfinder m_PathFinder;
 
         /**
          * refuse talk countdown

--- a/src/logic/PlayerController.h
+++ b/src/logic/PlayerController.h
@@ -614,6 +614,9 @@ namespace Logic
         bool m_NoAniRootPosHack;
         size_t m_LastAniRootPosUpdatedAniHash;
 
+        // Main noise sound slot. Other sounds using it won't play if there is already a sound playing here.
+        Utils::Ticket<World::AudioWorld> m_MainNoiseSoundSlot;
+
         /**
          * Contstants
          */

--- a/src/logic/messages/EventManager.cpp
+++ b/src/logic/messages/EventManager.cpp
@@ -20,6 +20,9 @@ EventManager::EventManager(World::WorldInstance& world, Handle::EntityHandle hos
 
 void EventManager::handleMessage(SharedEMessage message, Handle::EntityHandle sourceVob)
 {
+
+    message->isFirstRun = true;
+
     // Check if we shall execute this right away
     if (!message->isJob && (message->isHighPriority || m_EventQueue.empty()))
     {
@@ -51,6 +54,8 @@ void EventManager::sendMessageToHost(SharedEMessage message, Handle::EntityHandl
     Vob::VobInformation vob = Vob::asVob(m_World, m_HostVob);
 
     vob.logic->onMessage(message, sourceVob);
+
+    message->isFirstRun = false;
 }
 
 void EventManager::processMessageQueue()

--- a/src/logic/messages/EventMessage.h
+++ b/src/logic/messages/EventMessage.h
@@ -100,6 +100,11 @@ namespace Logic
             bool isOverlay;
 
             /**
+             * Whether this is the first time this message is being handled
+             */
+            bool isFirstRun;
+
+            /**
              * Adds a callback, triggered when this message has been successfully and completely processed
              * @param hostVob Vob which the callback is set from
              * @param callback Callback function

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -568,20 +568,19 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         std::string fpname = vm.popString(true);
         int32_t self = vm.popVar();
 
+        // FIXME: Same as ai_gotofp. What's the exact difference between them?
         VobTypes::NpcVobInformation npc = getNPCByInstance(self);
 
         if (npc.isValid())
         {
-            // Find closest fp not used by npc
-            std::vector<Handle::EntityHandle> fp = pWorld->getFreepointsInRange(npc.position->m_WorldMatrix.Translation(), 20.0f, fpname, true, npc.entity);
+            // Find closest fp
+            std::vector<Handle::EntityHandle> fp = pWorld->getFreepointsInRange(npc.position->m_WorldMatrix.Translation(), 20.0f, fpname, true);
 
             if(!fp.empty())
             {
-                Math::float3 fpPosition = pWorld->getEntity<Components::PositionComponent>(fp.front()).m_WorldMatrix.Translation();
-
                 EventMessages::MovementMessage sm;
-                sm.subType = EventMessages::MovementMessage::ST_GotoPos;
-                sm.targetPosition = fpPosition;
+                sm.subType = EventMessages::MovementMessage::ST_GotoFP;
+                sm.targetVob = fp.front();
                 npc.playerController->getEM().onMessage(sm);
             }
         }
@@ -600,11 +599,9 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
 
             if(!fp.empty())
             {
-                Math::float3 fpPosition = pWorld->getEntity<Components::PositionComponent>(fp.front()).m_WorldMatrix.Translation();
-
                 EventMessages::MovementMessage sm;
-                sm.subType = EventMessages::MovementMessage::ST_GotoPos;
-                sm.targetPosition = fpPosition;
+                sm.subType = EventMessages::MovementMessage::ST_GotoFP;
+                sm.targetVob = fp.front();
                 npc.playerController->getEM().onMessage(sm);
             }
         }

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -565,19 +565,50 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
     });
 
     vm->registerExternalFunction("ai_gotonextfp", [=](Daedalus::DaedalusVM& vm) {
-        std::string fp = vm.popString(true);
+        std::string fpname = vm.popString(true);
         int32_t self = vm.popVar();
 
         VobTypes::NpcVobInformation npc = getNPCByInstance(self);
 
         if (npc.isValid())
         {
-            EventMessages::MovementMessage sm;
-            sm.subType = EventMessages::MovementMessage::ST_GotoFP;
-            sm.targetVobName = fp;
-            npc.playerController->getEM().onMessage(sm);
-            //npc.playerController->gotoWaypoint(World::Waynet::getWaypointIndex(pWorld->getWaynet(), wp));
+            // Find closest fp not used by npc
+            std::vector<Handle::EntityHandle> fp = pWorld->getFreepointsInRange(npc.position->m_WorldMatrix.Translation(), 20.0f, fpname, true, npc.entity);
+
+            if(!fp.empty())
+            {
+                Math::float3 fpPosition = pWorld->getEntity<Components::PositionComponent>(fp.front()).m_WorldMatrix.Translation();
+
+                EventMessages::MovementMessage sm;
+                sm.subType = EventMessages::MovementMessage::ST_GotoPos;
+                sm.targetPosition = fpPosition;
+                npc.playerController->getEM().onMessage(sm);
+            }
         }
+    });
+
+    vm->registerExternalFunction("ai_gotofp", [=](Daedalus::DaedalusVM& vm) {
+        std::string fpname = vm.popString(true);
+        int32_t self = vm.popVar();
+
+        VobTypes::NpcVobInformation npc = getNPCByInstance(self);
+
+        if (npc.isValid())
+        {
+            // Find closest fp
+            std::vector<Handle::EntityHandle> fp = pWorld->getFreepointsInRange(npc.position->m_WorldMatrix.Translation(), 20.0f, fpname, true);
+
+            if(!fp.empty())
+            {
+                Math::float3 fpPosition = pWorld->getEntity<Components::PositionComponent>(fp.front()).m_WorldMatrix.Translation();
+
+                EventMessages::MovementMessage sm;
+                sm.subType = EventMessages::MovementMessage::ST_GotoPos;
+                sm.targetPosition = fpPosition;
+                npc.playerController->getEM().onMessage(sm);
+            }
+        }
+
     });
 
     vm->registerExternalFunction("ai_gotonpc", [=](Daedalus::DaedalusVM& vm) {
@@ -907,7 +938,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         if (npc.isValid())
         {
             // Find closest fp
-            std::vector<Handle::EntityHandle> fp = pWorld->getFreepointsInRange(npc.position->m_WorldMatrix.Translation(), 100.0f, fpname, true);
+            std::vector<Handle::EntityHandle> fp = pWorld->getFreepointsInRange(npc.position->m_WorldMatrix.Translation(), 20.0f, fpname, true);
 
             vm.setReturn(!fp.empty());
         }
@@ -926,7 +957,7 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         if (npc.isValid())
         {
             // Find closest fp
-            std::vector<Handle::EntityHandle> fp = pWorld->getFreepointsInRange(npc.position->m_WorldMatrix.Translation(), 100.0f, fpname, true, npc.entity);
+            std::vector<Handle::EntityHandle> fp = pWorld->getFreepointsInRange(npc.position->m_WorldMatrix.Translation(), 20.0f, fpname, true, npc.entity);
 
             vm.setReturn(!fp.empty());
         }

--- a/src/logic/visuals/ModelVisual.cpp
+++ b/src/logic/visuals/ModelVisual.cpp
@@ -159,14 +159,14 @@ bool ModelVisual::load(const std::string& visual)
     {
         // Init positions
         Components::EntityComponent& entity = m_World.getEntity<Components::EntityComponent>(e);
-        Components::addComponent<Components::PositionComponent>(entity);
+        Components::Actions::initComponent<Components::PositionComponent>(m_World.getComponentAllocator(), e);
 
         // Copy world-matrix
         Components::PositionComponent& pos = m_World.getEntity<Components::PositionComponent>(e);
         pos = hostPos;
 
         // Init animation components
-        Components::addComponent<Components::AnimationComponent>(entity);
+        Components::Actions::initComponent<Components::AnimationComponent>(m_World.getComponentAllocator(), e);
         Components::AnimationComponent& anim = m_World.getEntity<Components::AnimationComponent>(e);
 
         // Assign the main-vob as animation controller
@@ -176,6 +176,9 @@ bool ModelVisual::load(const std::string& visual)
     /****
      * Read nodes and attachments
      ****/
+
+    // In case this wasn't already initialized...
+    Components::Actions::initComponent<Components::AnimationComponent>(m_World.getComponentAllocator(), m_Entity);
 
     // Read attachments
     if (m_VisualAttachments.size() < getAnimationHandler().getObjectSpaceTransforms().size())
@@ -230,7 +233,7 @@ bool ModelVisual::load(const std::string& visual)
             {
                 // Init positions
                 Components::EntityComponent& entity = m_World.getEntity<Components::EntityComponent>(e);
-                Components::addComponent<Components::PositionComponent>(entity);
+                Components::Actions::initComponent<Components::PositionComponent>(m_World.getComponentAllocator(), e);
 
                 // Important: Apply draw distance, and every other setting from the host
                 Components::PositionComponent& pos = m_World.getEntity<Components::PositionComponent>(e);

--- a/src/logic/visuals/StaticMeshVisual.cpp
+++ b/src/logic/visuals/StaticMeshVisual.cpp
@@ -42,7 +42,7 @@ bool StaticMeshVisual::load(const std::string& visual)
     {
         // Init positions
         Components::EntityComponent& entity = m_World.getEntity<Components::EntityComponent>(e);
-        Components::addComponent<Components::PositionComponent>(entity);
+        Components::Actions::initComponent<Components::PositionComponent>(m_World.getComponentAllocator(), e);
 
         // Copy world-matrix
         Components::PositionComponent& pos = m_World.getEntity<Components::PositionComponent>(e);

--- a/src/render/RenderSystem.h
+++ b/src/render/RenderSystem.h
@@ -95,5 +95,8 @@ namespace Render
          */
         std::vector<bgfx::DynamicVertexBufferHandle> m_InstanceDataBuffers;
         std::vector<uint32_t> m_FreeInstanceDataBuffers;
+
+        std::vector<bgfx::ProgramHandle> m_LoadedPrograms;
+        std::vector<bgfx::UniformHandle> m_AllUniforms;
     };
 }


### PR DESCRIPTION
- Npcs now move using their animations. This also means they do the "start-running" and "stop-running" animations.
- Npcs could now draw weapons and fight, but there isn't any code triggering that at the moment.
- Pathfinding was improved. Walking towards moving targets has been improved as well. 
- Npcs can now go to arbitrary positions, thus, moving to freepoints has been implemented and following someone has been improved (Think Mud!)
- Argument `--show-routes` has been added for debuggung
- Some misc sound fixes and improvements
- World now actually runs destruct-functions of components
- Event-Messages now have a "isFirstRun"-flag