### PR TITLE
Implement Chapter Notification

### DIFF
--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -1507,12 +1507,15 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
     });
 
     vm->registerExternalFunction("introducechapter", [=](Daedalus::DaedalusVM& vm) {
+
         double waittime = vm.popDataValue();
         std::string sound = vm.popString();
         std::string texture = vm.popString();
         std::string subtitle = vm.popString();
         std::string title = vm.popString();
 
+        LogInfo() << "Queued up chapter introduction " << title;
+        
         engine->getJobManager().executeInMainThread<void>([=](Engine::BaseEngine* pEngine) {
             engine->getHud().getIntroduceChapterView().enqueueChapterIntroduction(title, subtitle, texture, sound, waittime);
         });

--- a/src/logic/scriptExternals/Externals.cpp
+++ b/src/logic/scriptExternals/Externals.cpp
@@ -10,7 +10,9 @@
 #include <engine/GameEngine.h>
 #include <logic/PlayerController.h>
 #include <logic/visuals/ModelVisual.h>
+#include <ui/Hud.h>
 #include <ui/PrintScreenMessages.h>
+#include <ui/IntroduceChapterView.h>
 #include <utils/logger.h>
 #include <logic/ScriptEngine.h>
 #include <logic/DialogManager.h>
@@ -1502,5 +1504,18 @@ void ::Logic::ScriptExternals::registerEngineExternals(World::WorldInstance& wor
         {
             npc.playerController->drawWeaponMelee(true);
         }
+    });
+
+    vm->registerExternalFunction("introducechapter", [=](Daedalus::DaedalusVM& vm) {
+        double waittime = vm.popDataValue();
+        std::string sound = vm.popString();
+        std::string texture = vm.popString();
+        std::string subtitle = vm.popString();
+        std::string title = vm.popString();
+
+        engine->getJobManager().executeInMainThread<void>([=](Engine::BaseEngine* pEngine) {
+            engine->getHud().getIntroduceChapterView().enqueueChapterIntroduction(title, subtitle, texture, sound, waittime);
+        });
+
     });
 }

