### PR TITLE
Log tweaks

### DIFF
--- a/src/engine/GameSession.h
+++ b/src/engine/GameSession.h
@@ -9,6 +9,7 @@
 #include "GameClock.h"
 #include "World.h"
 #include <handle/HandleDef.h>
+#include <logic/LogManager.h>
 #include <json/json.hpp>
 
 namespace Engine
@@ -128,6 +129,8 @@ namespace Engine
          */
         void removeAllWorlds();
 
+        Logic::LogManager& getLogManager() { return m_LogManager; }
+
     private:
         std::map<std::string, nlohmann::json> m_InactiveWorlds;
 
@@ -145,6 +148,11 @@ namespace Engine
          * known infoInstances by npcInstances
          */
         std::map<size_t, std::set<size_t>> m_KnownInfos;
+
+        /**
+         * The log-manager
+         */
+        Logic::LogManager m_LogManager;
 
         /**
          * Currently active world instances

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -49,7 +49,6 @@ WorldInstance::WorldInstance(Engine::BaseEngine& engine)
     , m_AnimationLibrary(*this)
     , m_Sky(*this)
     , m_DialogManager(*this)
-    , m_LogManager(*this)
     , m_BspTree(*this)
     , m_PfxManager(*this)
     , m_AudioWorld(nullptr)
@@ -480,7 +479,7 @@ bool WorldInstance::init(const std::string& zen,
         // Load logManager if one is provided.
         if (!logManager.empty())
         {
-            m_LogManager.importLogManager(logManager);
+            engine.getSession().getLogManager().importLogManager(logManager);
         }
 
         m_pEngine->getHud().getLoadingScreen().setSectionProgress(100);

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -16,7 +16,6 @@
 #include <content/VertexTypes.h>
 #include <logic/CameraController.h>
 #include <logic/DialogManager.h>
-#include <logic/LogManager.h>
 #include <logic/PfxManager.h>
 #include <logic/ScriptEngine.h>
 #include <memory/AllocatorBundle.h>
@@ -261,10 +260,7 @@ namespace World
         {
             return m_DialogManager;
         }
-        Logic::LogManager& getLogManager()
-        {
-            return m_LogManager;
-        }
+
         World::AudioWorld& getAudioWorld()
         {
             return *m_AudioWorld;
@@ -451,11 +447,6 @@ namespace World
          * This worlds dialog-manager
          */
         Logic::DialogManager m_DialogManager;
