### PR TITLE
Removed log-spam, which slowed down windows startup times

### DIFF
--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -856,7 +856,6 @@ void REGoth::initConsole()
       if (Utils::endsWith(Utils::lowered(fileName), ".wav"))
       {
         playSoundFiles.push_back(fileName);
-        LogInfo() << "FOUND WAV: " << fileName;
       }
     }
 


### PR DESCRIPTION
I forgot to take out some logging a while ago, which would cause windows builds to take like 5 minutes to start up due to stdout being so slow...