### PR TITLE
Camera animation

### DIFF
--- a/src/components/AnimHandler.cpp
+++ b/src/components/AnimHandler.cpp
@@ -9,6 +9,8 @@
 
 #include "AnimHandler.h"
 
+
+
 using namespace Components;
 using namespace ZenLoad;
 

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -415,13 +415,13 @@ void Logic::CameraController::setTransforms(const Math::float3& position, float 
 void Logic::CameraController::storeKeyframe(unsigned idx)
 {
     Keyframe f;
-    f.position = m_ViewMatrix.Invert().Translation();
+    f.position = m_ViewMatrix.Invert().Translation(); 
     f.lookat = -1.0f * m_ViewMatrix.Invert().Forward();
 
     if(idx >= m_Keyframes.size())
-        m_Keyframes.resize(idx, f);
+        m_Keyframes.resize(idx + 1, f);
 
-    m_Keyframes.push_back(f);
+    m_Keyframes[idx] = f;
 }
 
 void Logic::CameraController::clearKeyframes()

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -38,10 +38,7 @@ Logic::CameraController::CameraController(World::WorldInstance& world, Handle::E
     m_CameraSettings.thirdPersonCameraSettings.currentLookAt = Math::float3(0, 0, 0);
 
     m_KeyframeDuration = 1.0f;
-}
 
-void Logic::CameraController::setupKeybinds()
-{
     // FirstPerson action
     {
         using namespace Engine;
@@ -418,13 +415,13 @@ void Logic::CameraController::setTransforms(const Math::float3& position, float 
 void Logic::CameraController::storeKeyframe(unsigned idx)
 {
     Keyframe f;
-    f.position = m_ViewMatrix.Invert().Translation(); 
+    f.position = m_ViewMatrix.Invert().Translation();
     f.lookat = -1.0f * m_ViewMatrix.Invert().Forward();
 
     if(idx >= m_Keyframes.size())
-        m_Keyframes.resize(idx + 1, f);
+        m_Keyframes.resize(idx, f);
 
-    m_Keyframes[idx] = f;
+    m_Keyframes.push_back(f);
 }
 
 void Logic::CameraController::clearKeyframes()

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -38,7 +38,10 @@ Logic::CameraController::CameraController(World::WorldInstance& world, Handle::E
     m_CameraSettings.thirdPersonCameraSettings.currentLookAt = Math::float3(0, 0, 0);
 
     m_KeyframeDuration = 1.0f;
+}
 
+void Logic::CameraController::setupKeybinds()
+{
     // FirstPerson action
     {
         using namespace Engine;

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -130,6 +130,11 @@ namespace Logic
         }
 
         /**
+         * Registers all inputs inside the engine
+         */
+        void setupKeybinds();
+
+        /**
          * Sets the transform of this camera
          */
         void setTransforms(const Math::float3& position, float yaw = 0.0f, float pitch = 0.0f);

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -13,7 +13,8 @@ namespace Logic
             Static = 1,
             FirstPerson = 2,
             ThirdPerson = 3,
-            Viewer  // name is open to change
+            KeyedAnimation,
+            Viewer // name is open to change
         };
 
         struct CameraSettings
@@ -133,12 +134,36 @@ namespace Logic
          */
         void setTransforms(const Math::float3& position, float yaw = 0.0f, float pitch = 0.0f);
 
+        /**
+         * Stores a keyframe with the current camera postion/rotation
+         * @param idx Index of the keyframe to store
+         */
+        void storeKeyframe(unsigned idx);
+
+        /**
+         * Clears all stored keyframes
+         */
+        void clearKeyframes();
+
+        /**
+         * Plays all stored keyframes
+         */
+        void playKeyframes(float duration = 1.0f);
     protected:
+
+        /**
+         * Moves the camera according to the stored keyframes
+         * @return (Position, lookat)
+         */
+        std::pair<Math::float3, Math::float3> updateKeyframedPlay(float dt);
+
         /**
          * Transforms the given yaw/pitch into the corresponding direction vectors
          * @return pair of (forward, right)
          */
         std::pair<Math::float3, Math::float3> getDirectionVectors(float yaw, float pitch);
+
+
 
         /**
          * Whether this controller should read player input
@@ -174,7 +199,24 @@ namespace Logic
          */
         float m_moveSpeedMultiplier;
 
+        struct Keyframe
+        {
+            Math::float3 position;
+            Math::float3 lookat;
+        };
+
         /**
+         * List of keyframes currently set
+         */
+        std::vector<Keyframe> m_Keyframes;
+
+        /**
+         * Currently active keyframe (fraction). -1 = no keyframe active
+         */
+        float m_KeyframeActive;
+        float m_KeyframeDuration;
+
+	/**
          * Direction to use during locked camera while using mobs
          */
         Math::float3 m_savedPdir;

--- a/src/logic/NpcAIHandler.cpp
+++ b/src/logic/NpcAIHandler.cpp
@@ -98,7 +98,7 @@ void NpcAIHandler::playerUpdate(float deltaTime)
             break;
 
         case EMovementState::Forward:
-            if (m_MovementState.isForward)
+            if(m_MovementState.isForward)
             {
                 // Forward-key still pressed, keep going
                 if (!getNpcAnimationHandler().Action_GoForward())
@@ -129,7 +129,7 @@ void NpcAIHandler::playerUpdate(float deltaTime)
             break;
 
         case EMovementState::Backward:
-            if (m_MovementState.isBackward)
+            if(m_MovementState.isBackward)
             {
                 // Backward-key still pressed, keep going
                 getNpcAnimationHandler().Action_GoBackward();

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -32,6 +32,11 @@ using namespace Logic;
 using SharedEMessage = std::shared_ptr<Logic::EventMessages::EventMessage>;
 
 /**
+ * Radius the sound of the voicelines and other sounds of the NPCs(in meters)
+ */
+const float NPC_SOUND_RADIUS = 14;
+
+/**
  * Standard node-names
  */
 namespace BodyNodes

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1964,8 +1964,9 @@ void PlayerController::changeAttribute(Daedalus::GEngineClasses::C_Npc::EAttribu
 
 void PlayerController::setupKeyBindings()
 {
-    // Engine::Input::clearActions();
+    Engine::Input::clearActions();
     m_AIHandler.bindKeys();
+    m_World.getCameraController()->setupKeybinds();
 
     Engine::Input::RegisterAction(Engine::ActionType::Quicksave, [this](bool triggered, float) {
         if (triggered)

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -256,43 +256,43 @@ void REGoth::initConsole()
            << "Largest SkeletalMesh: " << nameLargestSkel << " (" << sizeLargestSkel / 1024 << " kb)" << std::endl
            << "Largest StaticMesh:   " << nameLargestStatic << " (" << sizeLargestStatic / 1024 << " kb)" << std::endl;
 
-        LogInfo() << ss.str();
-        return ss.str();
+            LogInfo() << ss.str();
+            return ss.str();
+            });
+
+    console.registerCommand("kf", [&](const std::vector<std::string>& args) -> std::string {
+        if(args.size() < 2)
+            return "Missing argument. Usage: kf <idx>";
+
+        m_pEngine->getMainCameraController()->storeKeyframe(atoi(args[1].c_str()));
+        return "Saved keyframe";
     });
 
-        console.registerCommand("kf", [&](const std::vector<std::string>& args) -> std::string {
-            if(args.size() < 2)
-                return "Missing argument. Usage: kf <idx>";
+    console.registerCommand("ckf", [&](const std::vector<std::string>& args) -> std::string {
+        if(args.size() < 2)
+            return "Missing argument. Usage: kf <idx>";
 
-            m_pEngine->getMainWorld().get().getCameraController()->storeKeyframe(atoi(args[1].c_str()));
-            return "Saved keyframe";
-        });
+        m_pEngine->getMainCameraController()->clearKeyframes();
+        return "Cleared keyframe";
+    });
 
-        console.registerCommand("ckf", [&](const std::vector<std::string>& args) -> std::string {
-            if(args.size() < 2)
-                return "Missing argument. Usage: kf <idx>";
+    console.registerCommand("pkf", [&](const std::vector<std::string>& args) -> std::string {
 
-            m_pEngine->getMainWorld().get().getCameraController()->clearKeyframes();
-            return "Cleared keyframe";
-        });
+        if(args.size() < 2)
+            return "Missing argument. Usage: pkf <duration>";
 
-        console.registerCommand("pkf", [&](const std::vector<std::string>& args) -> std::string {
-
-            if(args.size() < 2)
-                return "Missing argument. Usage: pkf <duration>";
-
-            m_pEngine->getMainWorld().get().getCameraController()->playKeyframes(atof(args[1].c_str()));
-            return "Playing keyed animation";
-        });
+        m_pEngine->getMainCameraController()->playKeyframes(atof(args[1].c_str()));
+        return "Playing keyed animation";
+    });
 
 
-        console.registerCommand("stats", [](const std::vector<std::string>& args) -> std::string {
-            static bool s_Stats = false;
-            s_Stats = !s_Stats;
+    console.registerCommand("stats", [](const std::vector<std::string>& args) -> std::string {
+        static bool s_Stats = false;
+        s_Stats = !s_Stats;
 
         bgfx::setDebug(s_Stats ? BGFX_DEBUG_STATS : 0);
         return "Toggled stats";
-    });
+        });
 
         console.registerCommand("hud", [this](const std::vector<std::string>& args) -> std::string {
 

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -260,30 +260,30 @@ void REGoth::initConsole()
             return ss.str();
             });
 
-    console.registerCommand("kf", [&](const std::vector<std::string>& args) -> std::string {
-        if(args.size() < 2)
-            return "Missing argument. Usage: kf <idx>";
+        console.registerCommand("kf", [&](const std::vector<std::string>& args) -> std::string {
+            if(args.size() < 2)
+                return "Missing argument. Usage: kf <idx>";
 
-        m_pEngine->getMainCameraController()->storeKeyframe(atoi(args[1].c_str()));
-        return "Saved keyframe";
-    });
+            m_pEngine->getMainWorld().get().getCameraController()->storeKeyframe(atoi(args[1].c_str()));
+            return "Saved keyframe";
+        });
 
     console.registerCommand("ckf", [&](const std::vector<std::string>& args) -> std::string {
         if(args.size() < 2)
             return "Missing argument. Usage: kf <idx>";
 
-        m_pEngine->getMainCameraController()->clearKeyframes();
-        return "Cleared keyframe";
-    });
+            m_pEngine->getMainWorld().get().getCameraController()->clearKeyframes();
+            return "Cleared keyframe";
+        });
 
     console.registerCommand("pkf", [&](const std::vector<std::string>& args) -> std::string {
 
         if(args.size() < 2)
             return "Missing argument. Usage: pkf <duration>";
 
-        m_pEngine->getMainCameraController()->playKeyframes(atof(args[1].c_str()));
-        return "Playing keyed animation";
-    });
+            m_pEngine->getMainWorld().get().getCameraController()->playKeyframes(atof(args[1].c_str()));
+            return "Playing keyed animation";
+        });
 
 
     console.registerCommand("stats", [](const std::vector<std::string>& args) -> std::string {

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -157,9 +157,9 @@ void REGoth::init(int _argc, char** _argv)
         m_reset |= BGFX_RESET_VSYNC;
 #endif
 
-    m_Width = getWindowWidth();
-    m_Height = getWindowHeight();
-    m_NoHUD = false;
+        m_Width = getWindowWidth();
+        m_Height = getWindowHeight();
+        m_HUDMode = 2;
 
     bgfx::init();
     bgfx::reset(m_Width, m_Height, m_reset);
@@ -294,11 +294,12 @@ void REGoth::initConsole()
         return "Toggled stats";
     });
 
-    console.registerCommand("hud", [this](const std::vector<std::string>& args) -> std::string {
-        static bool s_Stats = false;
-        s_Stats = !s_Stats;
+        console.registerCommand("hud", [this](const std::vector<std::string>& args) -> std::string {
 
-        m_NoHUD = !m_NoHUD;
+            if(args.size() < 2)
+                return "Missing argument. Usage: hud <mode> | (0=None, 1=Gameplay, 2=Full)";
+
+            m_HUDMode = std::min(2, std::stoi(args[1]));
 
         return "Toggled hud";
     });
@@ -1039,12 +1040,12 @@ bool REGoth::update()
     // Use debug font to print information about this example.
     bgfx::dbgTextClear();
 
-    if (!m_NoHUD)
-    {
-        uint16_t xOffset = static_cast<uint16_t>(m_pEngine->getConsole().isOpen() ? 100 : 0);
-        bgfx::dbgTextPrintf(xOffset, 1, 0x4f, "REGoth-Engine (%s)", m_pEngine->getEngineArgs().startupZEN.c_str());
-        bgfx::dbgTextPrintf(xOffset, 2, 0x0f, "Frame: % 7.3f[ms] %.1f[fps]", 1000.0 * dt, 1.0f / (double(dt)));
-    }
+        if(m_HUDMode >= 2)
+        {
+            uint16_t xOffset = static_cast<uint16_t>(m_pEngine->getConsole().isOpen() ? 100 : 0);
+            bgfx::dbgTextPrintf(xOffset, 1, 0x4f, "REGoth-Engine (%s)", m_pEngine->getEngineArgs().startupZEN.c_str());
+            bgfx::dbgTextPrintf(xOffset, 2, 0x0f, "Frame: % 7.3f[ms] %.1f[fps]", 1000.0 * dt, 1.0f / (double(dt)));
+        }
 
     // This dummy draw call is here to make sure that view 0 is cleared
     // if no other draw callvm.getDATFile().getSymbolByIndex(self)s are submitted to view 0.
@@ -1056,22 +1057,22 @@ bool REGoth::update()
 
     ddBegin(0);
 
-    m_pEngine->frameUpdate(dt, (uint16_t)getWindowWidth(), (uint16_t)getWindowHeight());
-    // Draw and process all UI-Views
-    // Set render states.
-    {
-        auto& cfg = m_pEngine->getDefaultRenderSystem().getConfig();
-        float gameSpeed = m_pEngine->getGameClock().getGameEngineSpeedFactor();
-        if (m_NoHUD)
+        m_pEngine->frameUpdate(dt, (uint16_t)getWindowWidth(), (uint16_t)getWindowHeight());
+        // Draw and process all UI-Views
+        // Set render states.
+
         {
-            // draw console even if HUD is disabled
-            m_pEngine->getHud().getConsoleBox().update(dt * gameSpeed, ms, cfg);
+            auto& cfg = m_pEngine->getDefaultRenderSystem().getConfig();
+            float gameSpeed = m_pEngine->getGameClock().getGameEngineSpeedFactor();
+            if(m_HUDMode == 0)
+            {
+                // draw console even if HUD is disabled
+                m_pEngine->getHud().getConsoleBox().update(dt * gameSpeed, ms, cfg);
+            } else if(m_HUDMode >= 1)
+            {
+                m_pEngine->getRootUIView().update(dt * gameSpeed, ms, cfg);
+            }
         }
-        else
-        {
-            m_pEngine->getRootUIView().update(dt * gameSpeed, ms, cfg);
-        }
-    }
 
     // debug draw
     {
@@ -1112,10 +1113,17 @@ bool REGoth::update()
     return true;
 }
 
-void REGoth::drawLog()
-{
-    const std::list<std::string>& logs = Utils::Log::getLastLogLines();
-    auto it = logs.begin();
+    Engine::GameEngine* m_pEngine;
+    uint32_t m_debug;
+    uint32_t m_reset;
+    int m_Width, m_Height;
+    int64_t m_timeOffset;
+    float axis;
+    int32_t m_scrollArea;
+    int m_HUDMode;
+    // prevents imgui from crashing if we failed on startup and didn't init it
+    bool m_ImgUiCreated = false;
+};
 
     for (int i = 49; i >= 0 && it != logs.end(); i++)
     {

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -260,9 +260,38 @@ void REGoth::initConsole()
         return ss.str();
     });
 
-    console.registerCommand("stats", [](const std::vector<std::string>& args) -> std::string {
-        static bool s_Stats = false;
-        s_Stats = !s_Stats;
+        auto& console = m_pEngine->getHud().getConsole();
+
+
+        console.registerCommand("kf", [&](const std::vector<std::string>& args) -> std::string {
+            if(args.size() < 2)
+                return "Missing argument. Usage: kf <idx>";
+
+            m_pEngine->getMainCameraController()->storeKeyframe(atoi(args[1].c_str()));
+            return "Saved keyframe";
+        });
+
+        console.registerCommand("ckf", [&](const std::vector<std::string>& args) -> std::string {
+            if(args.size() < 2)
+                return "Missing argument. Usage: kf <idx>";
+
+            m_pEngine->getMainCameraController()->clearKeyframes();
+            return "Cleared keyframe";
+        });
+
+        console.registerCommand("pkf", [&](const std::vector<std::string>& args) -> std::string {
+
+            if(args.size() < 2)
+                return "Missing argument. Usage: pkf <duration>";
+
+            m_pEngine->getMainCameraController()->playKeyframes(atof(args[1].c_str()));
+            return "Playing keyed animation";
+        });
+
+
+        console.registerCommand("stats", [](const std::vector<std::string>& args) -> std::string {
+            static bool s_Stats = false;
+            s_Stats = !s_Stats;
 
         bgfx::setDebug(s_Stats ? BGFX_DEBUG_STATS : 0);
         return "Toggled stats";

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -157,9 +157,9 @@ void REGoth::init(int _argc, char** _argv)
         m_reset |= BGFX_RESET_VSYNC;
 #endif
 
-        m_Width = getWindowWidth();
-        m_Height = getWindowHeight();
-        m_HUDMode = 2;
+    m_Width = getWindowWidth();
+    m_Height = getWindowHeight();
+    m_HUDMode = 2;
 
     bgfx::init();
     bgfx::reset(m_Width, m_Height, m_reset);
@@ -294,7 +294,7 @@ void REGoth::initConsole()
         return "Toggled stats";
         });
 
-        console.registerCommand("hud", [this](const std::vector<std::string>& args) -> std::string {
+    console.registerCommand("hud", [this](const std::vector<std::string>& args) -> std::string {
 
             if(args.size() < 2)
                 return "Missing argument. Usage: hud <mode> | (0=None, 1=Gameplay, 2=Full)";

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -260,14 +260,11 @@ void REGoth::initConsole()
         return ss.str();
     });
 
-        auto& console = m_pEngine->getHud().getConsole();
-
-
         console.registerCommand("kf", [&](const std::vector<std::string>& args) -> std::string {
             if(args.size() < 2)
                 return "Missing argument. Usage: kf <idx>";
 
-            m_pEngine->getMainCameraController()->storeKeyframe(atoi(args[1].c_str()));
+            m_pEngine->getMainWorld().get().getCameraController()->storeKeyframe(atoi(args[1].c_str()));
             return "Saved keyframe";
         });
 
@@ -275,7 +272,7 @@ void REGoth::initConsole()
             if(args.size() < 2)
                 return "Missing argument. Usage: kf <idx>";
 
-            m_pEngine->getMainCameraController()->clearKeyframes();
+            m_pEngine->getMainWorld().get().getCameraController()->clearKeyframes();
             return "Cleared keyframe";
         });
 
@@ -284,7 +281,7 @@ void REGoth::initConsole()
             if(args.size() < 2)
                 return "Missing argument. Usage: pkf <duration>";
 
-            m_pEngine->getMainCameraController()->playKeyframes(atof(args[1].c_str()));
+            m_pEngine->getMainWorld().get().getCameraController()->playKeyframes(atof(args[1].c_str()));
             return "Playing keyed animation";
         });
 

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -269,9 +269,6 @@ void REGoth::initConsole()
         });
 
     console.registerCommand("ckf", [&](const std::vector<std::string>& args) -> std::string {
-        if(args.size() < 2)
-            return "Missing argument. Usage: kf <idx>";
-
             m_pEngine->getMainWorld().get().getCameraController()->clearKeyframes();
             return "Cleared keyframe";
         });

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -1113,25 +1113,7 @@ bool REGoth::update()
     return true;
 }
 
-    Engine::GameEngine* m_pEngine;
-    uint32_t m_debug;
-    uint32_t m_reset;
-    int m_Width, m_Height;
-    int64_t m_timeOffset;
-    float axis;
-    int32_t m_scrollArea;
-    int m_HUDMode;
-    // prevents imgui from crashing if we failed on startup and didn't init it
-    bool m_ImgUiCreated = false;
-};
 
-    for (int i = 49; i >= 0 && it != logs.end(); i++)
-    {
-        bgfx::dbgTextPrintf(0, i + 1, 0x4f, (*it).c_str());
-
-        it++;
-    }
-}
 
 void REGoth::showSplash()
 {

--- a/src/target/REGoth.h
+++ b/src/target/REGoth.h
@@ -24,13 +24,13 @@ public:
     void showSplash();
     void renderScreenSpaceQuad(uint32_t _view, bgfx::ProgramHandle _program, float _x, float _y, float _width, float _height);
 
-    Engine::GameEngine* m_pEngine;
-    uint32_t m_debug;
-    uint32_t m_reset;
-    uint32_t m_Width, m_Height;
-    int64_t m_timeOffset;
-    int32_t m_scrollArea;
-    bool m_NoHUD;
-    // prevents imgui from crashing if we failed on startup and didn't init it
-    bool m_ImgUiCreated = false;
+        Engine::GameEngine* m_pEngine;
+        uint32_t m_debug;
+        uint32_t m_reset;
+        uint32_t m_Width, m_Height;
+        int64_t m_timeOffset;
+        int32_t m_scrollArea;
+        int m_HUDMode;
+        // prevents imgui from crashing if we failed on startup and didn't init it
+        bool m_ImgUiCreated = false;
 };


### PR DESCRIPTION
> You can move the free camera to a location, put a keyframe there, move it to a different location, put another keyframe and then have it interpolate between those positions.

There are 3 commands, kept short since you need to type them often:
kf - put keyframe
ckf - clear all keyframes
pkf <duration> - play keyframes (interpolate between all keyframes)

Improves the `hud` console command, so you can turn off the Debug-Text on the upper left corner.
Adds `-rdist` flag for controlling the render-distance