### PR TITLE
Restructuring engine parts

### DIFF
--- a/lib/adpcm/adpcm-lib.cpp
+++ b/lib/adpcm/adpcm-lib.cpp
@@ -337,7 +337,7 @@ int adpcm_decode_block (int16_t *outbuf, const uint8_t *inbuf, size_t inbufsize,
     int32_t pcmdata[2];
     int8_t index[2];
 
-    if (inbufsize < channels * 4)
+    if (inbufsize < (size_t)channels * 4)
         return 0;
 
     for (ch = 0; ch < channels; ch++) {

--- a/src/audio/AudioWorld.cpp
+++ b/src/audio/AudioWorld.cpp
@@ -14,7 +14,8 @@
 #include <logic/ScriptEngine.h>
 #include <utils/logger.h>
 
-#include "engine/BaseEngine.h"
+#include "engine/GameEngine.h"
+#include "engine/GameSession.h"
 
 #include "AudioEngine.h"
 #include "AudioWorld.h"
@@ -24,7 +25,7 @@ using namespace Audio;
 
 namespace World
 {
-    AudioWorld::AudioWorld(Engine::BaseEngine& engine, AudioEngine& audio_engine, const VDFS::FileIndex& vdfidx)
+    AudioWorld::AudioWorld(Engine::GameEngine& engine, AudioEngine& audio_engine, const VDFS::FileIndex& vdfidx)
         : m_Engine(engine)
         , m_VDFSIndex(vdfidx)
     {
@@ -175,7 +176,7 @@ namespace World
 
         LogInfo() << "play sound " << snd.sfx.file << " vol " << snd.sfx.vol;
 
-        alSourcef(s.m_Handle, AL_PITCH, m_Engine.getGameClock().getGameEngineSpeedFactor());
+        alSourcef(s.m_Handle, AL_PITCH, m_Engine.getSession().getGameClock().getGameEngineSpeedFactor());
         alSourcef(s.m_Handle, AL_GAIN, snd.sfx.vol / 127.0f);
         alSource3f(s.m_Handle, AL_POSITION, position.x, position.y, position.z);
         alSource3f(s.m_Handle, AL_VELOCITY, 0, 0, 0);

--- a/src/audio/AudioWorld.cpp
+++ b/src/audio/AudioWorld.cpp
@@ -176,7 +176,7 @@ namespace World
 
         LogInfo() << "play sound " << snd.sfx.file << " vol " << snd.sfx.vol;
 
-        alSourcef(s.m_Handle, AL_PITCH, m_Engine.getSession().getGameClock().getGameEngineSpeedFactor());
+        alSourcef(s.m_Handle, AL_PITCH, m_Engine.getGameClock().getGameEngineSpeedFactor());
         alSourcef(s.m_Handle, AL_GAIN, snd.sfx.vol / 127.0f);
         alSource3f(s.m_Handle, AL_POSITION, position.x, position.y, position.z);
         alSource3f(s.m_Handle, AL_VELOCITY, 0, 0, 0);

--- a/src/audio/AudioWorld.h
+++ b/src/audio/AudioWorld.h
@@ -20,7 +20,7 @@ namespace Audio
 
 namespace Engine
 {
-    class BaseEngine;
+    class GameEngine;
 }
 
 namespace Daedalus
@@ -50,7 +50,7 @@ namespace World
         friend class Audio::AudioEngine;
 
     public:
-        AudioWorld(Engine::BaseEngine& engine, Audio::AudioEngine& audio_engine, const VDFS::FileIndex& vdfidx);
+        AudioWorld(Engine::GameEngine& engine, Audio::AudioEngine& audio_engine, const VDFS::FileIndex& vdfidx);
 
         virtual ~AudioWorld();
 
@@ -118,7 +118,7 @@ namespace World
         void continueSounds();
 
     private:
-        Engine::BaseEngine& m_Engine;
+        Engine::GameEngine& m_Engine;
 
         /**
          * Pointer to a vdfs-index to work on (can be nullptr)

--- a/src/components/VobClasses.cpp
+++ b/src/components/VobClasses.cpp
@@ -4,7 +4,7 @@
 
 #include "VobClasses.h"
 #include "EntityActions.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <engine/World.h>
 #include <logic/ItemController.h>
 #include <logic/MobController.h>

--- a/src/content/AnimationLibrary.cpp
+++ b/src/content/AnimationLibrary.cpp
@@ -1,6 +1,6 @@
 #include <algorithm>
 #include <ZenLib/zenload/zCMaterial.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <engine/World.h>
 #include <utils/logger.h>
 #include <vdfs/fileIndex.h>

--- a/src/content/SkeletalMeshAllocator.cpp
+++ b/src/content/SkeletalMeshAllocator.cpp
@@ -1,7 +1,7 @@
 #include "SkeletalMeshAllocator.h"
 #include "VertexTypes.h"
 #include <bgfx/bgfx.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <utils/logger.h>
 #include <vdfs/fileIndex.h>
 #include <zenload/zCModelMeshLib.h>
@@ -9,7 +9,7 @@
 
 using namespace Meshes;
 
-SkeletalMeshAllocator::SkeletalMeshAllocator(Engine::BaseEngine& engine)
+SkeletalMeshAllocator::SkeletalMeshAllocator(Engine::GameEngine& engine)
     : m_Engine(engine)
 {
 }
@@ -144,7 +144,7 @@ Handle::MeshHandle SkeletalMeshAllocator::loadFromPacked(const ZenLoad::PackedSk
 
     // Flush the pipeline to prevent an overflow
     //bgfx::frame();
-    m_Engine.executeInMainThread([this, h](Engine::BaseEngine* pEngine) {
+    m_Engine.executeInMainThread([this, h](Engine::GameEngine* pEngine) {
         bgfx::frame();  // quick fix: executes all pending resource creations to prevent overflow
 
         finalizeLoad(h);

--- a/src/content/SkeletalMeshAllocator.h
+++ b/src/content/SkeletalMeshAllocator.h
@@ -8,7 +8,7 @@
 
 namespace Engine
 {
-    class BaseEngine;
+    class GameEngine;
 }
 
 namespace Meshes
@@ -20,7 +20,7 @@ namespace Meshes
     class SkeletalMeshAllocator
     {
     public:
-        SkeletalMeshAllocator(Engine::BaseEngine& engine);
+        SkeletalMeshAllocator(Engine::GameEngine& engine);
         virtual ~SkeletalMeshAllocator();
 
         /**
@@ -78,7 +78,7 @@ namespace Meshes
         /**
          * Engine
          */
-        Engine::BaseEngine& m_Engine;
+        Engine::GameEngine& m_Engine;
 
         /**
          * Rough estimation about how much memory the loaded textures need on the GPU

--- a/src/content/Sky.cpp
+++ b/src/content/Sky.cpp
@@ -6,7 +6,8 @@
 #include <cstdint>
 #include <iostream>
 #include "engine/Input.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
+#include <engine/GameSession.h>
 #include <engine/World.h>
 #include <entry/input.h>
 #include <utils/Utils.h>
@@ -80,7 +81,7 @@ void Sky::calculateLUT_ZenGin(const Math::float3& col0, const Math::float3& col1
 void Sky::interpolate()
 {
     // time since 12:00 in days
-    double skyTime = std::fmod(m_World.getEngine()->getGameClock().getTimeOfDay() + 0.5, 1.0);
+    double skyTime = std::fmod(m_World.getEngine()->getSession().getGameClock().getTimeOfDay() + 0.5, 1.0);
     m_MasterState.time = static_cast<float>(skyTime);
 
     // init with values for case: time >= TIME_KEY_7 (= 0.75f)

--- a/src/content/Sky.cpp
+++ b/src/content/Sky.cpp
@@ -81,7 +81,7 @@ void Sky::calculateLUT_ZenGin(const Math::float3& col0, const Math::float3& col1
 void Sky::interpolate()
 {
     // time since 12:00 in days
-    double skyTime = std::fmod(m_World.getEngine()->getSession().getGameClock().getTimeOfDay() + 0.5, 1.0);
+    double skyTime = std::fmod(m_World.getEngine()->getGameClock().getTimeOfDay() + 0.5, 1.0);
     m_MasterState.time = static_cast<float>(skyTime);
 
     // init with values for case: time >= TIME_KEY_7 (= 0.75f)

--- a/src/content/StaticMeshAllocator.cpp
+++ b/src/content/StaticMeshAllocator.cpp
@@ -1,7 +1,7 @@
 #include "StaticMeshAllocator.h"
 #include "VertexTypes.h"
 #include <bgfx/bgfx.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <utils/logger.h>
 #include <vdfs/fileIndex.h>
 #include <zenload/zCModelMeshLib.h>
@@ -9,7 +9,7 @@
 
 using namespace Meshes;
 
-StaticMeshAllocator::StaticMeshAllocator(Engine::BaseEngine& engine)
+StaticMeshAllocator::StaticMeshAllocator(Engine::GameEngine& engine)
     : GenericMeshAllocator(&engine.getVDFSIndex())
     , m_Engine(engine)
 {
@@ -62,7 +62,7 @@ Handle::MeshHandle StaticMeshAllocator::loadFromPackedSubmesh(const ZenLoad::Pac
     mesh.mesh.m_IndexBufferHandle.idx = bgfx::invalidHandle;
     mesh.mesh.m_VertexBufferHandle.idx = bgfx::invalidHandle;
 
-    m_Engine.executeInMainThread([this, h](Engine::BaseEngine* pEngine) {
+    m_Engine.executeInMainThread([this, h](Engine::GameEngine* pEngine) {
         finalizeLoad(h);
     });
 
@@ -140,7 +140,7 @@ Handle::MeshHandle StaticMeshAllocator::loadFromPackedTriList(const ZenLoad::Pac
     mesh.mesh.m_IndexBufferHandle.idx = bgfx::invalidHandle;
     mesh.mesh.m_VertexBufferHandle.idx = bgfx::invalidHandle;
 
-    m_Engine.executeInMainThread([this, h](Engine::BaseEngine* pEngine) {
+    m_Engine.executeInMainThread([this, h](Engine::GameEngine* pEngine) {
         bgfx::frame();  // Flush the pipeline to prevent an overflow
         finalizeLoad(h);
     });

--- a/src/content/StaticMeshAllocator.h
+++ b/src/content/StaticMeshAllocator.h
@@ -10,7 +10,7 @@
 
 namespace Engine
 {
-    class BaseEngine;
+    class GameEngine;
 }
 
 namespace Meshes
@@ -37,7 +37,7 @@ namespace Meshes
     class StaticMeshAllocator : public GenericMeshAllocator
     {
     public:
-        StaticMeshAllocator(Engine::BaseEngine& engine);
+        StaticMeshAllocator(Engine::GameEngine& engine);
         virtual ~StaticMeshAllocator();
 
         /**
@@ -88,7 +88,7 @@ namespace Meshes
         /**
          * Engine
          */
-        Engine::BaseEngine& m_Engine;
+        Engine::GameEngine& m_Engine;
 
         /**
          * Rough estimation about how much memory the loaded textures need on the GPU

--- a/src/content/Texture.cpp
+++ b/src/content/Texture.cpp
@@ -1,6 +1,6 @@
 #include "Texture.h"
 #include <bgfx/bgfx.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <utils/logger.h>
 #include <vdfs/fileIndex.h>
 #include <zenload/ztex2dds.h>
@@ -12,7 +12,7 @@ typedef unsigned char stbi_uc;
 extern "C" stbi_uc* stbi_load_from_memory(stbi_uc const* _buffer, int _len, int* _x, int* _y, int* _comp, int _req_comp);
 extern "C" void stbi_image_free(void* _ptr);
 
-TextureAllocator::TextureAllocator(Engine::BaseEngine& engine)
+TextureAllocator::TextureAllocator(Engine::GameEngine& engine)
     : m_Engine(engine)
 {
 }
@@ -161,7 +161,7 @@ Handle::TextureHandle TextureAllocator::loadTextureVDF(const VDFS::FileIndex& id
         h = loadTextureRGBA8(ztex, (uint16_t)desc.dwWidth, (uint16_t)desc.dwHeight, name);
     }
 
-    m_Engine.executeInMainThread([this, h](Engine::BaseEngine* pEngine) {
+    m_Engine.executeInMainThread([this, h](Engine::GameEngine* pEngine) {
         finalizeLoad(h);
     });
 

--- a/src/content/Texture.h
+++ b/src/content/Texture.h
@@ -8,7 +8,7 @@
 
 namespace Engine
 {
-    class BaseEngine;
+    class GameEngine;
 }
 
 namespace VDFS
@@ -34,7 +34,7 @@ namespace Textures
     class TextureAllocator
     {
     public:
-        TextureAllocator(Engine::BaseEngine& engine);
+        TextureAllocator(Engine::GameEngine& engine);
         virtual ~TextureAllocator();
 
         /**
@@ -79,7 +79,7 @@ namespace Textures
         /**
          * Engine
          */
-        Engine::BaseEngine& m_Engine;
+        Engine::GameEngine& m_Engine;
 
         /**
          * Rough estimation about how much memory the loaded textures need on the GPU in bytes

--- a/src/engine/AsyncAction.cpp
+++ b/src/engine/AsyncAction.cpp
@@ -3,11 +3,11 @@
 //
 
 #include "AsyncAction.h"
-#include "BaseEngine.h"
+#include "GameEngine.h"
 
 using namespace Engine;
 
-bool Engine::AsyncAction::run(Engine::BaseEngine& engine)
+bool Engine::AsyncAction::run(Engine::GameEngine& engine)
 {
     return m_Job(&engine);
 }

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -75,8 +75,36 @@ void BaseEngine::initEngine(int argc, char** argv)
         m_Args.playerScriptname = Flags::playerScriptname.getParam(0);
 
     m_Args.startNewGame = Flags::startNewGame.isSet();
+}
 
+void BaseEngine::onWorldCreated(Handle::WorldHandle world)
+{
+}
 
+World::WorldInstance& BaseEngine::getWorldInstance(Handle::WorldHandle& h)
+{
+    return h.get();
+}
+
+BaseEngine::EngineArgs BaseEngine::getEngineArgs()
+{
+    return m_Args;
+}
+
+bool BaseEngine::saveWorld(Handle::WorldHandle world, const std::string& file)
+{
+    json j;
+    world.get().exportWorld(j);
+
+    // Save
+    std::ofstream f(file);
+    if (!f.is_open())
+        return false;
+
+    f << Utils::iso_8859_1_to_utf8(j.dump(4));
+    f.close();
+
+    return true;
 }
 
 void BaseEngine::loadArchives()
@@ -90,18 +118,18 @@ void BaseEngine::loadArchives()
     //m_FileIndex.loadVDF("vdf/Anims_Addon.vdf");
 
     /*m_FileIndex.loadVDF("vdf/g1/anims.VDF");
-	m_FileIndex.loadVDF("vdf/g1/fonts.VDF");
-	m_FileIndex.loadVDF("vdf/g1/meshes.VDF");
-	m_FileIndex.loadVDF("vdf/g1/sound_patch2.VDF");
-	m_FileIndex.loadVDF("vdf/g1/sound.VDF");
-	m_FileIndex.loadVDF("vdf/g1/speech_patch2.VDF");
-	m_FileIndex.loadVDF("vdf/g1/speech.VDF");
-	m_FileIndex.loadVDF("vdf/g1/textures_apostroph_patch_neu.VDF");
-	m_FileIndex.loadVDF("vdf/g1/textures_choicebox_32pixel_modialpha.VDF");
-	m_FileIndex.loadVDF("vdf/g1/textures_patch.VDF");
-	m_FileIndex.loadVDF("vdf/g1/textures_Startscreen_ohne_Logo.VDF");
-	m_FileIndex.loadVDF("vdf/g1/textures.VDF");
-	m_FileIndex.loadVDF("vdf/g1/worlds.VDF");*/
+    m_FileIndex.loadVDF("vdf/g1/fonts.VDF");
+    m_FileIndex.loadVDF("vdf/g1/meshes.VDF");
+    m_FileIndex.loadVDF("vdf/g1/sound_patch2.VDF");
+    m_FileIndex.loadVDF("vdf/g1/sound.VDF");
+    m_FileIndex.loadVDF("vdf/g1/speech_patch2.VDF");
+    m_FileIndex.loadVDF("vdf/g1/speech.VDF");
+    m_FileIndex.loadVDF("vdf/g1/textures_apostroph_patch_neu.VDF");
+    m_FileIndex.loadVDF("vdf/g1/textures_choicebox_32pixel_modialpha.VDF");
+    m_FileIndex.loadVDF("vdf/g1/textures_patch.VDF");
+    m_FileIndex.loadVDF("vdf/g1/textures_Startscreen_ohne_Logo.VDF");
+    m_FileIndex.loadVDF("vdf/g1/textures.VDF");
+    m_FileIndex.loadVDF("vdf/g1/worlds.VDF");*/
 
     std::list<std::string> vdfArchives = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "vdf");
 
@@ -137,36 +165,6 @@ void BaseEngine::loadArchives()
     {
         m_FileIndex.loadVDF(m_Args.modfile, 2);
     }
-}
-
-void BaseEngine::onWorldCreated(Handle::WorldHandle world)
-{
-}
-
-World::WorldInstance& BaseEngine::getWorldInstance(Handle::WorldHandle& h)
-{
-    return h.get();
-}
-
-BaseEngine::EngineArgs BaseEngine::getEngineArgs()
-{
-    return m_Args;
-}
-
-bool BaseEngine::saveWorld(Handle::WorldHandle world, const std::string& file)
-{
-    json j;
-    world.get().exportWorld(j);
-
-    // Save
-    std::ofstream f(file);
-    if (!f.is_open())
-        return false;
-
-    f << Utils::iso_8859_1_to_utf8(j.dump(4));
-    f.close();
-
-    return true;
 }
 
 size_t ExcludeFrameTime::m_ReferenceCounter = 0;

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -1,19 +1,14 @@
 #include "BaseEngine.h"
+#include "GameSession.h"
 #include <fstream>
-#include "AsyncAction.h"
 #include "World.h"
-#include "audio/AudioEngine.h"
 #include <bx/commandline.h>
 #include <components/EntityActions.h>
 #include <components/Vob.h>
 #include <components/VobClasses.h>
 #include <logic/PlayerController.h>
 #include <render/WorldRender.h>
-#include <ui/Hud.h>
-#include <ui/LoadingScreen.h>
-#include <ui/zFont.h>
 #include <utils/bgfx_lib.h>
-#include <utils/cli.h>
 #include <utils/logger.h>
 #include <vdfs/fileIndex.h>
 #include <zenload/zCMesh.h>
@@ -22,44 +17,16 @@
 
 using namespace Engine;
 
-namespace Flags
-{
-    Cli::Flag gameDirectory("g", "game-dir", 1, "Root-folder of your Gothic installation", {"."}, "Data");
-    Cli::Flag g1Directory("", "g1-path", 1, "Game data to use when the -g1 flag is specified on the commandline", {"."}, "Data");
-    Cli::Flag g2Directory("", "g2-path", 1, "Game data to use when the -g2 flag is specified on the commandline", {"."}, "Data");
-    Cli::Flag startG1("g1", "start-g1", 0, "Uses the path stored in the 'g1-path' config setting as game data path");
-    Cli::Flag startG2("g2", "start-g2", 0, "Uses the path stored in the 'g2-path' config setting as game data path");
-
-    Cli::Flag modFile("m", "mod-file", 1, "Additional .mod-file to load", {""}, "Data");
-    Cli::Flag world("w", "world", 1, ".ZEN-file to load out of one of the vdf-archives", {""}, "Data");
-    Cli::Flag emptyWorld("", "empty-world", 0, "Will load no .ZEN-file at all.");
-    Cli::Flag playerScriptname("p", "player", 1, "When starting a new game, the player will be inserted as the given NPC", {"PC_HERO"});
-    Cli::Flag startNewGame("", "skipmenu", 0, "Skips the menu and starts a new game directly on game startup");
-    Cli::Flag sndDevice("snd", "sound-device", 1, "OpenAL sound device", {""}, "Sound");
-}
-
 BaseEngine::BaseEngine()
-    : m_MainThreadID(std::this_thread::get_id())
-    , m_RootUIView(*this)
-    , m_Console(*this)
-    , m_EngineTextureAlloc(*this)
 {
-    m_pHUD = nullptr;
-    m_pFontCache = nullptr;
-
     m_BasicGameType = Daedalus::GameType::GT_Gothic2;
     m_Paused = false;
     m_ExcludedFrameTime = 0;
     // allocate and init default session
-    resetSession();
 }
 
 BaseEngine::~BaseEngine()
 {
-    getRootUIView().removeChild(m_pHUD);
-    delete m_AudioEngine;
-    delete m_pHUD;
-    delete m_pFontCache;
 }
 
 void BaseEngine::initEngine(int argc, char** argv)
@@ -109,21 +76,7 @@ void BaseEngine::initEngine(int argc, char** argv)
 
     m_Args.startNewGame = Flags::startNewGame.isSet();
 
-    std::string snd_device;
-    if (Flags::sndDevice.isSet())
-        snd_device = Flags::sndDevice.getParam(0);
 
-    m_AudioEngine = new Audio::AudioEngine(snd_device);
-
-    // Init HUD
-    m_pFontCache = new UI::zFontCache(*this);
-    m_pHUD = new UI::Hud(*this);
-    getRootUIView().addChild(m_pHUD);
-}
-
-void BaseEngine::frameUpdate(double dt, uint16_t width, uint16_t height)
-{
-    onFrameUpdate(dt * getGameClock().getGameEngineSpeedFactor(), width, height);
 }
 
 void BaseEngine::loadArchives()
@@ -214,84 +167,6 @@ bool BaseEngine::saveWorld(Handle::WorldHandle world, const std::string& file)
     f.close();
 
     return true;
-}
-
-void BaseEngine::setPaused(bool paused)
-{
-    if (paused != m_Paused)
-    {
-        if (getMainWorld().isValid())
-        {
-            if (paused)
-                getMainWorld().get().getAudioWorld().pauseSounds();
-            else
-                getMainWorld().get().getAudioWorld().continueSounds();
-        }
-        m_Paused = paused;
-    }
-}
-
-void BaseEngine::processMessageQueue()
-{
-    m_MessageQueueMutex.lock();
-    auto current = m_MessageQueue.begin();
-    while (current != m_MessageQueue.end())
-    {
-        auto& action = *current;
-        // if the job queues a new job it would create a deadlock, so we need to release the mutex before
-        m_MessageQueueMutex.unlock();
-        bool finished = action.run(*this);
-        m_MessageQueueMutex.lock();
-        if (finished)
-            current = m_MessageQueue.erase(current);  // erase returns next iterator
-        else
-            std::advance(current, 1);
-    }
-    m_MessageQueueMutex.unlock();
-}
-
-void BaseEngine::resetSession()
-{
-    // GameSession's destructor will clean up worlds
-    m_Session = std::make_unique<GameSession>(*this);
-}
-
-GameClock& BaseEngine::getGameClock()
-{
-    return getSession().getGameClock();
-}
-
-Handle::WorldHandle BaseEngine::getMainWorld()
-{
-    return getSession().getMainWorld();
-}
-
-void BaseEngine::executeInMainThread(const AsyncAction::JobType<void>& job, bool forceQueue)
-{
-    auto wrappedJob = [job](Engine::BaseEngine* engine) -> bool {
-        job(engine);
-        return true;
-    };
-    executeInMainThreadUntilTrue(wrappedJob, forceQueue);
-}
-
-void BaseEngine::executeInMainThreadUntilTrue(const AsyncAction::JobType<bool>& job, bool forceQueue)
-{
-    if (!forceQueue && isMainThread())
-    {
-        // execute right away
-        bool success = job(this);
-        if (success)
-            return;
-        // else job returned false -> queue the job
-    }
-    std::lock_guard<std::mutex> guard(m_MessageQueueMutex);
-    m_MessageQueue.emplace_back(AsyncAction{job});
-}
-
-bool BaseEngine::isMainThread()
-{
-    return std::this_thread::get_id() == m_MainThreadID;
 }
 
 size_t ExcludeFrameTime::m_ReferenceCounter = 0;

