### PR TITLE
If the g2 addon is available then prefer its textures and show its st…

### DIFF
--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -158,10 +158,27 @@ void BaseEngine::loadArchives()
       m_FileIndex.loadVDF(m_Args.modfile, 2);
     }
 
-    LogInfo() << "Loading VDF-Archives: " << vdfArchives;
+    // Load addon archives before the default archives and
+    // therefore with a higher priority
+    LogInfo() << "Loading Addon VDF-Archives: ";
     for (std::string& s : vdfArchives)
     {
-        m_FileIndex.loadVDF(s);
+        if (s.find("Addon") != std::string::npos)
+        {
+            LogInfo() << s;
+            m_FileIndex.loadVDF(s);
+        }
+    }
+
+    // Load default archives
+    LogInfo() << "Loading VDF-Archives: ";
+    for (std::string& s : vdfArchives)
+    {
+        if (s.find("Addon") == std::string::npos)
+        {
+            LogInfo() << s;
+            m_FileIndex.loadVDF(s);
+        }
     }
 
     // Happens on modded games

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -127,34 +127,30 @@ void BaseEngine::frameUpdate(double dt, uint16_t width, uint16_t height)
 
 void BaseEngine::loadArchives()
 {
-    //m_FileIndex.loadVDF("vdf/Worlds_Addon.vdf");
-    //m_FileIndex.loadVDF("vdf/Textures.vdf");
-    //m_FileIndex.loadVDF("vdf/Textures_Addon.vdf");
-    //m_FileIndex.loadVDF("vdf/Meshes_Addon.vdf");
-    //m_FileIndex.loadVDF("vdf/Meshes.vdf");
-    //m_FileIndex.loadVDF("vdf/Anims.vdf");
-    //m_FileIndex.loadVDF("vdf/Anims_Addon.vdf");
-
-    /*m_FileIndex.loadVDF("vdf/g1/anims.VDF");
-	m_FileIndex.loadVDF("vdf/g1/fonts.VDF");
-	m_FileIndex.loadVDF("vdf/g1/meshes.VDF");
-	m_FileIndex.loadVDF("vdf/g1/sound_patch2.VDF");
-	m_FileIndex.loadVDF("vdf/g1/sound.VDF");
-	m_FileIndex.loadVDF("vdf/g1/speech_patch2.VDF");
-	m_FileIndex.loadVDF("vdf/g1/speech.VDF");
-	m_FileIndex.loadVDF("vdf/g1/textures_apostroph_patch_neu.VDF");
-	m_FileIndex.loadVDF("vdf/g1/textures_choicebox_32pixel_modialpha.VDF");
-	m_FileIndex.loadVDF("vdf/g1/textures_patch.VDF");
-	m_FileIndex.loadVDF("vdf/g1/textures_Startscreen_ohne_Logo.VDF");
-	m_FileIndex.loadVDF("vdf/g1/textures.VDF");
-	m_FileIndex.loadVDF("vdf/g1/worlds.VDF");*/
-
-    // Load explicit modfile with even higher priority
+    // Load explicit modfile with highest priority
     if (!m_Args.modfile.empty())
     {
-      LogInfo() << "Reading Mod-File from Commandline: " << m_Args.modfile;
-      m_FileIndex.loadVDF(m_Args.modfile, 2);
+        LogInfo() << "Reading Mod-File from Commandline: " << m_Args.modfile;
+        m_FileIndex.loadVDF(m_Args.modfile);
     }
+
+    // Load mod archives
+    std::list<std::string> modArchives = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "mod", false);
+    modArchives.sort([](const std::string &lhs, const std::string &rhs)
+    { return VDFS::FileIndex::getLastModTime(lhs) > VDFS::FileIndex::getLastModTime(rhs); });
+    LogInfo() << "Loading MOD-Archives: " << modArchives;
+    if (!modArchives.empty())
+        for (std::string& s : modArchives)
+            m_FileIndex.loadVDF(s);
+
+    // Load zip archives
+    std::list<std::string> zipArchives = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "zip", false);
+    zipArchives.sort([](const std::string &lhs, const std::string &rhs)
+    { return VDFS::FileIndex::getLastModTime(lhs) > VDFS::FileIndex::getLastModTime(rhs); });
+    LogInfo() << "Loading ZIP-Archives: " << zipArchives;
+    if (!zipArchives.empty())
+        for (std::string& s : zipArchives)
+            m_FileIndex.loadVDF(s);
 
     // Load vdf archives
     std::list<std::string> vdfArchives = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "vdf");
