### PR TITLE
Anim: Workaround for goblins using the wrong animation-set

### DIFF
--- a/src/logic/NpcAnimationHandler.cpp
+++ b/src/logic/NpcAnimationHandler.cpp
@@ -472,7 +472,26 @@ void NpcAnimationHandler::startAni_UndrawWeapon()
 
 const NpcAnimationHandler::AnimationSet& NpcAnimationHandler::getActiveSet()
 {
-    return m_Anims[(int)getController().getWeaponMode()];
+    EWeaponMode mode = getController().getWeaponMode();
+
+    // See patchGoblinWeaponMode() why this is needed
+    mode = patchGoblinWeaponMode(mode);
+
+    return m_Anims[(int)mode];
+}
+
+EWeaponMode NpcAnimationHandler::patchGoblinWeaponMode(EWeaponMode targetMode)
+{
+    if(targetMode == EWeaponMode::Weapon1h)
+    {
+        // Goblins are using the "fist"-set, even though they are holding a 1h-weapon.
+        if(!isAnimationSetUsable(targetMode) && isAnimationSetUsable(EWeaponMode::WeaponFist))
+        {
+            return EWeaponMode::WeaponFist;
+        }
+    }
+
+    return targetMode;
 }
 
 void NpcAnimationHandler::playAnimation(Handle::AnimationHandle anim)
@@ -536,4 +555,18 @@ void NpcAnimationHandler::startAni_FightForward()
     {
         playAnimation(anim);
     }
+}
+
+bool NpcAnimationHandler::isAnimationSetUsable(EWeaponMode weaponMode)
+{
+    AnimationSet& set = m_Anims[(int)weaponMode];
+
+    bool valid = false;
+
+    valid = valid || set.s_run.isValid();
+    valid = valid || set.s_runl.isValid();
+    valid = valid || set.s_walk.isValid();
+    valid = valid || set.s_walkl.isValid();
+
+    return valid;
 }

--- a/src/logic/NpcAnimationHandler.h
+++ b/src/logic/NpcAnimationHandler.h
@@ -150,6 +150,23 @@ namespace Logic
         void playAnimation(Handle::AnimationHandle anim);
         void playAnimation(const std::string& anim);
 
+        /**
+         * Goblins use the "fist"-modes like all other monsters, even though they are holding a 1h-weapon.
+         * Maybe someone can come up with a nicer solution than this when we completely figured that one out.
+         * TODO: Completely figure that one out.
+         *
+         * @param targetMode Mode that is requested
+         * @return actual mode that should be used
+         */
+        EWeaponMode patchGoblinWeaponMode(EWeaponMode targetMode);
+
+        /**
+         * Checks whether crucial animations exist within this weapon-mode
+         * @param weaponMode Weaponmode to check the animations for
+         * @return Whether this is okay to use for a real monster
+         */
+        bool isAnimationSetUsable(EWeaponMode weaponMode);
+
         struct AnimationSet
         {
             /* ---- run ---- */


### PR DESCRIPTION
Goblins use the "fist"-modes like all other monsters, even though they are holding a 1h-weapon.
Maybe someone can come up with a nicer solution than this when we completely figured that one out.