-
-        /**
-         * The log-manager
-         */
-        Logic::LogManager m_LogManager;
 
         /**
          * Pfx-cache

--- a/src/logic/LogManager.cpp
+++ b/src/logic/LogManager.cpp
@@ -7,18 +7,19 @@
 #include <utils/logger.h>
 
 using namespace Logic;
+using LogTopic = Daedalus::GameState::LogTopic;
 
-const std::map<std::string, Daedalus::GameState::LogTopic>& Logic::LogManager::getPlayerLog()
+const std::map<std::string, LogTopic>& Logic::LogManager::getPlayerLog()
 {
     return m_PlayerLog;
 }
 
-void LogManager::createTopic(const std::string& topicName, Daedalus::GameState::LogTopic::ESection section)
+void LogManager::createTopic(const std::string& topicName, LogTopic::ESection section)
 {
     m_PlayerLog[topicName].section = section;
 }
 
-void LogManager::setTopicStatus(const std::string& topicName, Daedalus::GameState::LogTopic::ELogStatus status)
+void LogManager::setTopicStatus(const std::string& topicName, LogTopic::ELogStatus status)
 {
     m_PlayerLog[topicName].status = status;
 }
@@ -42,32 +43,32 @@ void LogManager::exportLogManager(json& log)
         jsonTopic["name"] = topic.first;
         jsonTopic["entries"] = topic.second.entries;
 
-        if (topic.second.section == Daedalus::GameState::LogTopic::ESection::LT_Mission)
+        if (topic.second.section == LogTopic::ESection::LT_Mission)
         {
             switch (topic.second.status)
             {
-                case Daedalus::GameState::LogTopic::ELogStatus::LS_Running:
+                case LogTopic::ELogStatus::LS_Running:
                     log["mission"]["running"].push_back(jsonTopic);
                     break;
-                case Daedalus::GameState::LogTopic::ELogStatus::LS_Success:
+                case LogTopic::ELogStatus::LS_Success:
                     log["mission"]["success"].push_back(jsonTopic);
                     break;
-                case Daedalus::GameState::LogTopic::ELogStatus::LS_Failed:
+                case LogTopic::ELogStatus::LS_Failed:
                     log["mission"]["failed"].push_back(jsonTopic);
                     break;
-                case Daedalus::GameState::LogTopic::ELogStatus::LS_Obsolete:
+                case LogTopic::ELogStatus::LS_Obsolete:
                     log["mission"]["obsolete"].push_back(jsonTopic);
                     break;
             }
         }
-        else if (topic.second.section == Daedalus::GameState::LogTopic::ESection::LT_Note)
+        else if (topic.second.section == LogTopic::ESection::LT_Note)
         {
             log["note"].push_back(jsonTopic);
         }
     }
 }
 
-void LogManager::importTopic(const json& topic, Daedalus::GameState::LogTopic::ESection section, Daedalus::GameState::LogTopic::ELogStatus status)
+void LogManager::importTopic(const json& topic, LogTopic::ESection section, LogTopic::ELogStatus status)
 {
     std::string name = Utils::utf8_to_iso8859_1(topic.at("name").get<std::string>().c_str());
     createTopic(name, section);
@@ -78,7 +79,7 @@ void LogManager::importTopic(const json& topic, Daedalus::GameState::LogTopic::E
 
 void LogManager::importLogManager(const json& log)
 {
-    using ELogStatus = Daedalus::GameState::LogTopic::ELogStatus;
+    using ELogStatus = LogTopic::ELogStatus;
     const std::map<std::string, ELogStatus> logStatus {
         std::make_pair("running", ELogStatus::LS_Running),
         std::make_pair("success", ELogStatus::LS_Success),
@@ -90,9 +91,9 @@ void LogManager::importLogManager(const json& log)
     {
         auto status = logStatus.at(missionStatus.key());
         for (auto missionTopic : missionStatus.value())
-            importTopic(missionTopic, Daedalus::GameState::LogTopic::ESection::LT_Mission, status);
+            importTopic(missionTopic, LogTopic::ESection::LT_Mission, status);
     }
 
     for (auto noteTopic : log.at("note"))
-        importTopic(noteTopic, Daedalus::GameState::LogTopic::ESection::LT_Note, ELogStatus::LS_Running);
+        importTopic(noteTopic, LogTopic::ESection::LT_Note, ELogStatus::LS_Running);
 }

--- a/src/logic/LogManager.h
+++ b/src/logic/LogManager.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <json.hpp>
-#include <daedalus/DaedalusDialogManager.h>
 #include <daedalus/DaedalusGameState.h>
-#include <logic/messages/EventMessage.h>
 
 using json = nlohmann::json;
 
@@ -17,13 +15,25 @@ namespace Logic
     class LogManager
     {
     public:
-        LogManager(World::WorldInstance& world);
-        ~LogManager();
-
         /**
          * Get the current player log
          */
-        std::map<std::string, Daedalus::GameState::LogTopic>& getPlayerLog();
+        const std::map<std::string, Daedalus::GameState::LogTopic>& getPlayerLog();
+
+        /**
+         * Creates a new Topic
+         */
+        void createTopic(const std::string& topicName, Daedalus::GameState::LogTopic::ESection section);
+
+        /**
+         * Creates a new Topic
+         */
+        void setTopicStatus(const std::string& topicName, Daedalus::GameState::LogTopic::ELogStatus status);
+
+        /**
+         * Adds an entry to a topic
+         */
+        void addEntry(const std::string& topicName, std::string entry);
 
         /**
          * Export the current log to the given log parameter
@@ -41,9 +51,10 @@ namespace Logic
         void importTopic(const json& topic, Daedalus::GameState::LogTopic::ESection section, Daedalus::GameState::LogTopic::ELogStatus status);
 
     private:
+
         /**
-         * World this runs in
+         * @brief The players log. Map of Entries by Topics
          */