@@ -166,36 +162,11 @@ void BaseEngine::loadArchives()
 
     // Happens on modded games
     std::list<std::string> vdfArchivesDisabled = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "disabled");
-
     LogInfo() << "Loading VDF-Archives: " << vdfArchivesDisabled;
     for (std::string& s : vdfArchivesDisabled)
     {
         m_FileIndex.loadVDF(s);
     }
-
-    // Load mod archives with higher priority
-    std::list<std::string> modArchives = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "mod", false);
-
-    LogInfo() << "Loading MOD-Archives: " << modArchives;
-    if (!modArchives.empty())
-    {
-        for (std::string& s : modArchives)
-        {
-            m_FileIndex.loadVDF(s, 1);
-        }
-    }
-
-    // Load zip archives with yet higher priority
-    std::list<std::string> zipArchives = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "zip", false);
-
-    LogInfo() << "Loading ZIP-Archives: " << zipArchives;
-    if (!zipArchives.empty())
-      {
-        for (std::string& s : zipArchives)
-          {
-            m_FileIndex.loadVDF(s, 1);
-          }
-      }
 
     m_FileIndex.finalizeLoad();
 }

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -160,14 +160,6 @@ void BaseEngine::loadArchives()
     for (std::string& s : vdfArchives)
         m_FileIndex.loadVDF(s);
 
-    // Happens on modded games
-    std::list<std::string> vdfArchivesDisabled = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "disabled");
-    LogInfo() << "Loading VDF-Archives: " << vdfArchivesDisabled;
-    for (std::string& s : vdfArchivesDisabled)
-    {
-        m_FileIndex.loadVDF(s);
-    }
-
     m_FileIndex.finalizeLoad();
 }
 

--- a/src/engine/BaseEngine.cpp
+++ b/src/engine/BaseEngine.cpp
@@ -149,8 +149,6 @@ void BaseEngine::loadArchives()
 	m_FileIndex.loadVDF("vdf/g1/textures.VDF");
 	m_FileIndex.loadVDF("vdf/g1/worlds.VDF");*/
 
-    std::list<std::string> vdfArchives = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "vdf");
-
     // Load explicit modfile with even higher priority
     if (!m_Args.modfile.empty())
     {
@@ -158,28 +156,13 @@ void BaseEngine::loadArchives()
       m_FileIndex.loadVDF(m_Args.modfile, 2);
     }
 
-    // Load addon archives before the default archives and
-    // therefore with a higher priority
-    LogInfo() << "Loading Addon VDF-Archives: ";
+    // Load vdf archives
+    std::list<std::string> vdfArchives = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "vdf");
+    vdfArchives.sort([](const std::string &lhs, const std::string &rhs)
+    { return VDFS::FileIndex::getLastModTime(lhs) > VDFS::FileIndex::getLastModTime(rhs); });
+    LogInfo() << "Loading VDF-Archives: " << vdfArchives;
     for (std::string& s : vdfArchives)
-    {
-        if (s.find("Addon") != std::string::npos)
-        {
-            LogInfo() << s;
-            m_FileIndex.loadVDF(s);
-        }
-    }
-
-    // Load default archives
-    LogInfo() << "Loading VDF-Archives: ";
-    for (std::string& s : vdfArchives)
-    {
-        if (s.find("Addon") == std::string::npos)
-        {
-            LogInfo() << s;
-            m_FileIndex.loadVDF(s);
-        }
-    }
+        m_FileIndex.loadVDF(s);
 
     // Happens on modded games
     std::list<std::string> vdfArchivesDisabled = Utils::getFilesInDirectory(m_Args.gameBaseDirectory + "/Data", "disabled");


### PR DESCRIPTION
…artscreen with its fonts.

Loads the addon vdfs of g2 before the default ones. Then if the addon is installed its textures will be prefered and the proper startscreen of the g2 addon is shown. This will only work with the pr I made at autalien/zenlib. 