### PR TITLE
Walkmode g2 fix

### DIFF
--- a/src/components/AnimHandler.cpp
+++ b/src/components/AnimHandler.cpp
@@ -208,7 +208,19 @@ void AnimHandler::updateAnimations(double deltaTime)
         }
         else
         {
-            // Try to play it by name
+            // Try to play it by name. But check if it even exists first, because otherwise, we would be stuck
+            // inside the current animation with nowhere to go.
+            //
+            // This happens in G2, where T_WALKL_2_WALK defines "S_WALK" as next animation, but "S_WALK" doesn't exist.
+            if (!hasAnimation(anim->m_NextName))
+            {
+                if (!addAnimation(anim->m_NextName))
+                {
+                    stopAnimation();
+                    return;
+                }
+            }
+
             playAnimation(anim->m_NextName);
             return;
         }

--- a/src/logic/NpcAnimationHandler.cpp
+++ b/src/logic/NpcAnimationHandler.cpp
@@ -138,8 +138,15 @@ bool NpcAnimationHandler::playAnimationTrans(const std::string& anim)
     }
     else
     {
-        model->playAnimation(anim);
-        return false;
+        // Try to fallback to target animation
+        Handle::AnimationHandle fallbackAni = getAnimLib().getAnimation(h.getMeshLibName(), h.getOverlay(), anim);
+
+        // Cancel if the animation really doesn't exist
+        if(!fallbackAni.isValid())
+            return false;
+
+        model->playAnimation(fallbackAni);
+        return true;
     }
 }
 
@@ -605,8 +612,11 @@ void NpcAnimationHandler::setWalkMode(NpcAnimationHandler::WalkMode walkMode)
     if(isAnimationActive(getActiveSet().s_run) || isAnimationActive(getActiveSet().s_walk))
     {
         std::string tag = getWalkModeTag(walkMode);
-
-        playAnimationTrans("S_" + tag);
+        std::string animation = "S_" + tag;
+        if(!playAnimationTrans(animation))
+        {
+            LogWarn() << "Failed to set walk-mode on NPC (Could not find Animation " << animation << "): " << getController().getScriptInstance().name[0];
+        }
     }
 }
 

--- a/src/logic/NpcAnimationHandler.h
+++ b/src/logic/NpcAnimationHandler.h
@@ -165,6 +165,62 @@ namespace Logic
         void playAnimation(const std::string& anim);
 
         /**
+         * Given a string like "RUN", this will append the correct weapon-prefix, ie. return "S_FISTRUN".
+         * @param state State animation name (RUN, WALK, RUNL, ...)
+         * @return Full animation name for the current weapon being held
+         */
+        std::string buildStateAnimationNameBasedOnWeapon(const std::string& state);
+
+        /**
+         * Handles animations like "T_RUNTURNL", which are neither state, nor transition. Same as
+         * buildStateAnimationNameBasedOnWeapon otherwise.
+         * @param substate Sub-state animation name like "TURNL"
+         * @return Full animation name for the current weapon being held
+         */
+        std::string buildSubStateAnimationNameBasedOnWeapon(const std::string& state);
+
+        /**
+         * Builds the transition-animation for the two given states, based on the current weapon.
+         * @param stateFrom State the transition should be starting from (ie. RUN)
+         * @param stateTo State the transition should be going to (ie. RUNL)
+         * @return Full animation name which handles the transistion. (ie. T_RUN_2_RUNL)
+         *         If no fitting animation was found, the target state animation is returned.
+         */
+        std::string buildTransitionAnimationNameBasedOnWeapon(const std::string& stateFrom, const std::string& stateTo);
+
+
+
+        /**
+         * Builds the animation we would have to play to get from the currently playing animation to the given one.
+         * This is also based on the current state of the NPC (ie. weapon being held)
+         * @param stateTo Target State-animation
+         * @return Full animation name which handles the transition (ie. T_RUN_2_RUNL).
+         *         Be sure to check whether this animation actually exists!
+         */
+        std::string buildTransitionAnimationFromCurrentToGiven(const std::string& stateTo);
+
+        /**
+         * @return The default idle animation to use if everything fails and no other animation can be found to fall back to.
+         */
+        std::string getDefaultStandAniName();
+
+        /**
+         * @return Whether the given animation exists (includes the currently applied overlay)
+         */
+        bool doesAnimationExist(const std::string& animName);
+
+        /**
+         * @return Whether there is a state-animation currently playing (ie. all animations starting with "S_" or an invalid one)
+         */
+        bool isStateAnimationPlaying();
+
+        /**
+         * @return Whether a turning animation (ie. T_RUNTURNL) is currently playing
+         */
+        bool isTurningAnimationPlaying();
+        bool isSubStateAnimationPlaying();
+
+        /**
          * Goblins use the "fist"-modes like all other monsters, even though they are holding a 1h-weapon.
          * Maybe someone can come up with a nicer solution than this when we completely figured that one out.
          * TODO: Completely figure that one out.


### PR DESCRIPTION
Reworked `NpcAnimationHandler`.
- Walking now works in G2, too
- Other walkmodes (Walk, Swim, Dive, Sneak) are available and functional
- Overall animation handling is now less rigid than before

Also fixes Dialogs not startable in G2, caused by NPCs being stuck in an invalid animation state due to the `S_WALK` animation missing. (Issue #287 )