### PR TITLE
fixed init_world script-fu run before script engine import

### DIFF
--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -336,7 +336,7 @@ bool DialogManager::init()
 
     if (ou.empty())
     {
-        LogWarn() << "Failed to read OU-file!";
+        LogError() << "Failed to read OU-file!";
         return false;
     }
     else


### PR DESCRIPTION
The state of the scriptengine (global vars) is now imported before `init_<worldname>()` is run.
fixes #280 