### PR TITLE
fix for game only showing in the lower left corner of the window

### DIFF
--- a/src/engine/PlatformGLFW.cpp
+++ b/src/engine/PlatformGLFW.cpp
@@ -134,7 +134,10 @@ int32_t PlatformGLFW::run(int argc, char** argv)
     glfwSetCursorPosCallback(window, GLFWmouseMoveEvent);
     glfwSetScrollCallback(window, GLFWscrollEvent);
 
-    glfwSetWindowSizeCallback(window, GLFWwindowSizeEvent);
+    // window size is in screen units, while framebuffer size is in pixels
+    // we want pixels
+    glfwSetFramebufferSizeCallback(window, GLFWwindowSizeEvent);
+    glfwGetFramebufferSize(window, &width, &height);
     GLFWwindowSizeEvent(window, width, height);
 
     setMouseLockCallback([&window](bool lock) {


### PR DESCRIPTION
this happens for example on macos with retina displays where screen units don't necessarily map to pixels 1:1