-        World::WorldInstance& m_World;
+        std::map<std::string, Daedalus::GameState::LogTopic> m_PlayerLog;
     };
 }

--- a/src/logic/LogManager.h
+++ b/src/logic/LogManager.h
@@ -21,12 +21,12 @@ namespace Logic
         const std::map<std::string, Daedalus::GameState::LogTopic>& getPlayerLog();
 
         /**
-         * Creates a new Topic
+         * Creates a new topic
          */
         void createTopic(const std::string& topicName, Daedalus::GameState::LogTopic::ESection section);
 
         /**
-         * Creates a new Topic
+         * Sets the status of a topic
          */
         void setTopicStatus(const std::string& topicName, Daedalus::GameState::LogTopic::ELogStatus status);
 
@@ -46,14 +46,14 @@ namespace Logic
         void importLogManager(const json& log);
 
         /**
-         * imports a single Mission-topic or Note-topic
+         * Imports a single mission-topic or note-topic
          */
         void importTopic(const json& topic, Daedalus::GameState::LogTopic::ESection section, Daedalus::GameState::LogTopic::ELogStatus status);
 
     private:
 
         /**
-         * @brief The players log. Map of Entries by Topics
+         * @brief The player's log. Map of entries by topics
          */
         std::map<std::string, Daedalus::GameState::LogTopic> m_PlayerLog;
     };

--- a/src/logic/LogManager.h
+++ b/src/logic/LogManager.h
@@ -35,6 +35,11 @@ namespace Logic
          */
         void importLogManager(const json& log);
 
+        /**
+         * imports a single Mission-topic or Note-topic
+         */
+        void importTopic(const json& topic, Daedalus::GameState::LogTopic::ESection section, Daedalus::GameState::LogTopic::ELogStatus status);
+
     private:
         /**
          * World this runs in

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -325,7 +325,7 @@ void Engine::SavegameManager::saveToSlot(int index, std::string savegameName)
 
     // export log info
     json logManager;
-    mainWorld.getLogManager().exportLogManager(logManager);
+    gameEngine->getSession().getLogManager().exportLogManager(logManager);
     Engine::SavegameManager::writeFileInSlot(index, "logmanager.json", Utils::iso_8859_1_to_utf8(logManager.dump(4)));
 
     // export script engine

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -1344,23 +1344,23 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         }
     });
 
-    vm->registerExternalFunction("log_createtopic", [=](Daedalus::DaedalusVM& vm) {
+    vm->registerExternalFunction("Log_CreateTopic", [=](Daedalus::DaedalusVM& vm) {
         int32_t section = vm.popDataValue();
         std::string topicName = vm.popString();
 
-        auto& playerLog = vm.getGameState().getPlayerLog();
-        playerLog[topicName].section = static_cast<Daedalus::GameState::LogTopic::ESection>(section);
+        auto& logManager = engine->getSession().getLogManager();
+        logManager.createTopic(topicName, static_cast<Daedalus::GameState::LogTopic::ESection>(section));
     });
 
-    vm->registerExternalFunction("log_settopicstatus", [=](Daedalus::DaedalusVM& vm) {
+    vm->registerExternalFunction("Log_SetTopicStatus", [=](Daedalus::DaedalusVM& vm) {
         int32_t status = vm.popDataValue();
         std::string topicName = vm.popString();
 
-        auto& playerLog = vm.getGameState().getPlayerLog();
-        playerLog[topicName].status = static_cast<Daedalus::GameState::LogTopic::ELogStatus>(status);
+        auto& logManager = engine->getSession().getLogManager();
+        logManager.setTopicStatus(topicName, static_cast<Daedalus::GameState::LogTopic::ELogStatus>(status));
     });
 
-    vm->registerExternalFunction("log_addentry", [=](Daedalus::DaedalusVM& vm) {
+    vm->registerExternalFunction("Log_AddEntry", [=](Daedalus::DaedalusVM& vm) {
         std::string entry = vm.popString();
         std::string topicName = vm.popString();
 
@@ -1369,8 +1369,8 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         LogInfo() << entry;
         LogInfo() << "";
 
-        auto& playerLog = vm.getGameState().getPlayerLog();
-        playerLog[topicName].entries.push_back(entry);
+        auto& logManager = engine->getSession().getLogManager();
+        logManager.addEntry(topicName, entry);
 
         pWorld->getScriptEngine().onLogEntryAdded(topicName, entry);
     });

--- a/src/ui/MenuItemListbox.cpp
+++ b/src/ui/MenuItemListbox.cpp
@@ -71,7 +71,7 @@ bool MenuItemTypes::MenuItemListbox::hasTopics()
         return false;
 }
 
-void MenuItemTypes::MenuItemListbox::addTopic(std::string topic_name, Daedalus::GameState::LogTopic& topic)
+void MenuItemTypes::MenuItemListbox::addTopic(std::string topic_name, const Daedalus::GameState::LogTopic& topic)
 {
     m_Entries.push_back(new MenuItemListboxEntry(m_Engine, m_BaseMenu, m_ScriptHandle, topic_name, topic));
 }

--- a/src/ui/MenuItemListbox.h
+++ b/src/ui/MenuItemListbox.h
@@ -30,7 +30,7 @@ namespace UI
              * @param topic_name The name of the topic
              * @param topic The topic containing the topic entries
              */