--- a/src/engine/BaseEngine.h
+++ b/src/engine/BaseEngine.h
@@ -1,10 +1,8 @@
 #pragma once
-#include "World.h"
 #include <bx/commandline.h>
 #include <engine/World.h>
 #include <logic/SavegameManager.h>
 #include <memory/StaticReferencedAllocator.h>
-#include <ui/View.h>
 #include <vdfs/fileIndex.h>
 #include <utils/cli.h>
 
@@ -26,8 +24,6 @@ namespace Flags
 
 namespace Engine
 {
-    class GameSession;
-    class AsyncAction;
     const int MAX_NUM_WORLDS = 4;
 
     enum class ExecutionPolicy
@@ -36,6 +32,10 @@ namespace Engine
         NewThread
     };
 
+    /**
+     * @brief The BaseEngine class
+     * Covering start parameters and archive loading
+     */
     class BaseEngine
     {
     public:
@@ -94,7 +94,8 @@ namespace Engine
          * @param path New path
          */
         void setContentBasePath(const std::string& path) { m_ContentBasePath = path; }
-        /*+
+
+        /**
          * @return The path where the engine is looking for content files
          */
         const std::string& getContentBasePath() { return m_ContentBasePath; }
@@ -111,12 +112,21 @@ namespace Engine
          * increase the time, which the current frame should not treat as elapsed
          */
         void addToExludedFrameTime(int64_t milliseconds) { m_ExcludedFrameTime += milliseconds; }
+
+        /**
+         * @return The excluded frame time, which is not treated as elapsed.
+         */
         int64_t getExludedFrameTime() { return m_ExcludedFrameTime; }
+
+        /**
+         * Resets the excluded frame time.
+         */
         void resetExludedFrameTime() { m_ExcludedFrameTime = 0; }
 
         /**
          * Called when a world was added
-         * TODO onWorld... should be protected, but currently need to call this function from GameSession
+         * TODO onWorld... should be protected, but currently there is a need to call
+         * this function from GameSession.
          */
         virtual void onWorldCreated(Handle::WorldHandle world);
         virtual void onWorldRemoved(Handle::WorldHandle world){}

--- a/src/engine/BaseEngine.h
+++ b/src/engine/BaseEngine.h
@@ -1,15 +1,13 @@
 #pragma once
-#include <future>
 #include "World.h"
 #include <bx/commandline.h>
 #include <engine/GameClock.h>
-#include <engine/GameSession.h>
 #include <engine/World.h>
-#include <logic/Console.h>
 #include <logic/SavegameManager.h>
 #include <memory/StaticReferencedAllocator.h>
 #include <ui/View.h>
 #include <vdfs/fileIndex.h>
+#include <utils/cli.h>
 
 namespace UI
 {
@@ -21,6 +19,22 @@ namespace UI
 namespace Audio
 {
     class AudioEngine;
+}
+
+namespace Flags
+{
+    static Cli::Flag gameDirectory("g", "game-dir", 1, "Root-folder of your Gothic installation", {"."}, "Data");
+    static Cli::Flag g1Directory("", "g1-path", 1, "Game data to use when the -g1 flag is specified on the commandline", {"."}, "Data");
+    static Cli::Flag g2Directory("", "g2-path", 1, "Game data to use when the -g2 flag is specified on the commandline", {"."}, "Data");
+    static Cli::Flag startG1("g1", "start-g1", 0, "Uses the path stored in the 'g1-path' config setting as game data path");
+    static Cli::Flag startG2("g2", "start-g2", 0, "Uses the path stored in the 'g2-path' config setting as game data path");
+
+    static Cli::Flag modFile("m", "mod-file", 1, "Additional .mod-file to load", {""}, "Data");
+    static Cli::Flag world("w", "world", 1, ".ZEN-file to load out of one of the vdf-archives", {""}, "Data");
+    static Cli::Flag emptyWorld("", "empty-world", 0, "Will load no .ZEN-file at all.");
+    static Cli::Flag playerScriptname("p", "player", 1, "When starting a new game, the player will be inserted as the given NPC", {"PC_HERO"});
+    static Cli::Flag startNewGame("", "skipmenu", 0, "Skips the menu and starts a new game directly on game startup");
+    static Cli::Flag sndDevice("snd", "sound-device", 1, "OpenAL sound device", {""}, "Sound");
 }
 
 namespace Engine
@@ -70,10 +84,6 @@ namespace Engine
          * @return Basic gametype this is. Needed for sky configuration, for example
          */
         void setBasicGameType(Daedalus::GameType type) { m_BasicGameType = type; }
-        /**
-         * @brief Frame update // TODO: Remove width and height
-         */
-        void frameUpdate(double dt, uint16_t width, uint16_t m_height);
 
         /**
          * @return Main VDF-Archive
@@ -88,40 +98,10 @@ namespace Engine
         World::WorldInstance& getWorldInstance(Handle::WorldHandle& h);
 
         /**
-         * @return Gameclock
-         */
-        GameClock& getGameClock();
-
-        /**
-         * information stored in a session is cleared when loading a savegame or starting a new game
-         * @return GameSession
-         */
-        GameSession& getSession() { return *m_Session; }
-        /**
-         * drop all information bound to the current session
-         */
-        void resetSession();
-
-        /**
-         * @return Console
-         */
-        Logic::Console& getConsole() { return m_Console; }
-        /**
          * @return Arguments passed to the engine
          */
         EngineArgs getEngineArgs();
 
-        /**
-         * @return Base-level UI-View. Parent of all other views.
-         */
-        UI::View& getRootUIView() { return m_RootUIView; }
-        /**
-         * // TODO: Move to GameEngine, or pass GameEngine to world!
-         * @return HUD
-         */
-        UI::Hud& getHud() { return *m_pHUD; }
-        UI::zFontCache& getFontCache() { return *m_pFontCache; }
-        Audio::AudioEngine& getAudioEngine() { return *m_AudioEngine; }
         /**
          * Sets the path the engine is looking for files
          * @param path New path
@@ -131,14 +111,6 @@ namespace Engine
          * @return The path where the engine is looking for content files
          */
         const std::string& getContentBasePath() { return m_ContentBasePath; }
-        /**
-         * @return Allocator for always present textures
-         */
-        Textures::TextureAllocator& getEngineTextureAlloc() { return m_EngineTextureAlloc; }
-        /**
-         * @return data-access to the main world
-         */
-        Handle::WorldHandle getMainWorld();
 
         /**
          * Saves the given world to a file, as savegame
@@ -149,51 +121,18 @@ namespace Engine
         bool saveWorld(Handle::WorldHandle world, const std::string& file);
 
         /**
-         * Pauses or continues the game.
-         * @param paused
-         */
-        void setPaused(bool paused);
-
-        /**
-         * Pauses or continues the game. Depending on the current state
-         */
-        void togglePaused() { setPaused(!m_Paused); }
-        /**
          * increase the time, which the current frame should not treat as elapsed
          */
         void addToExludedFrameTime(int64_t milliseconds) { m_ExcludedFrameTime += milliseconds; };
         int64_t getExludedFrameTime() { return m_ExcludedFrameTime; };
         void resetExludedFrameTime() { m_ExcludedFrameTime = 0; };
-        /**
-         * @return true if the calling thread is the main thread
-         */
-        bool isMainThread();
-
-        /**
-         * Guarantees execution of the given function in the main thread
-         * @param job function to execute in the main thread
-         * @param forceQueueing if false AND if called from main thread: executes the job right away
-         * 		  instead of queueing and does not acquire the lock.
-         */
-        void executeInMainThread(const std::function<void(BaseEngine* engine)>& job, bool forceQueueing = false);
-
-        /**
-         * Execute the given job on the main thread one time per frame update until it returns true
-         */
-        void executeInMainThreadUntilTrue(const std::function<bool(BaseEngine* engine)>& job,
-                                          bool forceQueueing = false);
-
-        /**
-         * executes all jobs in the queue and removes the ones, that return true
-         */
-        void processMessageQueue();
 
         /**
          * Called when a world was added
          * TODO onWorld... should be protected, but currently need to call this function from GameSession
          */
         virtual void onWorldCreated(Handle::WorldHandle world);
-        virtual void onWorldRemoved(Handle::WorldHandle world){};
+        virtual void onWorldRemoved(Handle::WorldHandle world){}
 
     protected:
         /**
@@ -208,11 +147,6 @@ namespace Engine
         virtual void loadArchives();
 
         /**
-         * ID of the main thread (bgfx thread)
-         */
-        std::thread::id m_MainThreadID;
-
-        /**
          * Enum with values for Gothic I and Gothic II
          */
         Daedalus::GameType m_BasicGameType;
@@ -223,35 +157,9 @@ namespace Engine
         VDFS::FileIndex m_FileIndex;
 
         /**
-         * Game session, stores information that should be reset on starting a new game/loading
-         * unique_ptr is used, because we can't overwrite the session itself,
-         * because it has a member variable reference
-         */
-        std::unique_ptr<GameSession> m_Session;
-
-        /**
-         * ingame console
-         */
-        Logic::Console m_Console;
-
-        /**
          * Arguments
          */
         EngineArgs m_Args;
-
-        Audio::AudioEngine* m_AudioEngine = nullptr;
-
-        /**
-         * Base UI-View
-         */
-        UI::View m_RootUIView;
-        UI::Hud* m_pHUD;
-        UI::zFontCache* m_pFontCache;
-
-        /**
-         * Allocator for always present textures
-         */
-        Textures::TextureAllocator m_EngineTextureAlloc;
 
         /**
          * Folder where the content is
@@ -262,9 +170,6 @@ namespace Engine
          * if the engine is paused. When it is paused the world doesn't receive the delta time updates
          */
         bool m_Paused;
-
-        std::list<AsyncAction> m_MessageQueue;
-        std::mutex m_MessageQueueMutex;
 
         /**
          * amount of time for the next frame that should not be considered as elapsed

--- a/src/engine/BaseEngine.h
+++ b/src/engine/BaseEngine.h
@@ -1,25 +1,12 @@
 #pragma once
 #include "World.h"
 #include <bx/commandline.h>
-#include <engine/GameClock.h>
 #include <engine/World.h>
 #include <logic/SavegameManager.h>
 #include <memory/StaticReferencedAllocator.h>
 #include <ui/View.h>
 #include <vdfs/fileIndex.h>
 #include <utils/cli.h>
-
-namespace UI
-{
-    class Hud;
-    class zFont;
-    class zFontCache;
-}
-
-namespace Audio
-{
-    class AudioEngine;
-}
 
 namespace Flags
 {
@@ -79,7 +66,7 @@ namespace Engine
         /**
          * @return Basic gametype this is. Needed for sky configuration, for example
          */
-        Daedalus::GameType getBasicGameType() { return m_BasicGameType; };
+        Daedalus::GameType getBasicGameType() { return m_BasicGameType; }
         /**
          * @return Basic gametype this is. Needed for sky configuration, for example
          */
@@ -123,9 +110,9 @@ namespace Engine
         /**
          * increase the time, which the current frame should not treat as elapsed
          */
-        void addToExludedFrameTime(int64_t milliseconds) { m_ExcludedFrameTime += milliseconds; };
-        int64_t getExludedFrameTime() { return m_ExcludedFrameTime; };
-        void resetExludedFrameTime() { m_ExcludedFrameTime = 0; };
+        void addToExludedFrameTime(int64_t milliseconds) { m_ExcludedFrameTime += milliseconds; }
+        int64_t getExludedFrameTime() { return m_ExcludedFrameTime; }
+        void resetExludedFrameTime() { m_ExcludedFrameTime = 0; }
 
         /**
          * Called when a world was added

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -25,10 +25,10 @@ using namespace Engine;
 const float DRAW_DISTANCE = 100.0f;
 
 GameEngine::GameEngine()
-    : m_DefaultRenderSystem(*this)
+    : m_MainThreadID(std::this_thread::get_id())
+    , m_DefaultRenderSystem(*this)
     , m_RootUIView(*this)
     , m_EngineTextureAlloc(*this)
-    , m_MainThreadID(std::this_thread::get_id())
     , m_Console(*this)
 {
     m_pHUD = nullptr;

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -81,7 +81,7 @@ void GameEngine::initEngine(int argc, char** argv)
 
 void GameEngine::frameUpdate(double dt, uint16_t width, uint16_t height)
 {
-    onFrameUpdate(dt * getSession().getGameClock().getGameEngineSpeedFactor(), width, height);
+    onFrameUpdate(dt * m_GameClock.getGameEngineSpeedFactor(), width, height);
 }
 
 void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
@@ -105,7 +105,7 @@ void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
         }
         else
         {
-            getSession().getGameClock().update(dt);
+            m_GameClock.update(dt);
             for (auto& s : getSession().getWorldInstances())
             {
                 // Update main-world after every other world, since the camera is in there
@@ -230,6 +230,11 @@ void GameEngine::setPaused(bool paused)
         }
         m_Paused = paused;
     }
+}
+
+GameClock& GameEngine::getGameClock()
+{
+    return m_GameClock;
 }
 
 void GameEngine::onWorldCreated(Handle::WorldHandle world)

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -5,6 +5,7 @@
 #include "GameEngine.h"
 #include <engine/GameSession.h>
 #include <engine/AsyncAction.h>
+#include <engine/GameClock.h>
 #include <audio/AudioEngine.h>
 #include <common.h>
 #include <bx/commandline.h>

--- a/src/engine/GameEngine.cpp
+++ b/src/engine/GameEngine.cpp
@@ -3,9 +3,9 @@
 //
 
 #include "GameEngine.h"
-#include "GameSession.h"
-#include "audio/AudioEngine.h"
-#include "AsyncAction.h"
+#include <engine/GameSession.h>
+#include <engine/AsyncAction.h>
+#include <audio/AudioEngine.h>
 #include <common.h>
 #include <bx/commandline.h>
 #include <components/EntityActions.h>
@@ -81,7 +81,7 @@ void GameEngine::initEngine(int argc, char** argv)
 
 void GameEngine::frameUpdate(double dt, uint16_t width, uint16_t height)
 {
-    onFrameUpdate(dt * m_GameClock.getGameEngineSpeedFactor(), width, height);
+    onFrameUpdate(dt * getSession().getGameClock().getGameEngineSpeedFactor(), width, height);
 }
 
 void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
@@ -105,7 +105,7 @@ void GameEngine::onFrameUpdate(double dt, uint16_t width, uint16_t height)
         }
         else
         {
-            m_GameClock.update(dt);
+            getSession().getGameClock().update(dt);
             for (auto& s : getSession().getWorldInstances())
             {
                 // Update main-world after every other world, since the camera is in there
@@ -234,7 +234,7 @@ void GameEngine::setPaused(bool paused)
 
 GameClock& GameEngine::getGameClock()
 {
-    return m_GameClock;
+    return getSession().getGameClock();
 }
 
 void GameEngine::onWorldCreated(Handle::WorldHandle world)

--- a/src/engine/GameEngine.h
+++ b/src/engine/GameEngine.h
@@ -1,12 +1,13 @@
 #pragma once
-#include "BaseEngine.h"
-#include "GameSession.h"
-#include "GameClock.h"
 #include <future>
-#include "Input.h"
+#include <engine/BaseEngine.h>
+#include <engine/GameSession.h>
+#include <engine/GameClock.h>
+#include <engine/Input.h>
 #include <logic/CameraController.h>
 #include <logic/Console.h>
 #include <render/RenderSystem.h>
+#include <ui/View.h>
 
 namespace UI
 {
@@ -22,6 +23,9 @@ namespace Audio
 
 namespace Engine
 {
+    class GameSession;
+    class AsyncAction;
+
     class GameEngine : public BaseEngine
     {
     public:

--- a/src/engine/GameEngine.h
+++ b/src/engine/GameEngine.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "BaseEngine.h"
 #include "GameSession.h"
+#include "GameClock.h"
 #include <future>
 #include "Input.h"
 #include <logic/CameraController.h>
@@ -67,6 +68,11 @@ namespace Engine
          * @return GameSession
          */
         GameSession& getSession() { return *m_Session; }
+
+        /**
+         * @return Gameclock
+         */
+        GameClock& getGameClock();
 
         /**
          * drop all information bound to the current session
@@ -142,6 +148,11 @@ namespace Engine
          * because it has a member variable reference
          */
         std::unique_ptr<GameSession> m_Session;
+
+        /**
+         * Gameclock
+         */
+        GameClock m_GameClock;
 
         /**
          * Base UI-View

--- a/src/engine/GameEngine.h
+++ b/src/engine/GameEngine.h
@@ -2,7 +2,6 @@
 #include <future>
 #include <engine/BaseEngine.h>
 #include <engine/GameSession.h>
-#include <engine/GameClock.h>
 #include <engine/Input.h>
 #include <logic/CameraController.h>
 #include <logic/Console.h>
@@ -164,11 +163,6 @@ namespace Engine
          * because it has a member variable reference
          */
         std::unique_ptr<GameSession> m_Session;
-
-        /**
-         * Gameclock
-         */
-        GameClock m_GameClock;
 
         /**
          * Base UI-View

--- a/src/engine/GameEngine.h
+++ b/src/engine/GameEngine.h
@@ -147,16 +147,16 @@ namespace Engine
         void drawFrame(uint16_t width, uint16_t height);
 
         /**
+         * ID of the main thread (bgfx thread)
+         */
+        std::thread::id m_MainThreadID;
+
+        /**
          * Default rendering system
          */
         Render::RenderSystem m_DefaultRenderSystem;
 
         Audio::AudioEngine* m_AudioEngine = nullptr;
-
-        /**
-         * ingame console
-         */
-        Logic::Console m_Console;
 
         /**
          * Game session, stores information that should be reset on starting a new game/loading
@@ -171,11 +171,6 @@ namespace Engine
         UI::View m_RootUIView;
         UI::Hud* m_pHUD;
         UI::zFontCache* m_pFontCache;
-
-        /**
-         * ID of the main thread (bgfx thread)
-         */
-        std::thread::id m_MainThreadID;
         std::list<AsyncAction> m_MessageQueue;
         std::mutex m_MessageQueueMutex;
 
@@ -183,5 +178,10 @@ namespace Engine
          * Allocator for always present textures
          */
         Textures::TextureAllocator m_EngineTextureAlloc;
+
+        /**
+         * ingame console
+         */
+        Logic::Console m_Console;
     };
 }

