### PR TITLE
Autocompletion for playanimation console command

### DIFF
--- a/src/content/AnimationAllocator.h
+++ b/src/content/AnimationAllocator.h
@@ -36,11 +36,21 @@ namespace Animations
         Handle::AnimationHandle getAnimation(const std::string& name) const;
 
         Animation& getAnimation(Handle::AnimationHandle h) { return m_Allocator.getElement(h); }
+
+        std::vector<std::string> getAnimationNames() const;
     private:
         Memory::StaticReferencedAllocator<Animation, Config::MAX_NUM_LEVEL_ANIMATIONS> m_Allocator;
 
         std::map<std::string, Handle::AnimationHandle> m_AnimationsByName;
     };
+
+    inline std::vector<std::string> AnimationAllocator::getAnimationNames() const
+    {
+        std::vector<std::string> animationNames;
+        for (const auto& entry : m_AnimationsByName)
+            animationNames.push_back(entry.first);
+        return animationNames;
+    }
 
     inline Handle::AnimationHandle AnimationAllocator::allocate(const std::string& name)
     {

--- a/src/logic/Console.cpp
+++ b/src/logic/Console.cpp
@@ -171,18 +171,11 @@ std::string Console::submitCommand(std::string command)
 Logic::Console::Command& Console::registerCommand(const std::string& command, Callback callback)
 {
     auto tokens = Utils::splitAndRemoveEmpty(command, ' ');
-    std::vector<CandidateListGenerator> generators;
-    auto simpleGen = [](std::string token) -> std::vector<Suggestion> {
-        Suggestion suggestion = std::make_shared<SuggestionBase>(SuggestionBase{{token}});
-        return {suggestion};
-    };
-    for (const auto& token : tokens)
-    {
-        generators.push_back(std::bind(simpleGen, token));
-    }
     auto sanitizedCommand = Utils::join(tokens.begin(), tokens.end(), " ");
     bool requiresWorld = true;
-    m_Commands.push_back({sanitizedCommand, generators, callback, generators.size(), requiresWorld});
+    m_Commands.push_back({sanitizedCommand, {}, callback, tokens.size(), requiresWorld});
+    for (auto& token : tokens)
+        m_Commands.back().registerAutoComplete({token});
     return m_Commands.back();
 }
 

--- a/src/logic/Console.h
+++ b/src/logic/Console.h
@@ -70,15 +70,34 @@ namespace Logic
             // whether this command is disabled while no world is loaded
             bool requiresWorld;
 
+            /**
+             * A commands, that requires a world will not be visible/available when no world is loaded
+             */
             Command& setRequiresWorld(bool value)
             {
                 requiresWorld = value;
                 return *this;
             }
 
+            /**
+             * creates and registers a simple suggestion generator from vector<string>
+             * @param rows suggestions
+             * @return reference to Command
+             */
+            Command& registerAutoComplete(const std::vector<std::string>& rows)
+            {
+                std::vector<Suggestion> suggestions;
+                for (auto& row : rows)
+                    suggestions.push_back(std::make_shared<SuggestionBase>(SuggestionBase{{row}}));
+                auto generator = [s = std::move(suggestions)]() {
+                    return s;
+                };
+                return registerAutoComplete(std::move(generator));
+            }
+
             Command& registerAutoComplete(CandidateListGenerator generator)
             {
-                generators.push_back(generator);
+                generators.push_back(std::move(generator));
                 return *this;
             }
         };

--- a/src/target/REGoth.cpp
+++ b/src/target/REGoth.cpp
@@ -141,16 +141,6 @@ void REGoth::initConsole()
         return suggestions;
     };
 
-    // creates simple suggestion generator from iterables of string
-    auto simpleStringGenGen = [](const auto& stringContainer){
-        return [stringContainer](){
-            std::vector<Suggestion> suggestions;
-            for (auto& token : stringContainer)
-                suggestions.push_back(std::make_shared<SuggestionBase>(SuggestionBase{{std::move(token)}}));
-            return suggestions;
-        };
-    };
-
     console.registerCommand("estimatedGPUMem", [this](const std::vector<std::string>& args) -> std::string {
         World::WorldInstance& world = m_pEngine->getMainWorld().get();
 
@@ -216,7 +206,7 @@ void REGoth::initConsole()
 
     std::map<std::string, Logic::CameraController::ECameraMode> camModes = {
         {"ThirdPerson", Logic::CameraController::ECameraMode::ThirdPerson},
-        {"FirstPerson", Logic::CameraController::ECameraMode::FirstPerson, },
+        {"FirstPerson", Logic::CameraController::ECameraMode::FirstPerson},
         {"Free", Logic::CameraController::ECameraMode::Free},
         {"Viewer", Logic::CameraController::ECameraMode::Viewer},
         {"Static", Logic::CameraController::ECameraMode::Static},
@@ -238,7 +228,7 @@ void REGoth::initConsole()
     std::vector<std::string> camModeNames;
     for (const auto& pair : camModes)
         camModeNames.push_back(pair.first);
-    commandCamera.registerAutoComplete(simpleStringGenGen(camModeNames));
+    commandCamera.registerAutoComplete(camModeNames);
 
     console.registerCommand("test", [this](const std::vector<std::string>& args) -> std::string {
         auto& worldInstance = m_pEngine->getMainWorld().get();
@@ -356,7 +346,7 @@ void REGoth::initConsole()
     for (const auto& pair : walkModes)
         walkModeNames.push_back(pair.first);
 
-    setWalkmode.registerAutoComplete(simpleStringGenGen(walkModeNames));
+    setWalkmode.registerAutoComplete(walkModeNames);
 
     console.registerCommand("heroexport", [this](const std::vector<std::string>& args) -> std::string {
         auto& s = m_pEngine->getMainWorld().get().getScriptEngine();
@@ -924,7 +914,7 @@ void REGoth::initConsole()
       }
     }
 
-    playsound.registerAutoComplete(simpleStringGenGen(playSoundFiles));
+    playsound.registerAutoComplete(playSoundFiles);
 
     console.registerCommand("volume", [this](const std::vector<std::string>& args) -> std::string {
         if (args.size() < 2)


### PR DESCRIPTION
 - the `playanimation` command now has autocomplete.
 - it is possible to play the animation on specified target npc (default is player)

PS:
I'm not sure if it would be better to expose `std::map<std::string, Handle::AnimationHandle> m_AnimationsByName;` as `const reference` instead of returning a copy of the strings.