-            void addTopic(std::string topic_name, Daedalus::GameState::LogTopic& topic);
+            void addTopic(std::string topic_name, const Daedalus::GameState::LogTopic& topic);
 
             /*
              * Returns true if this listbox has at least one topic entry, false otherwise

--- a/src/ui/MenuItemListboxEntry.cpp
+++ b/src/ui/MenuItemListboxEntry.cpp
@@ -14,8 +14,8 @@ using namespace MenuItemTypes;
 
 MenuItemTypes::MenuItemListboxEntry::MenuItemListboxEntry(Engine::BaseEngine& e, UI::Menu& baseMenu,
                                                           const Daedalus::GameState::MenuItemHandle& scriptHandle,
-                                                          std::string& topic_name,
-                                                          Daedalus::GameState::LogTopic& topic)
+                                                          const std::string& topic_name,
+                                                          const Daedalus::GameState::LogTopic& topic)
     : MenuItemText(e, baseMenu, scriptHandle)
     , m_TopicName(topic_name)
     , m_Topic(topic)

--- a/src/ui/MenuItemListboxEntry.h
+++ b/src/ui/MenuItemListboxEntry.h
@@ -16,7 +16,10 @@ namespace UI
         class MenuItemListboxEntry : public MenuItemText
         {
         public:
-            MenuItemListboxEntry(Engine::BaseEngine& e, Menu& baseMenu, const Daedalus::GameState::MenuItemHandle& scriptHandle, std::string& topic_name, Daedalus::GameState::LogTopic& topic);
+            MenuItemListboxEntry(Engine::BaseEngine& e, Menu& baseMenu,
+                                 const Daedalus::GameState::MenuItemHandle& scriptHandle,
+                                 const std::string& topic_name,
+                                 const Daedalus::GameState::LogTopic& topic);
 
             /**
              * Get the entries of this listbox entry

--- a/src/ui/Menu_Log.cpp
+++ b/src/ui/Menu_Log.cpp
@@ -63,7 +63,7 @@ void Menu_Log::initializeLogEntries()
             listbox_info = dynamic_cast<MenuItemTypes::MenuItemListbox*>(item.second);
 
     // Set topic entries to listboxes
-    std::map<std::string, Daedalus::GameState::LogTopic>& log = m_Engine.getMainWorld().get().getLogManager().getPlayerLog();
+    const std::map<std::string, Daedalus::GameState::LogTopic>& log = m_Engine.getSession().getLogManager().getPlayerLog();
     for (auto& entry : log)
     {
         if (entry.second.section == Daedalus::GameState::LogTopic::ESection::LT_Mission)


### PR DESCRIPTION
- now keep mission-/note log on world switch (moving `LogManager` from `GameState` to `GameSession`)
- code refactoring