--- a/src/engine/GameEngine.h
+++ b/src/engine/GameEngine.h
@@ -1,7 +1,10 @@
 #pragma once
 #include "BaseEngine.h"
+#include "GameSession.h"
+#include <future>
 #include "Input.h"
 #include <logic/CameraController.h>
+#include <logic/Console.h>
 #include <render/RenderSystem.h>
 
 namespace Engine
@@ -25,12 +28,91 @@ namespace Engine
             return m_DefaultRenderSystem;
         }
 
-    protected:
+        /**
+         * executes all jobs in the queue and removes the ones, that return true
+         */
+        void processMessageQueue();
+
+        /**
+         * Guarantees execution of the given function in the main thread
+         * @param job function to execute in the main thread
+         * @param forceQueueing if false AND if called from main thread: executes the job right away
+         * 		  instead of queueing and does not acquire the lock.
+         */
+        void executeInMainThread(const std::function<void(GameEngine* engine)>& job, bool forceQueueing = false);
+
+        /**
+         * Execute the given job on the main thread one time per frame update until it returns true
+         */
+        void executeInMainThreadUntilTrue(const std::function<bool(GameEngine* engine)>& job,
+                                          bool forceQueueing = false);
+
+        /**
+         * @return Console
+         */
+        Logic::Console& getConsole() { return m_Console; }
+
+        /**
+         * @return Base-level UI-View. Parent of all other views.
+         */
+        UI::View& getRootUIView() { return m_RootUIView; }
+
+        /**
+         * @return Allocator for always present textures
+         */
+        Textures::TextureAllocator& getEngineTextureAlloc() { return m_EngineTextureAlloc; }
+
+        /**
+         * information stored in a session is cleared when loading a savegame or starting a new game
+         * @return GameSession
+         */
+        GameSession& getSession() { return *m_Session; }
+
+        /**
+         * drop all information bound to the current session
+         */
+        void resetSession();
+
+        /**
+         * Pauses or continues the game.
+         * @param paused
+         */
+        void setPaused(bool paused);
+
+        /**
+         * Pauses or continues the game. Depending on the current state
+         */
+        void togglePaused() { setPaused(!m_Paused); }
+
+        /**
+         * @return data-access to the main world
+         */
+        Handle::WorldHandle getMainWorld();
+
+        /**
+         * @return HUD
+         */
+        UI::Hud& getHud() { return *m_pHUD; }
+        UI::zFontCache& getFontCache() { return *m_pFontCache; }
+        Audio::AudioEngine& getAudioEngine() { return *m_AudioEngine; }
+
+        /**
+         * @return true if the calling thread is the main thread
+         */
+        bool isMainThread();
+
+        /**
+         * @brief Frame update // TODO: Remove width and height
+         */
+        void frameUpdate(double dt, uint16_t width, uint16_t m_height);
+
         /**
          * Called when a world was added
          */
         virtual void onWorldCreated(Handle::WorldHandle world) override;
         virtual void onWorldRemoved(Handle::WorldHandle world) override;
