### PR TITLE
Configure MacOS travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,15 @@ addons:
             - alsa-utils 
             - alsa-oss
 
-env:
-  - PLATFORM=linux
-  #- PLATFORM=android
-
 git:
   submodules: false
 
 script:
   - ./.travis_build.sh
+
+matrix:
+  include:
+    - os: linux
+      env: PLATFORM=linux
+    - os: osx
+      compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,7 @@ matrix:
   include:
     - os: linux
       env: PLATFORM=linux
+    - os: linux
+      env: PLATFORM=android
     - os: osx
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: c++
 
-addons:
-    apt:
-        sources:
+script:
+  - ./.travis_build.sh
+
+matrix:
+  include:
+    - os: linux
+      env: PLATFORM=linux
+      addons:
+        apt:
+          sources:
             - ubuntu-toolchain-r-test
             - george-edison55-precise-backports
-        packages:
+          packages:
             - g++-6
             - gcc-6
             - cmake
@@ -23,21 +30,24 @@ addons:
             - libxrandr-dev
             - libglew-dev
             - libsndfile1-dev
-            - libasound2-dev 
-            - alsa-utils 
+            - libasound2-dev
+            - alsa-utils
             - alsa-oss
-
-git:
-  submodules: false
-
-script:
-  - ./.travis_build.sh
-
-matrix:
-  include:
     - os: linux
-      env: PLATFORM=linux
-    - os: linux
+      language: android
       env: PLATFORM=android
+      android:
+        components:
+          - tools
+          - platform-tools
+          - tools # it's required to have this duplicated
+
+          - build-tools-25.0.2
+          - android-21
+        licenses:
+          - '.+'
+      install:
+        - "yes | sdkmanager ndk-bundle"
+        - "yes | sdkmanager \"extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2\""
     - os: osx
       compiler: clang

--- a/.travis_build.sh
+++ b/.travis_build.sh
@@ -5,11 +5,10 @@ set -e
 set -o pipefail
 
 if [ "$PLATFORM" = "android" ]; then
-    REGoth-Android/install_dependencies_and_build.sh;
-    [[ $? -ne 0 ]] && exit 1; # Exit if non-zero exit code
+    cd REGoth-Android/
+    ./gradlew build
 else
     if [ "$CXX" = "g++" ]; then export CXX="g++-6" CC="gcc-6"; fi
-    git submodule update --init --recursive;
     mkdir -p build;
     cd build;
     cmake ..;

--- a/.travis_build.sh
+++ b/.travis_build.sh
@@ -5,8 +5,10 @@ set -e
 set -o pipefail
 
 if [ "$PLATFORM" = "android" ]; then
+    export TERM=dumb # Fixes gradle output looking bad
     cd REGoth-Android/
-    ./gradlew build
+    ./gradlew task
+    ./gradlew assembleRelease
 else
     if [ "$CXX" = "g++" ]; then export CXX="g++-6" CC="gcc-6"; fi
     mkdir -p build;


### PR DESCRIPTION
It is possible to configure Travis to upload artifacts to every tag, but it requires GITHUB_OAUTH token, so I couldn't do that: https://docs.travis-ci.com/user/deployment/releases/