### PR TITLE
Fix for #298: [Android] Taps are not recognized + Hide ActionBar in fullscreen mode

### DIFF
--- a/REGoth-Android/app/src/main/AndroidManifest.xml
+++ b/REGoth-Android/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
             android:name=".LoadLibraries"
             android:configChanges="orientation|keyboardHidden"
             android:screenOrientation="landscape"
-            android:theme="@style/Theme.AppCompat.NoActionBar">
+            android:theme="@style/REGothTheme">
 
             <meta-data
                 android:name="android.app.lib_name"

--- a/REGoth-Android/app/src/main/res/values/styles.xml
+++ b/REGoth-Android/app/src/main/res/values/styles.xml
@@ -1,3 +1,7 @@
 <resources>
-
+    <!-- the theme applied to the application or activity -->
+    <style name="REGothTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
 </resources>

--- a/src/engine/PlatformAndroid.cpp
+++ b/src/engine/PlatformAndroid.cpp
@@ -185,9 +185,8 @@ int PlatformAndroid::onInputEvent(struct android_app* app, AInputEvent* event)
 {
     static int activePointerIdx;
 
-    switch(AInputEvent_getSource(event))
+    if (AInputEvent_getSource(event) & AINPUT_SOURCE_TOUCHSCREEN)
 	{
-	case AINPUT_SOURCE_TOUCHSCREEN:
 		int action = AKeyEvent_getAction(event) & AMOTION_EVENT_ACTION_MASK;
 		int pointer = (AKeyEvent_getAction(event) & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
 
@@ -305,8 +304,7 @@ int PlatformAndroid::onInputEvent(struct android_app* app, AInputEvent* event)
 			return 1;
 			break;
 		}
-		break;
-	} // end switch
+	}
 
     return 1;
 }


### PR DESCRIPTION
On some devices both events AINPUT_SOURCE_TOUCHSCREEN & AINPUT_SOURCE_STYLUS are triggered on tap/touch.
see https://github.com/SFML/SFML/issues/953 for more details