### PR TITLE
Fix Bullet memory leaks

### DIFF
--- a/src/physics/PhysicsSystem.cpp
+++ b/src/physics/PhysicsSystem.cpp
@@ -439,6 +439,7 @@ Handle::CollisionShapeHandle PhysicsSystem::makeConvexCollisionShapeFromMesh(con
 
     // Init collision
     btTriangleMesh* wm = new btTriangleMesh;
+    // TODO fix memory leak: wm is never freed. FIX: move tmpShape to heap and add tmpShape to m_CollisionShapeAllocator?
 
     for (size_t s = 0; s < mesh.mesh.m_SubmeshStarts.size(); s++)
     {

--- a/src/physics/PhysicsSystem.cpp
+++ b/src/physics/PhysicsSystem.cpp
@@ -171,10 +171,9 @@ Handle::CollisionShapeHandle PhysicsSystem::makeCollisionShapeFromMesh(const std
     {
         // Convert to btvector
         const btVector3 v[] = {
-                {triangles[i].vertices[0].Position.x, triangles[i].vertices[0].Position.y, triangles[i].vertices[0].Position.z},
-                {triangles[i].vertices[1].Position.x, triangles[i].vertices[1].Position.y, triangles[i].vertices[1].Position.z},
-                {triangles[i].vertices[2].Position.x, triangles[i].vertices[2].Position.y, triangles[i].vertices[2].Position.z}
-        };
+            {triangles[i].vertices[0].Position.x, triangles[i].vertices[0].Position.y, triangles[i].vertices[0].Position.z},
+            {triangles[i].vertices[1].Position.x, triangles[i].vertices[1].Position.y, triangles[i].vertices[1].Position.z},
+            {triangles[i].vertices[2].Position.x, triangles[i].vertices[2].Position.y, triangles[i].vertices[2].Position.z}};
 
         wm->addTriangle(v[0], v[1], v[2]);
     }
@@ -460,14 +459,14 @@ Handle::CollisionShapeHandle PhysicsSystem::makeConvexCollisionShapeFromMesh(con
         }
     }
 
-    btConvexShape* tmpShape = new btConvexTriangleMeshShape(wm);
-    btShapeHull* hull = new btShapeHull(tmpShape);
+    btConvexTriangleMeshShape tmpShape(wm);
+    btShapeHull hull(&tmpShape);
 
-    btScalar margin = tmpShape->getMargin();
-    hull->buildHull(margin);
-    tmpShape->setUserPointer(hull);
+    btScalar margin = tmpShape.getMargin();
+    hull.buildHull(margin);
+    tmpShape.setUserPointer(&hull);
 
-    btConvexHullShape* simplifiedConvexShape = new btConvexHullShape((btScalar*)hull->getVertexPointer(), hull->numVertices());
+    btConvexHullShape* simplifiedConvexShape = new btConvexHullShape((btScalar*)hull.getVertexPointer(), hull.numVertices());
 
     Handle::CollisionShapeHandle csh = m_CollisionShapeAllocator.createObject();
     CollisionShape& cs = getCollisionShape(csh);
@@ -475,9 +474,6 @@ Handle::CollisionShapeHandle PhysicsSystem::makeConvexCollisionShapeFromMesh(con
     cs.shapeType = CollisionShape::ConvexMesh;
 
     cs.collisionShape->setUserIndex(-1);
-
-    delete tmpShape;
-    delete hull;
 
     if (!name.empty())
         m_ShapeCache[name] = csh;

--- a/src/physics/PhysicsSystem.h
+++ b/src/physics/PhysicsSystem.h
@@ -45,7 +45,11 @@ namespace Physics
 
         static void clean(CollisionShape& s)
         {
+            auto btTriangleMeshShape = dynamic_cast<btBvhTriangleMeshShape*>(s.collisionShape);
+            btStridingMeshInterface* mesh = btTriangleMeshShape ? btTriangleMeshShape->getMeshInterface() : nullptr;
+            // delete in reverse order of creation
             delete s.collisionShape;
+            delete mesh;
         }
     };
 
@@ -62,7 +66,7 @@ namespace Physics
         Math::float3 hitPosition;
 
         /**
-         * @brief Index of the trianlge the ray has potentially hit
+         * @brief Index of the triangle the ray has potentially hit
          */
         uint32_t hitTriangleIndex;
 


### PR DESCRIPTION
Fixes leaking of `btStridingMeshInterface`.
`PhysicsSystem::makeConvexCollisionShapeFromMesh` would still leak, but is not used atm.
fixes #296 