--- a/src/logic/scriptExternals/Stubs.cpp
+++ b/src/logic/scriptExternals/Stubs.cpp
@@ -1932,32 +1932,16 @@ void ::Logic::ScriptExternals::registerStubs(Daedalus::DaedalusVM& vm, bool verb
 
     vm.registerExternalFunction("introducechapter", [=](Daedalus::DaedalusVM& vm) {
         if (verbose) LogInfo() << "introducechapter";
-        int i4 = vm.popDataValue();
-        if (verbose) LogInfo() << "i4: " << i4;
-        std::string s3 = vm.popString();
-        if (verbose) LogInfo() << "s3: " << s3;
-        std::string s2 = vm.popString();
-        if (verbose) LogInfo() << "s2: " << s2;
-        std::string s1 = vm.popString();
-        if (verbose) LogInfo() << "s1: " << s1;
-        std::string s0 = vm.popString();
-        if (verbose) LogInfo() << "s0: " << s0;
-
-    });
-
-    vm.registerExternalFunction("introducechapter", [=](Daedalus::DaedalusVM& vm) {
-        if (verbose) LogInfo() << "introducechapter";
-        int waittime = vm.popDataValue();
+        double waittime = vm.popDataValue();
         if (verbose) LogInfo() << "waittime: " << waittime;
         std::string sound = vm.popString();
         if (verbose) LogInfo() << "sound: " << sound;
         std::string texture = vm.popString();
         if (verbose) LogInfo() << "texture: " << texture;
-        std::string untertitel = vm.popString();
-        if (verbose) LogInfo() << "untertitel: " << untertitel;
-        std::string titel = vm.popString();
-        if (verbose) LogInfo() << "titel: " << titel;
-
+        std::string subtitle = vm.popString();
+        if (verbose) LogInfo() << "subtitle: " << subtitle;
+        std::string title = vm.popString();
+        if (verbose) LogInfo() << "title: " << title;
     });
 
     vm.registerExternalFunction("log_addentry", [=](Daedalus::DaedalusVM& vm) {

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -257,8 +257,14 @@ void UI::Hud::onInputAction(Engine::ActionType action)
 {
     using Engine::ActionType;
 
-    if (!m_pLoadingScreen->isHidden() || !m_pIntroduceChapterView->isHidden())
+    if (!m_pLoadingScreen->isHidden())
         return;
+
+    if (!m_pIntroduceChapterView->isHidden() && action == ActionType::UI_ToggleMainMenu)
+    {
+        m_pIntroduceChapterView->close();
+        return;
+    }
 
     if (m_Engine.getConsole().isOpen())
     {

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -14,6 +14,7 @@
 #include "Menu_Status.h"
 #include "PrintScreenMessages.h"
 #include "TextView.h"
+#include "IntroduceChapterView.h"
 #include <components/VobClasses.h>
 #include <logic/PlayerController.h>
 #include <logic/CameraController.h>
@@ -39,6 +40,8 @@ UI::Hud::Hud(Engine::BaseEngine& e)
     m_pMenuBackground = new ImageView(m_Engine);
     m_pMenuBackground->setHidden(true);
     m_pMenuBackground->setRelativeSize(false);
+    m_pIntroduceChapterView = new IntroduceChapterView(m_Engine);
+    m_pIntroduceChapterView->setHidden(true);
 
     addChild(m_pHealthBar);
     addChild(m_pManaBar);
@@ -49,6 +52,7 @@ UI::Hud::Hud(Engine::BaseEngine& e)
     addChild(m_pLoadingScreen);
     addChild(m_pMenuBackground);
     addChild(m_pConsoleBox);
+    addChild(m_pIntroduceChapterView);
 
     // Initialize status bars
     {
@@ -119,6 +123,7 @@ UI::Hud::~Hud()
     removeChild(m_pLoadingScreen);
     removeChild(m_pConsoleBox);
     removeChild(m_pMenuBackground);
+    removeChild(m_pIntroduceChapterView);
 
     popAllMenus();
 
@@ -130,6 +135,7 @@ UI::Hud::~Hud()
     delete m_pClock;
     delete m_pLoadingScreen;
     delete m_pConsoleBox;
+    delete m_pIntroduceChapterView;
 }
 
 void UI::Hud::update(double dt, Engine::Input::MouseState& mstate, Render::RenderConfig& config)
@@ -251,7 +257,7 @@ void UI::Hud::onInputAction(Engine::ActionType action)
 {
     using Engine::ActionType;
 
-    if (!m_pLoadingScreen->isHidden())
+    if (!m_pLoadingScreen->isHidden() || !m_pIntroduceChapterView->isHidden())
         return;
 
     if (m_Engine.getConsole().isOpen())

--- a/src/ui/Hud.h
+++ b/src/ui/Hud.h
@@ -27,6 +27,7 @@ namespace UI
     class Menu;
     class DialogBox;
     class LoadingScreen;
+    class IntroduceChapterView;
 
     class Hud : public View
     {
@@ -103,6 +104,10 @@ namespace UI
          */
         LoadingScreen& getLoadingScreen() { return *m_pLoadingScreen; }
         /**
+         * IntroduceChapterView
+         */
+        IntroduceChapterView& getIntroduceChapterView() { return *m_pIntroduceChapterView; }
+        /**
          * Controls visibility of gameplay-hud
          */
         void setGameplayHudVisible(bool value);
@@ -154,6 +159,7 @@ namespace UI
         LoadingScreen* m_pLoadingScreen;
         ImageView* m_pMenuBackground;
         ConsoleBox* m_pConsoleBox;
+        IntroduceChapterView* m_pIntroduceChapterView;
 
         /**
          * Chain of opened menus. Only the last one will be rendered and processed

--- a/src/ui/IntroduceChapterView.cpp
+++ b/src/ui/IntroduceChapterView.cpp
@@ -1,0 +1,120 @@
+
+
+#include "IntroduceChapterView.h"
+#include <engine/BaseEngine.h>
+#include <logic/DialogManager.h>
+
+UI::IntroduceChapterView::IntroduceChapterView(Engine::BaseEngine& e)
+    : View(e)
+{
+    m_pImageView = new ImageView(e);
+    addChild(m_pImageView);
+    m_pImageView->setAlignment(EAlign::A_Center);
+    m_pImageView->setTranslation(Math::float2(0.25, 0.20)); //TODO: get this right
+    m_pImageView->setRelativeSize(false);
+    m_pImageView->setSize(Math::float2(4.5/8.0, 3.0/4.5));
+
+    m_pTitleTextView = new TextView(e);
+    addChild(m_pTitleTextView);
+    m_pTitleTextView->setAlignment(EAlign::A_Center);
+    m_pTitleTextView->setTranslation(Math::float2(0.5, 0.28));  //TODO: get this right
+    m_pTitleTextView->setFont(DEFAULT_FONT_LARGE);
+
+    m_pSubtitleTextView = new TextView(e);
+    addChild(m_pSubtitleTextView);
+    m_pSubtitleTextView->setAlignment(EAlign::A_Center);
+    m_pSubtitleTextView->setTranslation(Math::float2(0.5, 0.78));   //TODO: get this right
+    m_pSubtitleTextView->setFont(DEFAULT_FONT);
+
+    initializeIntroduceChapterView();
+}
+
+UI::IntroduceChapterView::~IntroduceChapterView()
+{
+    removeChild(m_pImageView);
+    delete m_pImageView;
+
+    removeChild(m_pTitleTextView);
+    delete m_pTitleTextView;
+
+    removeChild(m_pSubtitleTextView);
+    delete m_pSubtitleTextView;
+}
+
+void UI::IntroduceChapterView::initializeIntroduceChapterView()
+{
+    m_Title = "";
+    m_Subtitle = "";
+    m_TextureName = ""; //TODO: some default
+    m_SoundName = "";
+    m_WaitTime = 0;
+
+    m_QueueStatus = QueueStatus::Empty;
+
+    setHidden(true);
+
+    m_pImageView->setHidden(true);
+    m_pTitleTextView->setHidden(true);
+    m_pSubtitleTextView->setHidden(true);
+}
+
+void UI::IntroduceChapterView::update(double dt, Engine::Input::MouseState& mstate, Render::RenderConfig& config)
+{
+    if ( m_QueueStatus == QueueStatus::Empty || /* Dialog in progess */ m_Engine.getMainWorld().get().getDialogManager().isDialogActive() )
+        return;
+
+    //Dequeue
+    if ( m_QueueStatus == QueueStatus::InQueue )
+    {
+        //Setup ImageView picture
+        {
+            Textures::TextureAllocator& alloc = m_Engine.getEngineTextureAlloc();
+            Handle::TextureHandle image = alloc.loadTextureVDF(m_TextureName);
+            if (image.isValid())
+            {
+                m_pImageView->setImage(image);
+                m_pImageView->setHidden(false);
+            }
+        }
+
+        //Setup Text
+        {
+            m_pTitleTextView->setText(m_Title);
+            m_pTitleTextView->setHidden(false);
+        }
+        {
+            m_pSubtitleTextView->setText(m_Subtitle);
+            m_pTitleTextView->setHidden(false);
+        }
+
+        //Setup Sound
+
+        //TODO: Pause Engine?
+
+        m_QueueStatus = QueueStatus::Dequeued;
+
+        setHidden(false);
+    }
+
+    View::update(dt, mstate, config);
+
+    m_WaitTime -= dt;
+
+    if ( m_WaitTime < 0 )
+    {
+        //TODO: unpause Engine?
+
+        initializeIntroduceChapterView();        
+    }
+}
+
+void UI::IntroduceChapterView::enqueueChapterIntroduction(std::string title, std::string subtitle, std::string texture_name, std::string sound_name, double wait_time)
+{
+    m_Title = title;
+    m_Subtitle = subtitle;
+    m_TextureName = texture_name;
+    m_SoundName = sound_name;
+    m_WaitTime = wait_time/1000;
+
+    m_QueueStatus = QueueStatus::InQueue;
+}

--- a/src/ui/IntroduceChapterView.h
+++ b/src/ui/IntroduceChapterView.h
@@ -4,6 +4,7 @@
 #include "View.h"
 #include "ImageView.h"
 #include "TextView.h"
+#include <handle/HandleDef.h>
 
 namespace UI
 {
@@ -22,31 +23,64 @@ namespace UI
         void update(double dt, Engine::Input::MouseState& mstate, Render::RenderConfig& config) override;
 
         /**
-         * Adds a single choice
-         * @param choice Choice presented to the user
-         * @param name Name of the person or thing we are interacting with
+         * Queues up the ChapterIntroduction request
+         * @param title Title to display at the top of the view
+         * @param subtitle Subtitle to dispaly at the bottom of the view
+         * @param texture_name Name of the image to display
+         * @param sound_name Name of the sound to play
+         ' @param wait_time Duration to display this view for
          */
         void enqueueChapterIntroduction(std::string title, std::string subtitle, std::string texture_name, std::string sound_name, double wait_time);
 
-    private:
-
-        void initializeIntroduceChapterView();
+        /**
+         * Closes this view by resetting it
+         */
+        void close();
         
+    private:
+        /**
+         * Enum to show status of the requested ChapterIntroduction in the Queue
+         * Empty stops this view from being updated
+         * InQueue sets up Image, Text and Sound; plays Sound and pauses Engine
+         * Dequeued makes this view update as expected
+         */
         enum QueueStatus
         {
             Empty,
             InQueue,
             Dequeued
         };
-
+        /**
+         * Status of the requested ChapterIntroduction
+         */
         QueueStatus m_QueueStatus;
 
+        /**
+         * Title to the top of the view and Subtitle to the bottom of the view
+         */
         std::string m_Title;
         std::string m_Subtitle;
-        std::string m_TextureName;
-        std::string m_SoundName;
+
+        /**
+         * Image to display
+         */
+        Handle::TextureHandle m_Texture;
+
+        /**
+         * Sound to play
+         */
+        Handle::SfxHandle m_Sound;
+
+        /**
+         * Duration to display the view for
+         */
         double m_WaitTime;
 
+        /**
+         * ImageView for the Image to display
+         * TextView for the Title to display
+         * TextView for the Subtitle to display
+         */
         ImageView* m_pImageView;
         TextView* m_pTitleTextView;
         TextView* m_pSubtitleTextView;

--- a/src/ui/IntroduceChapterView.h
+++ b/src/ui/IntroduceChapterView.h
@@ -1,0 +1,54 @@
+
+#pragma once
+
+#include "View.h"
+#include "ImageView.h"
+#include "TextView.h"
+
+namespace UI
+{
+    class IntroduceChapterView : public View
+    {
+    public:
+        IntroduceChapterView(Engine::BaseEngine& e);
+
+        ~IntroduceChapterView();
+
+        /**
+         * Updates/draws the UI-Views
+         * @param dt time since last frame
+         * @param mstate mouse-state
+         */
+        void update(double dt, Engine::Input::MouseState& mstate, Render::RenderConfig& config) override;
+
+        /**
+         * Adds a single choice
+         * @param choice Choice presented to the user
+         * @param name Name of the person or thing we are interacting with
+         */
+        void enqueueChapterIntroduction(std::string title, std::string subtitle, std::string texture_name, std::string sound_name, double wait_time);
+
+    private:
+
+        void initializeIntroduceChapterView();
+        
+        enum QueueStatus
+        {
+            Empty,
+            InQueue,
+            Dequeued
+        };
+
+        QueueStatus m_QueueStatus;
+
+        std::string m_Title;
+        std::string m_Subtitle;
+        std::string m_TextureName;
+        std::string m_SoundName;
+        double m_WaitTime;
+
+        ImageView* m_pImageView;
+        TextView* m_pTitleTextView;
+        TextView* m_pSubtitleTextView;
+    };
+}


### PR DESCRIPTION
See Issue #338 

This might be better fit as some kind of menu, but there is not scriptdata for chapter notifications as far as I can tell.
So because it is just a view, handling input (closing the notification early) and pausing the engine might not be the ideal way to go about it.

Playing the sound is also a little convoluted. For now its good enough, but it should be changed once the audio system gets reworked to include a way to play sounds independently of the World.
You could use OpenAL directly, but I dont think that is very elegant.