+
+    protected:
 
         /**
          * Update-method for subclasses
@@ -46,5 +128,38 @@ namespace Engine
          * Default rendering system
          */
         Render::RenderSystem m_DefaultRenderSystem;
+
+        Audio::AudioEngine* m_AudioEngine = nullptr;
+
+        /**
+         * ingame console
+         */
+        Logic::Console m_Console;
+
+        /**
+         * Game session, stores information that should be reset on starting a new game/loading
+         * unique_ptr is used, because we can't overwrite the session itself,
+         * because it has a member variable reference
+         */
+        std::unique_ptr<GameSession> m_Session;
+
+        /**
+         * Base UI-View
+         */
+        UI::View m_RootUIView;
+        UI::Hud* m_pHUD;
+        UI::zFontCache* m_pFontCache;
+
+        /**
+         * ID of the main thread (bgfx thread)
+         */
+        std::thread::id m_MainThreadID;
+        std::list<AsyncAction> m_MessageQueue;
+        std::mutex m_MessageQueueMutex;
+
+        /**
+         * Allocator for always present textures
+         */
+        Textures::TextureAllocator m_EngineTextureAlloc;
     };
 }

--- a/src/engine/GameEngine.h
+++ b/src/engine/GameEngine.h
@@ -8,6 +8,18 @@
 #include <logic/Console.h>
 #include <render/RenderSystem.h>
 
