### PR TITLE
Fix engine always trying to load OU.BIN instead of OU.DAT in case it doesn't exist

### DIFF
--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -355,7 +355,7 @@ bool DialogManager::init()
       for (const auto& outFile : {OU_FILE, OU_FILE_2})
       {
           ou = Utils::getCaseSensitivePath(outFile, m_World.getEngine()->getEngineArgs().gameBaseDirectory);
-          if (!ou.empty())
+          if (!ou.empty() && Utils::fileExists(ou))
               break;
       }
 


### PR DESCRIPTION
I have always been experiencing this on my desktop but not on my laptop, for some reason `Utils::getCaseSensitivePath` returns a valid path even for nonexistant files, so the engine would always try to load OU.BIN instead of OU.DAT on desktop, making the game crash every time I start a dialog with an NPC