### PR TITLE
Log alignment fix

### DIFF
--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -170,15 +170,21 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
 
         int colID = 0;
         int columnOffsetX = strBeforeWidth;
+        int multilineAdjustment = 0;
         for (auto& column : columns)
         {
             std::vector<std::string> columnsSelected(column.size());
             if (m_CurrentlySelected != -1)
                 std::swap(column.at(currentlySelectedRelative), columnsSelected.at(currentlySelectedRelative));
             auto joined = Utils::join(column.begin(), column.end(), "\n");
-            drawText(joined, xDistanceToEdge + columnOffsetX, consoleSizeY + suggestionBoxSizeY + 0.5*fnt->getFontHeight(), A_BottomLeft, config, font);
+            
+            // Compensating multiline adjustment by a half glyph height
+            if (column.size() != 1)
+                multilineAdjustment = 0.5*fnt->getFontHeight();
+
+            drawText(joined, xDistanceToEdge + columnOffsetX, consoleSizeY + suggestionBoxSizeY + multilineAdjustment, A_BottomLeft, config, font);
             auto joinedSelected = Utils::join(columnsSelected.begin(), columnsSelected.end(), "\n");
-            drawText(joinedSelected, xDistanceToEdge + columnOffsetX, consoleSizeY + suggestionBoxSizeY + 0.5*fnt->getFontHeight(), A_BottomLeft, config, fontSelected);
+            drawText(joinedSelected, xDistanceToEdge + columnOffsetX, consoleSizeY + suggestionBoxSizeY + multilineAdjustment, A_BottomLeft, config, fontSelected);
             columnOffsetX += columnWidths[colID++] + spaceBetweenColumns;
         }
     }

--- a/src/ui/ConsoleBox.cpp
+++ b/src/ui/ConsoleBox.cpp
@@ -69,7 +69,7 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
         std::copy_n(outputList.begin(), numLines, outputLines.rbegin());
         outputLines.push_back(console.getTypedLine());
         auto joined = Utils::join(outputLines.begin(), outputLines.end(), "\n");
-        drawText(joined, xDistanceToEdge, consoleSizeY, A_BottomLeft, config, font);
+        drawText(joined, xDistanceToEdge, consoleSizeY + 0.5*fnt->getFontHeight(), A_BottomLeft, config, font);
     }
     // Draw suggestions
     {
@@ -176,9 +176,9 @@ void UI::ConsoleBox::update(double dt, Engine::Input::MouseState& mstate, Render
             if (m_CurrentlySelected != -1)
                 std::swap(column.at(currentlySelectedRelative), columnsSelected.at(currentlySelectedRelative));
             auto joined = Utils::join(column.begin(), column.end(), "\n");
-            drawText(joined, xDistanceToEdge + columnOffsetX, consoleSizeY + suggestionBoxSizeY, A_BottomLeft, config, font);
+            drawText(joined, xDistanceToEdge + columnOffsetX, consoleSizeY + suggestionBoxSizeY + 0.5*fnt->getFontHeight(), A_BottomLeft, config, font);
             auto joinedSelected = Utils::join(columnsSelected.begin(), columnsSelected.end(), "\n");
-            drawText(joinedSelected, xDistanceToEdge + columnOffsetX, consoleSizeY + suggestionBoxSizeY, A_BottomLeft, config, fontSelected);
+            drawText(joinedSelected, xDistanceToEdge + columnOffsetX, consoleSizeY + suggestionBoxSizeY + 0.5*fnt->getFontHeight(), A_BottomLeft, config, fontSelected);
             columnOffsetX += columnWidths[colID++] + spaceBetweenColumns;
         }
     }

--- a/src/ui/View.cpp
+++ b/src/ui/View.cpp
@@ -239,6 +239,9 @@ void View::drawText(const std::string& txt, int px, int py, EAlign alignment, Re
     std::size_t line_end = txt.find("\n");
     if (line_end == std::string::npos)
         line_end = txt.length();
+    else // Adjust vertical offset of multiline text by a half glyph height
+        hole_offset.y -= 0.5*fnt->getFontHeight();
+
     std::string txt_line = txt.substr(0, line_end);
     fnt->calcTextMetrics(txt_line, width, height);
     Math::float2 offset = getAlignOffset(alignment, width, height);


### PR DESCRIPTION
This pr fixes the vertical alignment of multiline text of the log menu. It seems that multiline text needs to be drawn a half font height closer to the top. Because the console uses multiline text with a different aligment I had to compensate the above changes.

@markusobi Well done with the level switch, works great!

Btw. I encountered that mutiline text is vertical drawn with 1 less pixel between the lines. I also found out that the horizontal offset between the glyphs is not always correct.