### PR TITLE
Pfx soft alpha

### DIFF
--- a/src/logic/PfxManager.cpp
+++ b/src/logic/PfxManager.cpp
@@ -175,6 +175,7 @@ const Logic::PfxManager::Emitter& Logic::PfxManager::getParticleFX(const std::st
     e.visTexIsQuadPoly = fx.visTexIsQuadPoly != 0;
     e.visTexAniFPS = fx.visTexAniFPS;
     e.visTexAniIsLooping = fx.visTexAniIsLooping != 0;
+    e.visSoftAlpha = fx.visTexAniIsLooping == 2; // Special case for Gothic 2
     e.visTexColorStart = parseFloat3(fx.visTexColorStart_S) * 1.0f / 255.0f;
     e.visTexColorEnd = parseFloat3(fx.visTexColorEnd_S) * 1.0f / 255.0f;
     e.visSizeStart = parseFloat2(fx.visSizeStart_S) * 0.01f;

--- a/src/logic/PfxManager.h
+++ b/src/logic/PfxManager.h
@@ -147,6 +147,7 @@ namespace Logic
             bool visTexIsQuadPoly;            // Whether to draw a complete polygon (Always the case in REGoth)
             float visTexAniFPS;               // Number of texture-animation frames per second
             bool visTexAniIsLooping;          // Whether to loop the texture animation
+            bool visSoftAlpha;                // Was encoded in visTexAniIsLooping=2, got it's own flag now. Whether to use sine-ease to soften the alpha-value.
             Math::float3 visTexColorStart;    // Start of texture color-modulation interpolation
             Math::float3 visTexColorEnd;      // End of texture color-modulation interpolation
             Math::float2 visSizeStart;        // Size of the particle on start. (visOrientation == None: Screen axis. X = Target direction otherwise)

--- a/src/logic/visuals/PfxVisual.cpp
+++ b/src/logic/visuals/PfxVisual.cpp
@@ -300,8 +300,21 @@ void Logic::PfxVisual::updateParticle(Components::PfxComponent::Particle& p, flo
     p.size += p.sizeVel * deltaTime;
     p.alpha += p.alphaVel * deltaTime;
 
+
+    float alphaFinal;
+
+    if(m_Emitter.visSoftAlpha)
+    {
+      float alphaRatio = (p.alpha - m_Emitter.visAlphaStart) / (m_Emitter.visAlphaEnd - m_Emitter.visAlphaStart);
+      alphaFinal = Math::sinusSmooth(alphaRatio) * p.alpha;
+    }
+    else
+    {
+      alphaFinal = p.alpha; 
+    }
+
     // Compute actual color for this frame
-    float alpha = std::max(0.0f, std::min(1.0f, p.alpha)) * 0.5f;  // FIXME: Hack! * 0.5f is just here because particles would be too bright for some strange reason...
+    alphaFinal = std::max(0.0f, std::min(1.0f, alphaFinal)) * 0.5f;  // FIXME: Hack! * 0.5f is just here because particles would be too bright for some strange reason...
     Math::float3 color = Math::float3(std::max(0.0f, std::min(1.0f, p.color.x)),
                                       std::max(0.0f, std::min(1.0f, p.color.y)),
                                       std::max(0.0f, std::min(1.0f, p.color.z)));
@@ -311,11 +324,11 @@ void Logic::PfxVisual::updateParticle(Components::PfxComponent::Particle& p, flo
                                      ? Math::float4(color.x,
                                                     color.y,
                                                     color.z,
-                                                    alpha)
-                                     : Math::float4(color.x * alpha,
-                                                    color.y * alpha,
-                                                    color.z * alpha,
-                                                    alpha);  // Need to modulate color on ADD-mode
+                                                    alphaFinal)
+                                     : Math::float4(color.x * alphaFinal,
+                                                    color.y * alphaFinal,
+                                                    color.z * alphaFinal,
+                                                    alphaFinal);  // Need to modulate color on ADD-mode
 
     p.particleColorU8 = particleColor.toRGBA8();
 

--- a/src/math/mathlib.h
+++ b/src/math/mathlib.h
@@ -26,6 +26,14 @@ namespace Math
         return glm::sin(((t * PI - PI * 0.5f) + 1.0f) / 2.0f);
     }
 
+    inline float sinusSmooth(float t)
+    {
+      if(t < 0.5f)
+        return sinusEase(t * 2.0f);
+      else
+        return 1.0f - sinusEase((t - 0.5f) * 2.0f);
+    }
+
     inline float sinusSlowStart(float t)
     {
         return 1.0f - glm::cos(t * (PI * 0.5f));


### PR DESCRIPTION
Implementes soft alpha fade for particles in G2.

Whether soft-alpha should be active is encoded inside the `visTexAniIsLooping` flag as a value of `2`. 

Fixes #273.