+namespace UI
+{
+    class Hud;
+    class zFont;
+    class zFontCache;
+}
+
+namespace Audio
+{
+    class AudioEngine;
+}
+
 namespace Engine
 {
     class GameEngine : public BaseEngine

--- a/src/engine/GameEngine.h
+++ b/src/engine/GameEngine.h
@@ -23,6 +23,7 @@ namespace Audio
 namespace Engine
 {
     class GameSession;
+    class GameClock;
     class AsyncAction;
 
     class GameEngine : public BaseEngine

--- a/src/engine/GameSession.cpp
+++ b/src/engine/GameSession.cpp
@@ -51,11 +51,6 @@ nlohmann::json GameSession::retrieveInactiveWorld(const std::string& worldName)
         return nlohmann::json();
 }
 
-GameClock& GameSession::getGameClock()
-{
-    return m_GameClock;
-}
-
 void GameSession::removeAllWorlds()
 {
     while (!m_WorldInstances.empty())

--- a/src/engine/GameSession.cpp
+++ b/src/engine/GameSession.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "GameSession.h"
+#include "GameEngine.h"
 #include <fstream>
 #include "AsyncAction.h"
 #include "ui/Hud.h"
@@ -12,7 +13,7 @@
 
 using namespace Engine;
 
-GameSession::GameSession(BaseEngine& engine)
+GameSession::GameSession(GameEngine& engine)
     : m_Engine(engine)
 {
     m_CurrentSlotIndex = -1;
@@ -137,7 +138,7 @@ void GameSession::removeWorld(Handle::WorldHandle world)
 
 void GameSession::switchToWorld(const std::string& worldFile)
 {
-    auto switchToWorld_ = [worldFile](BaseEngine* engine) {
+    auto switchToWorld_ = [worldFile](GameEngine* engine) {
 
         json newWorldJson;
         json exportedPlayer;
@@ -146,7 +147,7 @@ void GameSession::switchToWorld(const std::string& worldFile)
         /**
          * prolog
          */
-        auto exportData = [&](BaseEngine* engine) {
+        auto exportData = [&](GameEngine* engine) {
             auto strippedWorldName = Utils::uppered(Utils::stripExtension(worldFile));
             engine->getHud().getLoadingScreen().reset("LOADING_" + strippedWorldName + ".TGA");
             engine->getHud().getLoadingScreen().setHidden(false);
@@ -185,7 +186,7 @@ void GameSession::switchToWorld(const std::string& worldFile)
         /**
          * epilog
          */
-        auto registerWorld_ = [ w = std::move(pNewWorld), exportedPlayer ](BaseEngine * engine) mutable
+        auto registerWorld_ = [ w = std::move(pNewWorld), exportedPlayer ](GameEngine * engine) mutable
         {
             Handle::WorldHandle newWorld = engine->getSession().registerWorld(std::move(w));
             engine->getSession().setMainWorld(newWorld);
@@ -229,9 +230,9 @@ Handle::WorldHandle GameSession::addWorld(const std::string& worldFile,
 
 void GameSession::startNewGame(const std::string& worldFile)
 {
-    Engine::AsyncAction::JobType<void> addWorld = [worldFile](Engine::BaseEngine* engine) {
+    Engine::AsyncAction::JobType<void> addWorld = [worldFile](Engine::GameEngine* engine) {
 
-        auto prolog = [](Engine::BaseEngine* engine) {
+        auto prolog = [](Engine::GameEngine* engine) {
             engine->getHud().getLoadingScreen().reset();
             engine->getHud().getLoadingScreen().setHidden(false);
             engine->resetSession();
@@ -240,7 +241,7 @@ void GameSession::startNewGame(const std::string& worldFile)
 
         std::unique_ptr<World::WorldInstance> uniqueWorld = engine->getSession().createWorld(worldFile);
 
-        auto registerWorld = [w = std::move(uniqueWorld)](Engine::BaseEngine * engine) mutable
+        auto registerWorld = [w = std::move(uniqueWorld)](Engine::GameEngine * engine) mutable
         {
             Handle::WorldHandle worldHandle = engine->getSession().registerWorld(std::move(w));
             if (worldHandle.isValid())

--- a/src/engine/GameSession.h
+++ b/src/engine/GameSession.h
@@ -5,8 +5,8 @@
 #include <list>
 #include <map>
 #include <memory>
-#include "BaseEngine.h"
 #include "GameClock.h"
+#include "GameEngine.h"
 #include "World.h"
 #include <handle/HandleDef.h>
 #include <json/json.hpp>
@@ -16,7 +16,7 @@ namespace Engine
     class GameSession
     {
     public:
-        GameSession(BaseEngine& engine);
+        GameSession(GameEngine& engine);
 
         /**
          * Cleans current session
@@ -157,8 +157,8 @@ namespace Engine
         std::vector<Handle::WorldHandle> m_Worlds;
 
         /**
-         * reference to base engine
+         * reference to game engine
          */
-        BaseEngine& m_Engine;
+        GameEngine& m_Engine;
     };
 }

--- a/src/engine/GameSession.h
+++ b/src/engine/GameSession.h
@@ -5,8 +5,9 @@
 #include <list>
 #include <map>
 #include <memory>
-#include "GameEngine.h"
-#include "World.h"
+#include <engine/GameClock.h>
+#include <engine/GameEngine.h>
+#include <engine/World.h>
 #include <handle/HandleDef.h>
 #include <logic/LogManager.h>
 #include <json/json.hpp>
@@ -59,6 +60,11 @@ namespace Engine
         {
             return m_MainWorld;
         }
+
+        /**
+         * @return GameClock
+         */
+        GameClock& getGameClock() { return m_GameClock; }
 
         /**
          * @return const reference to the list of unqiue pointers to loaded worlds
@@ -162,5 +168,10 @@ namespace Engine
          * reference to game engine
          */
         GameEngine& m_Engine;
+
+        /**
+         * Gameclock
+         */
+        GameClock m_GameClock;
     };
 }

--- a/src/engine/GameSession.h
+++ b/src/engine/GameSession.h
@@ -5,7 +5,6 @@
 #include <list>
 #include <map>
 #include <memory>
-#include "GameClock.h"
 #include "GameEngine.h"
 #include "World.h"
 #include <handle/HandleDef.h>
@@ -46,11 +45,6 @@ namespace Engine
          * @return whether a world is currently unloaded to memory as json object
          */
         bool hasInactiveWorld(const std::string& worldName);
-
-        /**
-         * @return Gameclock
-         */
-        GameClock& getGameClock();
 
         void setCurrentSlot(int index) { m_CurrentSlotIndex = index; }
         int getCurrentSlot() { return m_CurrentSlotIndex; }
@@ -130,11 +124,6 @@ namespace Engine
          * last savegame slot used in this session (save or load). Is -1 if "new game" was started
          */
         int m_CurrentSlotIndex;
-
-        /**
-         * Gameclock
-         */
-        GameClock m_GameClock;
 
         /**
          * known infoInstances by npcInstances

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -664,7 +664,7 @@ void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, co
     m_ScriptEngine.onFrameEnd();
 
     // Update hud
-    m_pEngine->getHud().setDateTimeDisplay(m_pEngine->getSession().getGameClock().getDateTimeFormatted());
+    m_pEngine->getHud().setDateTimeDisplay(m_pEngine->getGameClock().getDateTimeFormatted());
 
     m_BspTree.debugDraw();
 }
@@ -738,7 +738,7 @@ WorldInstance::getFreepointsInRange(const Math::float3& center, float distance, 
             Components::SpotComponent& sp = getEntity<Components::SpotComponent>(fp);
             Components::PositionComponent& pos = getEntity<Components::PositionComponent>(fp);
 
-            if ((!sp.m_UsingEntity.isValid() || sp.m_UseEndTime < getEngine()->getSession().getGameClock().getTime()) && (!inst.isValid() || sp.m_UsingEntity != inst))
+            if ((!sp.m_UsingEntity.isValid() || sp.m_UseEndTime < getEngine()->getGameClock().getTime()) && (!inst.isValid() || sp.m_UsingEntity != inst))
             {
                 float fpd2 = (center - pos.m_WorldMatrix.Translation()).lengthSquared();
                 if (fpd2 < distance2)

--- a/src/engine/World.cpp
+++ b/src/engine/World.cpp
@@ -12,7 +12,7 @@
 #include <debugdraw/debugdraw.h>
 #include <engine/BaseEngine.h>
 #include <engine/GameEngine.h>
-#include <engine/GameEngine.h>
+#include <engine/GameSession.h>
 #include <engine/World.h>
 #include <entry/input.h>
 #include <handle/HandleDef.h>
@@ -42,7 +42,7 @@ const LoadSection LOAD_SECTION_COLLISION = {40, 60, "Generating world collision"
 const LoadSection LOAD_SECTION_VOBS = {60, 80, "Loading objects"};
 const LoadSection LOAD_SECTION_RUNSCRIPTS = {80, 100, "Running startup scripts"};
 
-WorldInstance::WorldInstance(Engine::BaseEngine& engine)
+WorldInstance::WorldInstance(Engine::GameEngine& engine)
     : m_pEngine(&engine)
     , m_WorldMesh(*this)
     , m_ScriptEngine(*this)
@@ -82,7 +82,7 @@ bool WorldInstance::init(const std::string& zen,
                          const json& dialogManager)
 {
     m_ZenFile = zen;
-    Engine::BaseEngine& engine = *m_pEngine;
+    Engine::GameEngine& engine = *m_pEngine;
 
     if (!m_AnimationLibrary.loadAnimations())
         LogError() << "failed to load animations!";
@@ -664,7 +664,7 @@ void WorldInstance::onFrameUpdate(double deltaTime, float updateRangeSquared, co
     m_ScriptEngine.onFrameEnd();
 
     // Update hud
-    m_pEngine->getHud().setDateTimeDisplay(m_pEngine->getGameClock().getDateTimeFormatted());
+    m_pEngine->getHud().setDateTimeDisplay(m_pEngine->getSession().getGameClock().getDateTimeFormatted());
 
     m_BspTree.debugDraw();
 }
@@ -738,7 +738,7 @@ WorldInstance::getFreepointsInRange(const Math::float3& center, float distance, 
             Components::SpotComponent& sp = getEntity<Components::SpotComponent>(fp);
             Components::PositionComponent& pos = getEntity<Components::PositionComponent>(fp);
 
-            if ((!sp.m_UsingEntity.isValid() || sp.m_UseEndTime < getEngine()->getGameClock().getTime()) && (!inst.isValid() || sp.m_UsingEntity != inst))
+            if ((!sp.m_UsingEntity.isValid() || sp.m_UseEndTime < getEngine()->getSession().getGameClock().getTime()) && (!inst.isValid() || sp.m_UsingEntity != inst))
             {
                 float fpd2 = (center - pos.m_WorldMatrix.Translation()).lengthSquared();
                 if (fpd2 < distance2)

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -33,14 +33,14 @@ namespace ZenLoad
 
 namespace Engine
 {
-    class BaseEngine;
+    class GameEngine;
 }
 
 namespace World
 {
     struct WorldAllocators
     {
-        WorldAllocators(Engine::BaseEngine& engine)
+        WorldAllocators(Engine::GameEngine& engine)
             : m_LevelTextureAllocator(engine)
             , m_LevelSkeletalMeshAllocator(engine)
             , m_LevelStaticMeshAllocator(engine)
@@ -82,7 +82,7 @@ namespace World
     class WorldInstance : public Handle::HandleTypeDescriptor<Handle::WorldHandle>
     {
     public:
-        WorldInstance(Engine::BaseEngine& engine);
+        WorldInstance(Engine::GameEngine& engine);
         ~WorldInstance();
 
         /**
@@ -235,7 +235,7 @@ namespace World
         {
             return Handle::WorldHandle(this);
         }
-        Engine::BaseEngine* getEngine()
+        Engine::GameEngine* getEngine()
         {
             return m_pEngine;
         }
@@ -391,7 +391,7 @@ namespace World
         /**
          * Engine-instance
          */
-        Engine::BaseEngine* m_pEngine;
+        Engine::GameEngine* m_pEngine;
 
         /**
          * Scripting-Engine of this world

--- a/src/logic/Console.cpp
+++ b/src/logic/Console.cpp
@@ -1,7 +1,7 @@
 #include "Console.h"
 #include <GLFW/glfw3.h>
 #include <ZenLib/utils/split.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <ui/Hud.h>
 #include <utils/Utils.h>
 #include <utils/logger.h>
@@ -9,8 +9,8 @@
 
 using Logic::Console;
 
-Console::Console(Engine::BaseEngine& e)
-    : m_BaseEngine(e)
+Console::Console(Engine::GameEngine& e)
+    : m_GameEngine(e)
 {
     m_HistoryIndex = 0;
     m_Open = false;
@@ -23,7 +23,7 @@ Console::~Console()
 
 void Console::onKeyDown(int glfwKey, int mods)
 {
-    auto& consoleBox = m_BaseEngine.getHud().getConsoleBox();
+    auto& consoleBox = m_GameEngine.getHud().getConsoleBox();
     if (glfwKey == GLFW_KEY_PAGE_DOWN)
     {
         consoleBox.increaseSelectionIndex(1);
@@ -192,7 +192,7 @@ void Console::outputAdd(const std::string& msg)
 
 std::list<Logic::Console::Command>::iterator Console::determineCommand(const std::vector<std::string>& tokens)
 {
-    bool worldAvailable = m_BaseEngine.getMainWorld().isValid();
+    bool worldAvailable = m_GameEngine.getMainWorld().isValid();
     std::vector<std::size_t> numMatchingTokens(m_Commands.size(), 0);
     size_t commandIndex = 0;
     for (auto it = m_Commands.begin(); it != m_Commands.end(); ++it, ++commandIndex)
@@ -235,7 +235,7 @@ void Console::generateSuggestions(const std::string& input, bool limitToFixed)
     vector<bool> commandIsAlive;
     for (const auto& command : m_Commands)
     {
-        bool disabled = command.requiresWorld && !m_BaseEngine.getMainWorld().isValid();
+        bool disabled = command.requiresWorld && !m_GameEngine.getMainWorld().isValid();
         commandIsAlive.push_back(!disabled);
     }
 
@@ -292,7 +292,7 @@ void Console::generateSuggestions(const std::string& input, bool limitToFixed)
 
 void Console::invalidateSuggestions()
 {
-    m_BaseEngine.getHud().getConsoleBox().setSelectionIndex(-1);
+    m_GameEngine.getHud().getConsoleBox().setSelectionIndex(-1);
     m_SuggestionsList.clear();
 }
 
@@ -313,7 +313,7 @@ void Console::replaceSelectedToken()
         return;
     // default for now: only auto complete last token
     const auto& suggestions = m_SuggestionsList.back();
-    auto selectedSuggestion = suggestions.at(m_BaseEngine.getHud().getConsoleBox().getSelectionIndex());
+    auto selectedSuggestion = suggestions.at(m_GameEngine.getHud().getConsoleBox().getSelectionIndex());
     std::vector<std::string> tokens = tokenized(m_TypedLine);
     tokens.back() = selectedSuggestion->aliasList.at(0);
     std::string newLine = Utils::join(tokens.begin(), tokens.end(), " ");

--- a/src/logic/Console.h
+++ b/src/logic/Console.h
@@ -83,7 +83,7 @@ namespace Logic
             }
         };
 
-        Console(Engine::BaseEngine& e);
+        Console(Engine::GameEngine& e);
 
         ~Console();
 
@@ -206,6 +206,6 @@ namespace Logic
          */
         bool m_Open;
 
-        Engine::BaseEngine& m_BaseEngine;
+        Engine::GameEngine& m_GameEngine;
     };
 }

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -5,7 +5,7 @@
 #include "DialogManager.h"
 #include <components/VobClasses.h>
 #include <engine/AsyncAction.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <engine/World.h>
 #include <logic/PlayerController.h>
 #include <logic/visuals/ModelVisual.h>
@@ -348,7 +348,7 @@ bool DialogManager::init()
                                                                             m_World.getEngine()->getSession().getKnownInfoMap());
 
     LogInfo() << "Adding dialog-UI to root view";
-    auto createSubtitleBox = [this](Engine::BaseEngine* engine) {
+    auto createSubtitleBox = [this](Engine::GameEngine* engine) {
         // Add subtitle box (Hidden if there is nothing to display)
         m_ActiveSubtitleBox = new UI::SubtitleBox(*engine);
         engine->getRootUIView().addChild(m_ActiveSubtitleBox);

--- a/src/logic/MobController.cpp
+++ b/src/logic/MobController.cpp
@@ -7,7 +7,7 @@
 #include <components/Vob.h>
 #include <components/VobClasses.h>
 #include <debugdraw/debugdraw.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <logic/mobs/Bed.h>
 #include <logic/mobs/Container.h>
 #include <logic/mobs/Ladder.h>

--- a/src/logic/NpcAnimationHandler.cpp
+++ b/src/logic/NpcAnimationHandler.cpp
@@ -1,7 +1,7 @@
 #include "NpcAnimationHandler.h"
 #include <ZenLib/utils/logger.h>
 #include <components/Entities.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <engine/World.h>
 #include <logic/PlayerController.h>
 #include <logic/visuals/ModelVisual.h>

--- a/src/logic/NpcScriptState.cpp
+++ b/src/logic/NpcScriptState.cpp
@@ -3,7 +3,7 @@
 #include <ZenLib/utils/logger.h>
 #include <components/Vob.h>
 #include <components/VobClasses.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <logic/visuals/ModelVisual.h>
 
 using namespace Logic;

--- a/src/logic/PfxManager.cpp
+++ b/src/logic/PfxManager.cpp
@@ -6,7 +6,7 @@
 #include <map>
 #include <ZenLib/utils/logger.h>
 #include <daedalus/DaedalusVM.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <engine/World.h>
 #include <utils/Utils.h>
 

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -13,7 +13,7 @@
 #include <components/Vob.h>
 #include <components/VobClasses.h>
 #include <debugdraw/debugdraw.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <engine/Input.h>
 #include <engine/Waynet.h>
 #include <engine/World.h>
@@ -1971,7 +1971,7 @@ void PlayerController::setupKeyBindings()
         if (triggered)
         {
             bool forceQueue = true; // better do saving at frame end and not between entity updates
-            m_World.getEngine()->executeInMainThread([](Engine::BaseEngine* engine){
+            m_World.getEngine()->executeInMainThread([](Engine::GameEngine* engine){
                 Engine::SavegameManager::saveToSlot(0, "");
             }, forceQueue);
         }

--- a/src/logic/SavegameManager.cpp
+++ b/src/logic/SavegameManager.cpp
@@ -227,8 +227,8 @@ std::string Engine::SavegameManager::loadSaveGameSlot(int index)
         return "Target world-file invalid: " + buildWorldPath(index, info.world);
     }
     auto timePlayed = info.timePlayed;
-    auto loadSave = [worldFileData, index, timePlayed](BaseEngine* engine) {
-        auto resetSession = [](BaseEngine* engine) {
+    auto loadSave = [worldFileData, index, timePlayed](GameEngine* engine) {
+        auto resetSession = [](GameEngine* engine) {
             gameEngine->resetSession();
             gameEngine->getHud().getLoadingScreen().reset();
             gameEngine->getHud().getLoadingScreen().setHidden(false);
@@ -243,7 +243,7 @@ std::string Engine::SavegameManager::loadSaveGameSlot(int index)
         gameEngine->getGameClock().setTotalSeconds(timePlayed);
         std::unique_ptr<World::WorldInstance> pWorld = gameEngine->getSession().createWorld("", worldJson, scriptEngine, dialogManager);
 
-        auto registerWorld = [ index, w = std::move(pWorld) ](BaseEngine * engine) mutable
+        auto registerWorld = [ index, w = std::move(pWorld) ](GameEngine * engine) mutable
         {
             Handle::WorldHandle worldHandle = gameEngine->getSession().registerWorld(std::move(w));
             if (worldHandle.isValid())

--- a/src/logic/SoundController.cpp
+++ b/src/logic/SoundController.cpp
@@ -4,7 +4,7 @@
 
 #include "SoundController.h"
 #include <ZenLib/zenload/zTypes.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <engine/World.h>
 
 using namespace Logic;

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -15,7 +15,7 @@
 
 void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& world, Daedalus::DaedalusVM* vm, bool verbose)
 {
-    Engine::BaseEngine* engine = world.getEngine();
+    Engine::GameEngine* engine = world.getEngine();
     World::WorldInstance* pWorld = &world;
     using Daedalus::GameState::NpcHandle;
     using Daedalus::GameState::ItemHandle;

--- a/src/ui/BarView.cpp
+++ b/src/ui/BarView.cpp
@@ -5,12 +5,12 @@
 #include "BarView.h"
 #include "ImageView.h"
 #include <content/Texture.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <imgui/imgui.h>
 
 extern bgfx::ProgramHandle imguiGetImageProgram(uint8_t _mip);
 
-UI::BarView::BarView(Engine::BaseEngine& e)
+UI::BarView::BarView(Engine::GameEngine& e)
     : View(e)
 {
     m_Value = 1.0f;

--- a/src/ui/BarView.h
+++ b/src/ui/BarView.h
@@ -12,7 +12,7 @@ namespace UI
     class BarView : public View
     {
     public:
-        BarView(Engine::BaseEngine& e);
+        BarView(Engine::GameEngine& e);
         ~BarView();
 
         /**

--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -1,12 +1,12 @@
 #include "ConsoleBox.h"
 #include "zFont.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <imgui/imgui.h>
 #include <logic/Console.h>
 #include <render/RenderSystem.h>
 #include <utils/logger.h>
 
-UI::ConsoleBox::ConsoleBox(Engine::BaseEngine& e)
+UI::ConsoleBox::ConsoleBox(Engine::GameEngine& e)
     : View(e)
 {
     m_BackgroundTexture = e.getEngineTextureAlloc().loadTextureVDF("CONSOLE.TGA");

--- a/src/ui/ConsoleBox.h
+++ b/src/ui/ConsoleBox.h
@@ -9,7 +9,7 @@ namespace UI
     class ConsoleBox : public View
     {
     public:
-        ConsoleBox(Engine::BaseEngine& e);
+        ConsoleBox(Engine::GameEngine& e);
         ~ConsoleBox();
 
         /**

--- a/src/ui/DialogBox.cpp
+++ b/src/ui/DialogBox.cpp
@@ -4,14 +4,14 @@
 
 #include "DialogBox.h"
 #include "zFont.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <imgui/imgui.h>
 #include <render/RenderSystem.h>
 #include <utils/logger.h>
 
 using namespace UI;
 
-DialogBox::DialogBox(Engine::BaseEngine& e)
+DialogBox::DialogBox(Engine::GameEngine& e)
     : View(e)
 {
     m_ScrollArea = 0;

--- a/src/ui/DialogBox.h
+++ b/src/ui/DialogBox.h
@@ -14,7 +14,7 @@ namespace UI
     class DialogBox : public View
     {
     public:
-        DialogBox(Engine::BaseEngine& e);
+        DialogBox(Engine::GameEngine& e);
 
         ~DialogBox();
 

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -15,11 +15,11 @@
 #include "TextView.h"
 #include "TextView.h"
 #include <components/VobClasses.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <logic/PlayerController.h>
 #include <utils/logger.h>
 
-UI::Hud::Hud(Engine::BaseEngine& e)
+UI::Hud::Hud(Engine::GameEngine& e)
     : View(e)
 {
     Textures::TextureAllocator& alloc = m_Engine.getEngineTextureAlloc();

--- a/src/ui/Hud.h
+++ b/src/ui/Hud.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Menu.h"
 #include "View.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <logic/Console.h>
 
 // HACK: Work around windows.h messing this up with its define
@@ -11,7 +11,7 @@
 
 namespace Engine
 {
-    class BaseEngine;
+    class GameEngine;
 }
 
 namespace UI
@@ -30,7 +30,7 @@ namespace UI
     class Hud : public View
     {
     public:
-        Hud(Engine::BaseEngine& e);
+        Hud(Engine::GameEngine& e);
         ~Hud();
 
         /**

--- a/src/ui/ImageView.cpp
+++ b/src/ui/ImageView.cpp
@@ -4,12 +4,12 @@
 
 #include "ImageView.h"
 #include <content/Texture.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <render/RenderSystem.h>
 
 extern bgfx::ProgramHandle imguiGetImageProgram(uint8_t _mip);
 
-UI::ImageView::ImageView(Engine::BaseEngine& e)
+UI::ImageView::ImageView(Engine::GameEngine& e)
     : View(e)
 {
     m_RelativeSize = true;

--- a/src/ui/ImageView.h
+++ b/src/ui/ImageView.h
@@ -7,7 +7,7 @@ namespace UI
     class ImageView : public View
     {
     public:
-        ImageView(Engine::BaseEngine& e);
+        ImageView(Engine::GameEngine& e);
         ~ImageView();
 
         /**

--- a/src/ui/LoadingScreen.cpp
+++ b/src/ui/LoadingScreen.cpp
@@ -5,7 +5,7 @@
 #include "LoadingScreen.h"
 #include "BarView.h"
 #include "TextView.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <render/RenderSystem.h>
 
 /**
@@ -21,7 +21,7 @@ const Math::float2 BAR_SIZE_G1 = {1.5f, 0.6f};
 const Math::float2 BAR_POSITION_G2 = {0.85f, 0.15f};
 const Math::float2 BAR_SIZE_G2 = {0.7f, 0.6f};
 
-UI::LoadingScreen::LoadingScreen(Engine::BaseEngine& e)
+UI::LoadingScreen::LoadingScreen(Engine::GameEngine& e)
     : ImageView(e)
 {
     Textures::TextureAllocator& alloc = m_Engine.getEngineTextureAlloc();

--- a/src/ui/LoadingScreen.h
+++ b/src/ui/LoadingScreen.h
@@ -13,7 +13,7 @@ namespace UI
     class LoadingScreen : public ImageView
     {
     public:
-        LoadingScreen(Engine::BaseEngine& e);
+        LoadingScreen(Engine::GameEngine& e);
         ~LoadingScreen();
 
         /**

--- a/src/ui/Menu.cpp
+++ b/src/ui/Menu.cpp
@@ -9,11 +9,11 @@
 #include "TextView.h"
 #include <ZenLib/utils/logger.h>
 #include <daedalus/DaedalusVM.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <render/RenderSystem.h>
 #include <utils/Utils.h>
 
-UI::Menu::Menu(Engine::BaseEngine& e)
+UI::Menu::Menu(Engine::GameEngine& e)
     : View(e)
     , m_pVM(nullptr)
 {

--- a/src/ui/Menu.h
+++ b/src/ui/Menu.h
@@ -21,7 +21,7 @@ namespace UI
     class Menu : public View
     {
     public:
-        Menu(Engine::BaseEngine& e);
+        Menu(Engine::GameEngine& e);
         ~Menu();
 
         /**

--- a/src/ui/MenuItem.cpp
+++ b/src/ui/MenuItem.cpp
@@ -6,12 +6,12 @@
 #include "ImageView.h"
 #include "Menu.h"
 #include "zFont.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <utils/logger.h>
 
 using namespace UI;
 
-MenuItem::MenuItem(Engine::BaseEngine& e, Menu& baseMenu, Daedalus::GameState::MenuItemHandle scriptHandle)
+MenuItem::MenuItem(Engine::GameEngine& e, Menu& baseMenu, Daedalus::GameState::MenuItemHandle scriptHandle)
     : View(e)
     , m_ScriptHandle(scriptHandle)
     , m_BaseMenu(baseMenu)
@@ -89,7 +89,7 @@ void MenuItem::setTextLine(const std::string& text, unsigned int line)
  *
  */
 
-MenuItemTypes::MenuItemText::MenuItemText(Engine::BaseEngine& e, UI::Menu& baseMenu,
+MenuItemTypes::MenuItemText::MenuItemText(Engine::GameEngine& e, UI::Menu& baseMenu,
                                           const Daedalus::GameState::MenuItemHandle& scriptHandle)
     : MenuItem(e, baseMenu, scriptHandle)
 {

--- a/src/ui/MenuItem.h
+++ b/src/ui/MenuItem.h
@@ -14,7 +14,7 @@ namespace UI
     class MenuItem : public View
     {
     public:
-        MenuItem(Engine::BaseEngine& e, Menu& baseMenu, Daedalus::GameState::MenuItemHandle scriptHandle);
+        MenuItem(Engine::GameEngine& e, Menu& baseMenu, Daedalus::GameState::MenuItemHandle scriptHandle);
         ~MenuItem();
 
         void setTextLine(const std::string& text, unsigned int line = 0);
@@ -74,7 +74,7 @@ namespace UI
         class MenuItemText : public MenuItem
         {
         public:
-            MenuItemText(Engine::BaseEngine& e, Menu& baseMenu, const Daedalus::GameState::MenuItemHandle& scriptHandle);
+            MenuItemText(Engine::GameEngine& e, Menu& baseMenu, const Daedalus::GameState::MenuItemHandle& scriptHandle);
 
             /**
              * Updates/draws the UI-Views

--- a/src/ui/MenuItemListbox.cpp
+++ b/src/ui/MenuItemListbox.cpp
@@ -6,13 +6,13 @@
 #include "Menu.h"
 #include "MenuItem.h"
 #include "zFont.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <utils/logger.h>
 
 using namespace UI;
 using namespace MenuItemTypes;
 
-MenuItemTypes::MenuItemListbox::MenuItemListbox(Engine::BaseEngine& e, UI::Menu& baseMenu,
+MenuItemTypes::MenuItemListbox::MenuItemListbox(Engine::GameEngine& e, UI::Menu& baseMenu,
                                                 const Daedalus::GameState::MenuItemHandle& scriptHandle)
     : MenuItem(e, baseMenu, scriptHandle)
 {

--- a/src/ui/MenuItemListbox.h
+++ b/src/ui/MenuItemListbox.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <ui/MenuItemListboxEntry.h>
 
 namespace UI
@@ -16,7 +16,7 @@ namespace UI
         class MenuItemListbox : public MenuItem
         {
         public:
-            MenuItemListbox(Engine::BaseEngine& e, Menu& baseMenu, const Daedalus::GameState::MenuItemHandle& scriptHandle);
+            MenuItemListbox(Engine::GameEngine& e, Menu& baseMenu, const Daedalus::GameState::MenuItemHandle& scriptHandle);
 
             /**
              * Updates/draws the UI-Views

--- a/src/ui/MenuItemListboxEntry.cpp
+++ b/src/ui/MenuItemListboxEntry.cpp
@@ -6,13 +6,13 @@
 #include "Menu.h"
 #include "MenuItem.h"
 #include "zFont.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <utils/logger.h>
 
 using namespace UI;
 using namespace MenuItemTypes;
 
-MenuItemTypes::MenuItemListboxEntry::MenuItemListboxEntry(Engine::BaseEngine& e, UI::Menu& baseMenu,
+MenuItemTypes::MenuItemListboxEntry::MenuItemListboxEntry(Engine::GameEngine& e, UI::Menu& baseMenu,
                                                           const Daedalus::GameState::MenuItemHandle& scriptHandle,
                                                           const std::string& topic_name,
                                                           const Daedalus::GameState::LogTopic& topic)

--- a/src/ui/MenuItemListboxEntry.h
+++ b/src/ui/MenuItemListboxEntry.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <ui/MenuItem.h>
 
 namespace UI
@@ -16,7 +16,7 @@ namespace UI
         class MenuItemListboxEntry : public MenuItemText
         {
         public:
-            MenuItemListboxEntry(Engine::BaseEngine& e, Menu& baseMenu,
+            MenuItemListboxEntry(Engine::GameEngine& e, Menu& baseMenu,
                                  const Daedalus::GameState::MenuItemHandle& scriptHandle,
                                  const std::string& topic_name,
                                  const Daedalus::GameState::LogTopic& topic);

--- a/src/ui/MenuItemScrollableText.cpp
+++ b/src/ui/MenuItemScrollableText.cpp
@@ -6,12 +6,12 @@
 #include "Menu.h"
 #include "MenuItem.h"
 #include "zFont.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <utils/logger.h>
 
 using namespace UI;
 
-MenuItemTypes::MenuItemScrollableText::MenuItemScrollableText(Engine::BaseEngine& e, UI::Menu& baseMenu,
+MenuItemTypes::MenuItemScrollableText::MenuItemScrollableText(Engine::GameEngine& e, UI::Menu& baseMenu,
                                                               const Daedalus::GameState::MenuItemHandle& scriptHandle)
     : MenuItemText(e, baseMenu, scriptHandle)
 {

--- a/src/ui/MenuItemScrollableText.h
+++ b/src/ui/MenuItemScrollableText.h
@@ -18,7 +18,7 @@ namespace UI
         class MenuItemScrollableText : public MenuItemText
         {
         public:
-            MenuItemScrollableText(Engine::BaseEngine& e, Menu& baseMenu, const Daedalus::GameState::MenuItemHandle& scriptHandle);
+            MenuItemScrollableText(Engine::GameEngine& e, Menu& baseMenu, const Daedalus::GameState::MenuItemHandle& scriptHandle);
 
             /**
              * Updates/draws the UI-Views

--- a/src/ui/Menu_Load.cpp
+++ b/src/ui/Menu_Load.cpp
@@ -1,13 +1,13 @@
 #include "Menu_Load.h"
 #include "Hud.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <logic/SavegameManager.h>
 #include <utils/Utils.h>
 #include <utils/logger.h>
 
 using namespace UI;
 
-Menu_Load::Menu_Load(Engine::BaseEngine& e)
+Menu_Load::Menu_Load(Engine::GameEngine& e)
     : Menu(e)
 {
 }
@@ -16,7 +16,7 @@ Menu_Load::~Menu_Load()
 {
 }
 
-Menu_Load* Menu_Load::create(Engine::BaseEngine& e)
+Menu_Load* Menu_Load::create(Engine::GameEngine& e)
 {
     Menu_Load* s = new Menu_Load(e);
     s->initializeInstance("MENU_SAVEGAME_LOAD");

--- a/src/ui/Menu_Load.h
+++ b/src/ui/Menu_Load.h
@@ -6,14 +6,14 @@ namespace UI
     class Menu_Load : public Menu
     {
     public:
-        Menu_Load(Engine::BaseEngine& e);
+        Menu_Load(Engine::GameEngine& e);
         ~Menu_Load();
 
         /**
          * Creates an instance of this class and appends it to the root UI-View
          * @return Instance of the class. Don't forget to delete!
          */
-        static Menu_Load* create(Engine::BaseEngine& e);
+        static Menu_Load* create(Engine::GameEngine& e);
 
         /**
          * Gathers all available savegames and writes their names to the slot-labels

--- a/src/ui/Menu_Log.cpp
+++ b/src/ui/Menu_Log.cpp
@@ -7,18 +7,18 @@
 #include "MenuItemListbox.h"
 #include "MenuItemScrollableText.h"
 #include <daedalus/DaedalusGameState.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <logic/LogManager.h>
 
 using namespace UI;
 
-Menu_Log::Menu_Log(Engine::BaseEngine& e)
+Menu_Log::Menu_Log(Engine::GameEngine& e)
     : Menu(e)
 {
     m_LogStatus = EMenuLogStatus::CategorySelection;
 }
 
-Menu_Log* Menu_Log::create(Engine::BaseEngine& e)
+Menu_Log* Menu_Log::create(Engine::GameEngine& e)
 {
     Menu_Log* s = new Menu_Log(e);
     s->initializeInstance("MENU_LOG");

--- a/src/ui/Menu_Log.h
+++ b/src/ui/Menu_Log.h
@@ -11,7 +11,7 @@ namespace UI
 {
     class Menu_Log : public Menu
     {
-        Menu_Log(Engine::BaseEngine& e);
+        Menu_Log(Engine::GameEngine& e);
 
     public:
         enum EMenuLogStatus
@@ -31,7 +31,7 @@ namespace UI
          * Creates an instance of this class and appends it to the root UI-View
          * @return Instance of the class. Don't forget to delete!
          */
-        static Menu_Log* create(Engine::BaseEngine& e);
+        static Menu_Log* create(Engine::GameEngine& e);
 
     private:
         /**

--- a/src/ui/Menu_Main.cpp
+++ b/src/ui/Menu_Main.cpp
@@ -5,19 +5,19 @@
 #include "Menu_Save.h"
 #include "Menu_Settings.h"
 #include "engine/AsyncAction.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <engine/Platform.h>
 #include <ui/LoadingScreen.h>
 #include <utils/logger.h>
 
 using namespace UI;
 
-Menu_Main::Menu_Main(Engine::BaseEngine& e)
+Menu_Main::Menu_Main(Engine::GameEngine& e)
     : Menu(e)
 {
 }
 
-Menu_Main* Menu_Main::create(Engine::BaseEngine& e)
+Menu_Main* Menu_Main::create(Engine::GameEngine& e)
 {
     Menu_Main* s = new Menu_Main(e);
     s->initializeInstance("MENU_MAIN");

--- a/src/ui/Menu_Main.h
+++ b/src/ui/Menu_Main.h
@@ -12,7 +12,7 @@ namespace UI
 {
     class Menu_Main : public Menu
     {
-        Menu_Main(Engine::BaseEngine& e);
+        Menu_Main(Engine::GameEngine& e);
 
     public:
         /**
@@ -25,7 +25,7 @@ namespace UI
          * Creates an instance of this class and appends it to the root UI-View
          * @return Instance of the class. Don't forget to delete!
          */
-        static Menu_Main* create(Engine::BaseEngine& e);
+        static Menu_Main* create(Engine::GameEngine& e);
 
         /**
          * @return the gametype of the Menu's VM (based on the existence of Gothic 2 specific symbols)

--- a/src/ui/Menu_Save.cpp
+++ b/src/ui/Menu_Save.cpp
@@ -3,13 +3,13 @@
 #include "MenuItem.h"
 #include "Menu_Main.h"
 #include <daedalus/DaedalusVM.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <engine/World.h>
 #include <logic/SavegameManager.h>
 
 using namespace UI;
 
-Menu_Save::Menu_Save(Engine::BaseEngine& e)
+Menu_Save::Menu_Save(Engine::GameEngine& e)
     : Menu(e)
 {
 }
@@ -18,7 +18,7 @@ Menu_Save::~Menu_Save()
 {
 }
 
-Menu_Save* Menu_Save::create(Engine::BaseEngine& e)
+Menu_Save* Menu_Save::create(Engine::GameEngine& e)
 {
     Menu_Save* s = new Menu_Save(e);
     s->initializeInstance("MENU_SAVEGAME_SAVE");

--- a/src/ui/Menu_Save.h
+++ b/src/ui/Menu_Save.h
@@ -6,14 +6,14 @@ namespace UI
     class Menu_Save : public Menu
     {
     public:
-        Menu_Save(Engine::BaseEngine& e);
+        Menu_Save(Engine::GameEngine& e);
         ~Menu_Save();
 
         /**
          * Creates an instance of this class and appends it to the root UI-View
          * @return Instance of the class. Don't forget to delete!
          */
-        static Menu_Save* create(Engine::BaseEngine& e);
+        static Menu_Save* create(Engine::GameEngine& e);
 
         /**
          * Gathers all available savegames and writes their names to the slot-labels

--- a/src/ui/Menu_Settings.cpp
+++ b/src/ui/Menu_Settings.cpp
@@ -2,7 +2,7 @@
 
 using namespace UI;
 
-Menu_Settings::Menu_Settings(Engine::BaseEngine& e)
+Menu_Settings::Menu_Settings(Engine::GameEngine& e)
     : Menu(e)
 {
 }
@@ -11,7 +11,7 @@ Menu_Settings::~Menu_Settings()
 {
 }
 
-Menu_Settings* Menu_Settings::create(Engine::BaseEngine& e)
+Menu_Settings* Menu_Settings::create(Engine::GameEngine& e)
 {
     Menu_Settings* s = new Menu_Settings(e);
     s->initializeInstance("MENU_OPTIONS");

--- a/src/ui/Menu_Settings.h
+++ b/src/ui/Menu_Settings.h
@@ -6,14 +6,14 @@ namespace UI
     class Menu_Settings : public Menu
     {
     public:
-        Menu_Settings(Engine::BaseEngine& e);
+        Menu_Settings(Engine::GameEngine& e);
         ~Menu_Settings();
 
         /**
          * Creates an instance of this class and appends it to the root UI-View
          * @return Instance of the class. Don't forget to delete!
          */
-        static Menu_Settings* create(Engine::BaseEngine& e);
+        static Menu_Settings* create(Engine::GameEngine& e);
 
     private:
     };

--- a/src/ui/Menu_Status.cpp
+++ b/src/ui/Menu_Status.cpp
@@ -3,16 +3,16 @@
 //
 
 #include "Menu_Status.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 
 using namespace UI;
 
-Menu_Status::Menu_Status(Engine::BaseEngine& e)
+Menu_Status::Menu_Status(Engine::GameEngine& e)
     : Menu(e)
 {
 }
 
-Menu_Status* Menu_Status::create(Engine::BaseEngine& e)
+Menu_Status* Menu_Status::create(Engine::GameEngine& e)
 {
     Menu_Status* s = new Menu_Status(e);
     s->initializeInstance("MENU_STATUS");

--- a/src/ui/Menu_Status.h
+++ b/src/ui/Menu_Status.h
@@ -11,7 +11,7 @@ namespace UI
 {
     class Menu_Status : public Menu
     {
-        Menu_Status(Engine::BaseEngine& e);
+        Menu_Status(Engine::GameEngine& e);
 
     public:
         enum EAttribute
@@ -50,7 +50,7 @@ namespace UI
          * Creates an instance of this class and appends it to the root UI-View
          * @return Instance of the class. Don't forget to delete!
          */
-        static Menu_Status* create(Engine::BaseEngine& e);
+        static Menu_Status* create(Engine::GameEngine& e);
 
     public:
     protected:

--- a/src/ui/PrintScreenMessages.cpp
+++ b/src/ui/PrintScreenMessages.cpp
@@ -5,7 +5,7 @@
 #include "PrintScreenMessages.h"
 #include "View.h"
 #include "zFont.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <render/RenderSystem.h>
 
 using namespace UI;
@@ -15,7 +15,7 @@ using namespace UI;
  */
 const double TIME_TO_POP_MESSAGE = 1.0;
 
-PrintScreenMessages::PrintScreenMessages(Engine::BaseEngine& e)
+PrintScreenMessages::PrintScreenMessages(Engine::GameEngine& e)
     : View(e)
 {
     m_TimeToPopMessage = TIME_TO_POP_MESSAGE;

--- a/src/ui/PrintScreenMessages.h
+++ b/src/ui/PrintScreenMessages.h
@@ -10,7 +10,7 @@ namespace UI
     class PrintScreenMessages : public View
     {
     public:
-        PrintScreenMessages(Engine::BaseEngine& e);
+        PrintScreenMessages(Engine::GameEngine& e);
         ~PrintScreenMessages();
 
         /**

--- a/src/ui/SubtitleBox.cpp
+++ b/src/ui/SubtitleBox.cpp
@@ -5,13 +5,13 @@
 #include "SubtitleBox.h"
 #include <algorithm>
 #include "zFont.h"
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <entry/input.h>
 #include <imgui/imgui.h>
 #include <render/RenderSystem.h>
 #include <utils/logger.h>
 
-UI::SubtitleBox::SubtitleBox(Engine::BaseEngine& e)
+UI::SubtitleBox::SubtitleBox(Engine::GameEngine& e)
     : View(e)
 {
     m_Scaling = 1;

--- a/src/ui/SubtitleBox.h
+++ b/src/ui/SubtitleBox.h
@@ -8,7 +8,7 @@ namespace UI
     class SubtitleBox : public View
     {
     public:
-        SubtitleBox(Engine::BaseEngine& e);
+        SubtitleBox(Engine::GameEngine& e);
         ~SubtitleBox();
 
         enum class TextAlignment

--- a/src/ui/TextView.cpp
+++ b/src/ui/TextView.cpp
@@ -4,7 +4,7 @@
 
 #include "TextView.h"
 
-UI::TextView::TextView(Engine::BaseEngine& e)
+UI::TextView::TextView(Engine::GameEngine& e)
     : View(e)
     , m_Font("FONT_OLD_20_WHITE.FNT")
 {

--- a/src/ui/TextView.h
+++ b/src/ui/TextView.h
@@ -7,7 +7,7 @@ namespace UI
     class TextView : public View
     {
     public:
-        TextView(Engine::BaseEngine& e);
+        TextView(Engine::GameEngine& e);
         ~TextView();
 
         /**

--- a/src/ui/View.cpp
+++ b/src/ui/View.cpp
@@ -5,7 +5,7 @@
 #include "View.h"
 #include "zFont.h"
 #include <assert.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 #include <handle/HandleDef.h>
 #include <imgui/imgui.h>
 
@@ -101,7 +101,7 @@ namespace ViewUtil
     }
 }
 
-View::View(Engine::BaseEngine& e)
+View::View(Engine::GameEngine& e)
     : m_Engine(e)
 {
     assert(e.isMainThread());

--- a/src/ui/View.h
+++ b/src/ui/View.h
@@ -7,7 +7,7 @@
 
 namespace Engine
 {
-    class BaseEngine;
+    class GameEngine;
 }
 
 namespace UI
@@ -65,7 +65,7 @@ namespace UI
     class View
     {
     public:
-        View(Engine::BaseEngine& e);
+        View(Engine::GameEngine& e);
 
         virtual ~View();
 
@@ -164,6 +164,6 @@ namespace UI
         /**
          * Engine
          */
-        Engine::BaseEngine& m_Engine;
+        Engine::GameEngine& m_Engine;
     };
 }

--- a/src/ui/zFont.cpp
+++ b/src/ui/zFont.cpp
@@ -4,7 +4,7 @@
 
 #include "zFont.h"
 #include <ZenLib/utils/logger.h>
-#include <engine/BaseEngine.h>
+#include <engine/GameEngine.h>
 
 #include <content/VertexTypes.h>
 
@@ -71,7 +71,7 @@ namespace FontUtil
     }
 }
 
-UI::zFont::zFont(Engine::BaseEngine& e, const ZenLoad::zCFont::FontInfo& fontInfo)
+UI::zFont::zFont(Engine::GameEngine& e, const ZenLoad::zCFont::FontInfo& fontInfo)
     : m_Engine(e)
     , m_Font(fontInfo)
 {
@@ -219,7 +219,7 @@ std::vector<std::string> UI::zFont::layoutText(const std::string& text, int maxW
     return lines;
 }
 
-UI::zFontCache::zFontCache(Engine::BaseEngine& e)
+UI::zFontCache::zFontCache(Engine::GameEngine& e)
     : m_Engine(e)
 {
 }

--- a/src/ui/zFont.h
+++ b/src/ui/zFont.h
@@ -10,7 +10,7 @@
 
 namespace Engine
 {
-    class BaseEngine;
+    class GameEngine;
 }
 
 namespace UI
@@ -18,7 +18,7 @@ namespace UI
     class zFont
     {
     public:
-        zFont(Engine::BaseEngine& e, const ZenLoad::zCFont::FontInfo& fontInfo);
+        zFont(Engine::GameEngine& e, const ZenLoad::zCFont::FontInfo& fontInfo);
         ~zFont();
 
         struct Glyph
@@ -113,13 +113,13 @@ namespace UI
         /**
          * Engine
          */
-        Engine::BaseEngine& m_Engine;
+        Engine::GameEngine& m_Engine;
     };
 
     class zFontCache
     {
     public:
-        zFontCache(Engine::BaseEngine& e);
+        zFontCache(Engine::GameEngine& e);
 
         /**
          * Tries to get a font from cache. If not already loaded, loads it.
@@ -132,7 +132,7 @@ namespace UI
         /**
          * Engine
          */
-        Engine::BaseEngine& m_Engine;
+        Engine::GameEngine& m_Engine;
 
         /**
          * Map of already loaded fonts


### PR DESCRIPTION
To sharpen the module structure of the project, I started moving some parts to other classes.

My concept is:

- BaseEngine: Processing parameters, loading archives, setting game mode.
- GameEngine: Initializing stuff for SinglePlayer standard gothic mode (renderer, sound, ui etc.) A handle of this class is now carried out to all ui classes that have had BaseEngine handles before.

This way I can use the BaseEngine for a Multiplayer server implementation for example without the need to init a renderer or have a sound card initialized and of course without tons of #ifdefs or regular ifs.

For a later multiplayer implementation I want to create different programs via the target directory and use as much as possible the existing structures, than creating modified copies of all things.

Regards.