### PR TITLE
Implemented basic dialog camera

### DIFF
--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -41,7 +41,7 @@ Logic::CameraController::CameraController(World::WorldInstance& world, Handle::E
 
     m_CameraSettings.thirdPersonCameraSettings.currentLookAt = Math::float3(0, 0, 0);
     m_CameraSettings.thirdPersonCameraSettings.zoomExponent = 3.2f; // initial zoom pos, feel free to modify
-    m_CameraSettings.thirdPersonCameraSettings.pitch = Math::degreeToRadians(20.0f); // initial camera angle, feel free to modify
+    m_CameraSettings.thirdPersonCameraSettings.pitch = Math::degreeToRadians(0.0f); // initial camera angle, feel free to modify
     // if you want to see more of the hero's legs, decrease this value
     m_CameraSettings.thirdPersonCameraSettings.cameraElevation = Math::degreeToRadians(25.0f);
     m_CameraSettings.thirdPersonCameraSettings.deltaPhi = 0;
@@ -236,7 +236,6 @@ void Logic::CameraController::switchModeActions(ECameraMode mode)
         }
     }
 }
-
 
 void Logic::CameraController::onUpdateExplicit(float deltaTime)
 {

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -42,7 +42,7 @@ Logic::CameraController::CameraController(World::WorldInstance& world, Handle::E
     m_CameraSettings.thirdPersonCameraSettings.currentLookAt = Math::float3(0, 0, 0);
     m_CameraSettings.thirdPersonCameraSettings.zoomExponent = 3.2f; // initial zoom pos, feel free to modify
     m_CameraSettings.thirdPersonCameraSettings.pitch = Math::degreeToRadians(0.0f); // initial camera angle, feel free to modify
-    // if you want to see more of the hero's legs, decrease this value
+                                                                                    // if you want to see more of the hero's legs, decrease this value
     m_CameraSettings.thirdPersonCameraSettings.cameraElevation = Math::degreeToRadians(25.0f);
     m_CameraSettings.thirdPersonCameraSettings.deltaPhi = 0;
 

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -240,7 +240,7 @@ void Logic::CameraController::switchModeActions(ECameraMode mode)
 void Logic::CameraController::onUpdateExplicit(float deltaTime)
 {
     switch (m_CameraMode) {
-        case ECameraMode::Dialog:
+        case ECameraMode::Dialogue:
         {
             const std::string npc_name = m_World.getScriptEngine().getGameState().getNpc(m_NPCTarget).name[0];
             Handle::EntityHandle npc_handle = m_World.getScriptEngine().findWorldNPC(npc_name);
@@ -481,7 +481,7 @@ void Logic::CameraController::setCameraMode(Logic::CameraController::ECameraMode
         case ECameraMode::ThirdPerson:
             Engine::Input::setMouseLock(true);
             break;
-        case ECameraMode::Dialog:
+        case ECameraMode::Dialogue:
             Engine::Input::setMouseLock(true);
             break;
         case ECameraMode::KeyedAnimation:

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -271,22 +271,26 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
             {
                 case EDialogueShotType::Full:
                 {
-                    m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0);
-                    m_ViewMatrix *= Math::Matrix::CreateTranslation(1.5 * reverseShotModifier,0.6,-0.3); // right, up, back
-                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), -1.0 * reverseShotModifier);
+                    m_ViewMatrix = otherTrans.RotatedAroundLine(otherTrans.Translation(), otherTrans.Right(), 0);
+                    m_ViewMatrix *= Math::Matrix::CreateTranslation(-1.5 * reverseShotModifier,0.5,1.8); // right, up, front
+                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), (Math::PI -1.0) * reverseShotModifier);
+                    // TODO Pull further back based on distance between characters
                 }
                 break;
                 case EDialogueShotType ::OverTheShoulder:
                 {
-                    m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0.15);
-                    m_ViewMatrix *= Math::Matrix::CreateTranslation(0.5 * reverseShotModifier,0.7,-0.5);
-                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), targetTrans.Up(), -0.45 * reverseShotModifier);
+                    m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0.2);
+                    m_ViewMatrix *= Math::Matrix::CreateTranslation(0.5 * reverseShotModifier,0.8,-0.6);
+                    // TODO Rotate towards target by a look-at function and then rotate by a offset to ensure both characters are in frame regardless of distance
+                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), targetTrans.Up(), -0.55 * reverseShotModifier);
                 }
                 break;
                 case EDialogueShotType ::CloseUp:
                 {
                     m_ViewMatrix = otherTrans.RotatedAroundLine(otherTrans.Translation(), otherTrans.Up(), Math::PI);
-                    m_ViewMatrix *= Math::Matrix::CreateTranslation(0.0, 0.6, -1.0);
+                    m_ViewMatrix *= Math::Matrix::CreateTranslation(-0.2 * reverseShotModifier, 0.8, -1.5);
+                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0.2);
+                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), targetTrans.Up(), 0.2 * reverseShotModifier);
                 }
                 break;
             }

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -237,6 +237,20 @@ void Logic::CameraController::switchModeActions(ECameraMode mode)
     }
 }
 
+void Logic::CameraController::nextDialogueShot()
+{
+    // TODO rule: use close-up and neutral only after at least two fulls or shoulders
+    if (m_DialogueShotType == EDialogueShotType::Full || m_DialogueShotType == EDialogueShotType::OverTheShoulder)
+    {
+        m_DialogueShotType = (EDialogueShotType)(rand() % 4);
+    }
+    else
+    {
+        m_DialogueShotType = (EDialogueShotType)(rand() % 2); // Only choose from first two (Full and OverTheShoulder)
+    }
+    // TODO rule: don't always cut to the hero. Leave chance for camera to stay on target NPC
+}
+
 void Logic::CameraController::onUpdateExplicit(float deltaTime)
 {
     switch (m_CameraMode) {
@@ -275,6 +289,8 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
                     m_ViewMatrix *= Math::Matrix::CreateTranslation(-1.5 * reverseShotModifier,0.5,1.8); // right, up, front
                     m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), (Math::PI -1.0) * reverseShotModifier);
                     // TODO Pull further back based on distance between characters
+                    // Calculate distance
+                    //float dist = (Vob::getTransform(vob1).Translation() - Vob::getTransform(vob2).Translation()).length();
                 }
                 break;
                 case EDialogueShotType::OverTheShoulder:

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -241,247 +241,262 @@ void Logic::CameraController::switchModeActions(ECameraMode mode)
     }
 }
 
-void Logic::CameraController::nextDialogueShot()
+void Logic::CameraController::nextDialogueShot() {
+    VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_World,
+                                                            m_World.getScriptEngine().getPlayerEntity());
+
+    EDialogueShotType nextShot;
+    bool playerTalking = m_dialogueTargetName == player.playerController->getScriptInstance().name[0];
+
+    // Rule: Use close-up and neutral only after at least two fulls or shoulders
+    // Rule: Only full or over-the-shoulder shot for PC_Hero
+    if (playerTalking || m_CameraSettings.dialogueCameraSettings.dialogueShotCounter <=
+                         m_CameraSettings.dialogueCameraSettings.dialogueShotLimit) {
+        // Rule: don't always cut to PC_Hero when they speak. Leave chance for camera to stay on target NPC
+        m_dontShowHero = rand() % m_CameraSettings.dialogueCameraSettings.dontShowHeroChance != 0;
+        if (m_CameraSettings.dialogueCameraSettings.dialogueShotCounter == 0 ||
+            m_CameraSettings.dialogueCameraSettings.dialogueShotCounter >
+            m_CameraSettings.dialogueCameraSettings.dialogueShotLimit) {
+
+            // Only choose from first two (Full and OverTheShoulder)
+            nextShot = (EDialogueShotType) (rand() % 2);
+        }
+    } else {
+        // Rule: A close-up is the only possible option after a neutral shot
+        if (m_DialogueShotType == EDialogueShotType::Neutral && rand() % 4 == 0)
+            nextShot = EDialogueShotType::CloseUp;
+            // Rule: No shot should come after a close-up
+        else if (m_DialogueShotType != EDialogueShotType::CloseUp)
+            nextShot = (EDialogueShotType) (rand() % 4);
+    }
+
+    m_DialogueShotType = nextShot;
+    m_CameraSettings.dialogueCameraSettings.dialogueShotCounter++;
+}
+
+void Logic::CameraController::updateDialogueCamera() {
+    VobTypes::NpcVobInformation npc_vob = VobTypes::getVobFromScriptHandle(m_World, m_dialogueTargetNPCHandle);
+
+    VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_World,
+                                                            m_World.getScriptEngine().getPlayerEntity());
+
+    Math::Matrix pTrans = player.playerController->getEntityTransform();
+    Math::Matrix npcTrans = npc_vob.playerController->getEntityTransform();
+    Math::Matrix otherTrans, targetTrans;
+
+    // Can be either 1 or -1, flip the camera based on which character is speaking
+    float reverseShotModifier;
+
+    if (m_dialogueTargetName == player.playerController->getScriptInstance().name[0] && m_dontShowHero) {
+        // The PC_Hero is talking
+        otherTrans = npcTrans;
+        targetTrans = pTrans;
+        reverseShotModifier = -1.0;
+    } else {
+        // The other character is talking
+        otherTrans = pTrans;
+        targetTrans = npcTrans;
+        reverseShotModifier = 1.0;
+    }
+
+    // Pull further back based on distance between characters
+    float distance = (pTrans.Translation() - npcTrans.Translation()).length();
+
+    switch (m_DialogueShotType) {
+        case EDialogueShotType::Full: {
+            m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0);
+            m_ViewMatrix *= Math::Matrix::CreateTranslation(-1.5 * reverseShotModifier, 0.5, distance + 0.3);
+            Math::Matrix targetLookAt = targetTrans * Math::Matrix::CreateTranslation(0.0, 0.6, 0.0);
+            m_ViewMatrix = Math::Matrix::CreateLookAt(m_ViewMatrix.Translation(), targetLookAt.Translation(),
+                                                      otherTrans.Up());
+            m_ViewMatrix = m_ViewMatrix.Invert();
+            m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(),
+                                                          -0.3 * reverseShotModifier);
+        }
+            break;
+        case EDialogueShotType::OverTheShoulder: {
+            m_ViewMatrix = otherTrans.RotatedAroundLine(otherTrans.Translation(), otherTrans.Right(), 0.2);
+            m_ViewMatrix *= Math::Matrix::CreateTranslation(0.5 * reverseShotModifier, 0.8, -0.6);
+            m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), otherTrans.Up(),
+                                                          -0.55 * reverseShotModifier);
+        }
+            break;
+        case EDialogueShotType::Neutral: {
+            m_ViewMatrix = npcTrans.RotatedAroundLine(npcTrans.Translation(), npcTrans.Up(), Math::PI / 2);
+            m_ViewMatrix *= Math::Matrix::CreateTranslation((distance / 2) * -1, 0.5, distance * -1);
+        }
+            break;
+        case EDialogueShotType::CloseUp: {
+            m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Up(), Math::PI);
+            m_ViewMatrix *= Math::Matrix::CreateTranslation(-0.3 * reverseShotModifier, 0.8, -1.5);
+            m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(otherTrans.Translation(), otherTrans.Right(), 0.2);
+            m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), otherTrans.Up(),
+                                                          0.2 * reverseShotModifier);
+        }
+            break;
+    }
+}
+
+void Logic::CameraController::updateThirdPersonCamera(float deltaTime) {
+    VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_World, m_World.getScriptEngine().getPlayerEntity());
+
+    if (player.isValid()) {
+        const float verticalFactor = std::sin(m_CameraSettings.thirdPersonCameraSettings.cameraElevation);
+        const float horizontalFactor = std::cos(m_CameraSettings.thirdPersonCameraSettings.cameraElevation);
+        // TODO use movestate direction instead? (swimming not tested)
+        Math::Matrix pTrans = player.playerController->getEntityTransformFacing();
+        Math::float3 pdir;
+
+        // If player is currently using a mob check if camera should be locked
+        // If so, use last known position and finish rotating to it
+        VobTypes::MobVobInformation mob = VobTypes::asMobVob(m_World, player.playerController->getUsedMob());
+        if (!mob.isValid()) {
+            pdir = pTrans.Forward();
+        } else if (!mob.mobController->isCameraLocked()) {
+            pdir = pTrans.Forward();
+            m_savedPdir = pdir;
+        } else
+            pdir = m_savedPdir;
+
+        const float interpolationFraction = std::min(CAMERA_SMOOTHING * deltaTime, 1.0f);
+        m_CameraSettings.thirdPersonCameraSettings.currentOffsetDirection = Math::float3::lerp(
+                m_CameraSettings.thirdPersonCameraSettings.currentOffsetDirection,
+                pdir,
+                interpolationFraction);
+
+        pdir = m_CameraSettings.thirdPersonCameraSettings.currentOffsetDirection;
+
+
+        Components::AnimationComponent &anim = Components::Actions::initComponent<Components::AnimationComponent>(
+                player.world->getComponentAllocator(), player.entity);
+        const auto &playerSize = anim.getAnimHandler().getMeshLib().getBBoxMax();
+        const auto &width = playerSize.x;
+        const auto &height = playerSize.y;
+        const auto &length = playerSize.z;
+        float playerDimension = (width + height + length) / 3;
+
+        const auto &playerCenter = pTrans.Translation();
+
+        const Math::float3 up = Math::float3(0.0f, 1.0f, 0.0f);
+
+        float angle = m_CameraSettings.thirdPersonCameraSettings.pitch;
+        const auto &elevation = m_CameraSettings.thirdPersonCameraSettings.cameraElevation;
+        auto actualCameraAngle = Math::radiansToDegree(angle + elevation);
+
+        auto rotationAxisDir = pTrans.Left();
+
+        // cardinalPoint around which the camera will rotate vertically
+        auto cameraRotationCenter = playerCenter;
+        const auto &zoomExponent = m_CameraSettings.thirdPersonCameraSettings.zoomExponent;
+        float zoom = std::exp(zoomExponent * playerDimension);
+
+        Math::float3 newLookAt = cameraRotationCenter + verticalFactor * zoom * up;
+        Math::float3 newCamPos = newLookAt - horizontalFactor * zoom * pdir;
+
+        auto &deltaPhi = m_CameraSettings.thirdPersonCameraSettings.deltaPhi;
+        for (auto p : {&newLookAt, &newCamPos}) {
+            *p = Math::Matrix::rotatedPointAroundLine(*p, cameraRotationCenter, rotationAxisDir, angle);
+            // rotate camera around y-axis
+            // *p = Math::Matrix::rotatedPointAroundLine(*pc, pTrans.Translation(), pTrans.Up(), deltaPhi);
+        }
+
+        Math::float3 oldCamPos = getEntityTransform().Translation();
+        Math::float3 intCamPos = Math::float3::lerp(oldCamPos, newCamPos, interpolationFraction);
+
+        const Math::float3 &oldLookAt = m_CameraSettings.thirdPersonCameraSettings.currentLookAt;
+        m_CameraSettings.thirdPersonCameraSettings.currentLookAt = Math::float3::lerp(oldLookAt, newLookAt,
+                                                                                      interpolationFraction);
+
+        m_ViewMatrix = Math::Matrix::CreateLookAt(intCamPos,
+                                                  m_CameraSettings.thirdPersonCameraSettings.currentLookAt,
+                                                  up);
+
+        m_ViewMatrix = m_ViewMatrix.Invert();
+    }
+}
+
+void Logic::CameraController::updateFirstPersonCamera()
 {
     VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_World,
                                                             m_World.getScriptEngine().getPlayerEntity());
-    bool playerTalking = m_dialogueTargetName == player.playerController->getScriptInstance().name[0];
 
-    // Rule: use close-up and neutral only after at least two fulls or shoulders
-    // Rule: Only full or over-the-shoulder shot for PC_Hero
-    if (playerTalking || m_CameraSettings.dialogueCameraSettings.dialogueShotCounter <= m_CameraSettings.dialogueCameraSettings.dialogueShotLimit) {
-        // Rule: don't always cut to the hero. Leave chance for camera to stay on target NPC
-        m_dontShowHero = rand() % m_CameraSettings.dialogueCameraSettings.dontShowHeroChance != 0;
-        if (m_CameraSettings.dialogueCameraSettings.dialogueShotCounter == 0 || m_CameraSettings.dialogueCameraSettings.dialogueShotCounter > m_CameraSettings.dialogueCameraSettings.dialogueShotLimit) {
-            m_DialogueShotType = (EDialogueShotType) (rand() %
-                                                      2); // Only choose from first two (Full and OverTheShoulder)
-            m_CameraSettings.dialogueCameraSettings.dialogueShotCounter = m_CameraSettings.dialogueCameraSettings.dialogueShotLimit - 1; // Keep this shot for at least two dialogue bits
-        }
-    } else {
-        // Rule: After a neutral shot should only come a close-up
-        if (m_DialogueShotType == EDialogueShotType::Neutral && rand() % 4 == 0)
-            m_DialogueShotType = EDialogueShotType::CloseUp;
-        // Rule: No shot should come after a close-up
-        else if (m_DialogueShotType != EDialogueShotType::CloseUp)
-            m_DialogueShotType = (EDialogueShotType) (rand() % 4);
+    if (player.isValid()) {
+        auto &settings = m_CameraSettings.firstPersonCameraSettings;
+        Math::Matrix pTrans = player.playerController->getEntityTransform();
+        // TODO find position of player's head
+        m_ViewMatrix = pTrans.RotatedAroundLine(pTrans.Translation(), pTrans.Right(), settings.pitch);
+    }
+}
+
+void Logic::CameraController::updateFreeCamera(float deltaTime)
+{
+    auto &settings = m_CameraSettings.floatingCameraSettings;
+
+    // Get forward/right vector
+    std::tie(settings.forward, settings.right) = getDirectionVectors(settings.yaw, settings.pitch);
+    settings.up = settings.right.cross(settings.forward);
+
+    settings.forward *= deltaTime * 100.0f;
+    settings.right *= deltaTime * 100.0f;
+
+    m_ViewMatrix = Math::Matrix::CreateView(settings.position,
+                                            settings.yaw,
+                                            settings.pitch);
+
+    m_ViewMatrix = m_ViewMatrix.Invert();
+}
+
+void Logic::CameraController::updateViewerCamera()
+{
+    auto &settings = m_CameraSettings.viewerCameraSettings;
+
+    // getDirectionVectors only returns 2 of 3 direction vectors
+    std::tie(settings.in, settings.right) = getDirectionVectors(settings.yaw, settings.pitch);
+    settings.up = settings.right.cross(settings.in);
+
+    m_ViewMatrix = Math::Matrix::CreateLookAt(
+            settings.lookAt + settings.zoom * settings.in, settings.lookAt, settings.up);
+    m_ViewMatrix = m_ViewMatrix.Invert();
+}
+
+void Logic::CameraController::updateKeyedAnimationCamera(float deltaTime) {
+    if (m_Keyframes.empty() && m_KeyframeActive == -1.0f) {
+        return;
     }
 
-    m_CameraSettings.dialogueCameraSettings.dialogueShotCounter++;
+    std::pair<Math::float3, Math::float3> poslookat = updateKeyframedPlay(deltaTime);
+    m_ViewMatrix = Math::Matrix::CreateLookAt(
+            poslookat.first, poslookat.first + poslookat.second, Math::float3(0, 1, 0));
+    m_ViewMatrix = m_ViewMatrix.Invert();
 }
 
 void Logic::CameraController::onUpdateExplicit(float deltaTime)
 {
+    Math::Matrix nextViewMatrix;
     switch (m_CameraMode) {
         case ECameraMode::Dialogue:
-        {
-            VobTypes::NpcVobInformation npc_vob = VobTypes::getVobFromScriptHandle(m_World, m_dialogueTargetNPCHandle);
-
-            VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_World,
-                                                                    m_World.getScriptEngine().getPlayerEntity());
-
-            Math::Matrix pTrans = player.playerController->getEntityTransform();
-            Math::Matrix npcTrans = npc_vob.playerController->getEntityTransform();
-            Math::Matrix otherTrans, targetTrans;
-            float reverseShotModifier; // Makes the camera not cross the line when cutting between characters
-
-            if (m_dialogueTargetName == player.playerController->getScriptInstance().name[0] && m_dontShowHero)
-            {
-                // The PC is talking
-                otherTrans = npcTrans;
-                targetTrans = pTrans;
-                reverseShotModifier = -1.0;
-            }
-            else
-            {
-                // The other character is talking
-                otherTrans = pTrans;
-                targetTrans = npcTrans;
-                reverseShotModifier = 1.0;
-            }
-
-            // Pull further back based on distance between characters
-            float distance = (pTrans.Translation() - npcTrans.Translation()).length();
-
-            switch(m_DialogueShotType)
-            {
-                case EDialogueShotType::Full:
-                {
-                    m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0);
-                    m_ViewMatrix *= Math::Matrix::CreateTranslation(-1.5 * reverseShotModifier,0.5,distance + 0.3);
-                    Math::Matrix targetLookAt = targetTrans * Math::Matrix::CreateTranslation(0.0, 0.6, 0.0);
-                    m_ViewMatrix = Math::Matrix::CreateLookAt(m_ViewMatrix.Translation(), targetLookAt.Translation(), otherTrans.Up());
-                    m_ViewMatrix = m_ViewMatrix.Invert();
-                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), -0.3 * reverseShotModifier);
-                }
-                break;
-                case EDialogueShotType::OverTheShoulder:
-                {
-                    m_ViewMatrix = otherTrans.RotatedAroundLine(otherTrans.Translation(), otherTrans.Right(), 0.2);
-                    m_ViewMatrix *= Math::Matrix::CreateTranslation(0.5 * reverseShotModifier,0.8,-0.6);
-                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), otherTrans.Up(), -0.55 * reverseShotModifier);
-                }
-                break;
-                case EDialogueShotType::Neutral:
-                {
-                    m_ViewMatrix = npcTrans.RotatedAroundLine(npcTrans.Translation(), npcTrans.Up(), Math::PI/2);
-                    m_ViewMatrix *= Math::Matrix::CreateTranslation((distance/2)*-1,0.5,distance*-1);
-                }
-                break;
-                case EDialogueShotType::CloseUp:
-                {
-                    m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Up(), Math::PI);
-                    m_ViewMatrix *= Math::Matrix::CreateTranslation(-0.3 * reverseShotModifier, 0.8, -1.5);
-                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(otherTrans.Translation(), otherTrans.Right(), 0.2);
-                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), otherTrans.Up(), 0.2 * reverseShotModifier);
-                }
-                break;
-            }
-
-            // Set camera transform to new position
-            setEntityTransform(m_ViewMatrix);
-        }
+            updateDialogueCamera();
             break;
-
         case ECameraMode::ThirdPerson:
-        {
-            VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_World, m_World.getScriptEngine().getPlayerEntity());
-
-            if (player.isValid()) {
-                const float verticalFactor = std::sin(m_CameraSettings.thirdPersonCameraSettings.cameraElevation);
-                const float horizontalFactor = std::cos(m_CameraSettings.thirdPersonCameraSettings.cameraElevation);
-                // TODO use movestate direction instead? (swimming not tested)
-                Math::Matrix pTrans = player.playerController->getEntityTransformFacing();
-                Math::float3 pdir;
-
-                // If player is currently using a mob check if camera should be locked
-                // If so, use last known position and finish rotating to it
-                VobTypes::MobVobInformation mob = VobTypes::asMobVob(m_World, player.playerController->getUsedMob());
-                if (!mob.isValid()) {
-                    pdir = pTrans.Forward();
-                } else if (!mob.mobController->isCameraLocked()) {
-                    pdir = pTrans.Forward();
-                    m_savedPdir = pdir;
-                } else
-                    pdir = m_savedPdir;
-
-                const float interpolationFraction = std::min(CAMERA_SMOOTHING * deltaTime, 1.0f);
-                m_CameraSettings.thirdPersonCameraSettings.currentOffsetDirection = Math::float3::lerp(
-                        m_CameraSettings.thirdPersonCameraSettings.currentOffsetDirection,
-                        pdir,
-                        interpolationFraction);
-
-                pdir = m_CameraSettings.thirdPersonCameraSettings.currentOffsetDirection;
-
-
-                Components::AnimationComponent &anim = Components::Actions::initComponent<Components::AnimationComponent>(
-                        player.world->getComponentAllocator(), player.entity);
-                const auto &playerSize = anim.getAnimHandler().getMeshLib().getBBoxMax();
-                const auto &width = playerSize.x;
-                const auto &height = playerSize.y;
-                const auto &length = playerSize.z;
-                float playerDimension = (width + height + length) / 3;
-
-                const auto &playerCenter = pTrans.Translation();
-
-                const Math::float3 up = Math::float3(0.0f, 1.0f, 0.0f);
-
-                float angle = m_CameraSettings.thirdPersonCameraSettings.pitch;
-                const auto &elevation = m_CameraSettings.thirdPersonCameraSettings.cameraElevation;
-                auto actualCameraAngle = Math::radiansToDegree(angle + elevation);
-
-                auto rotationAxisDir = pTrans.Left();
-
-                // cardinalPoint around which the camera will rotate vertically
-                auto cameraRotationCenter = playerCenter;
-                const auto &zoomExponent = m_CameraSettings.thirdPersonCameraSettings.zoomExponent;
-                float zoom = std::exp(zoomExponent * playerDimension);
-
-                Math::float3 newLookAt = cameraRotationCenter + verticalFactor * zoom * up;
-                Math::float3 newCamPos = newLookAt - horizontalFactor * zoom * pdir;
-
-                auto &deltaPhi = m_CameraSettings.thirdPersonCameraSettings.deltaPhi;
-                for (auto p : {&newLookAt, &newCamPos}) {
-                    *p = Math::Matrix::rotatedPointAroundLine(*p, cameraRotationCenter, rotationAxisDir, angle);
-                    // rotate camera around y-axis
-                    // *p = Math::Matrix::rotatedPointAroundLine(*pc, pTrans.Translation(), pTrans.Up(), deltaPhi);
-                }
-
-                Math::float3 oldCamPos = getEntityTransform().Translation();
-                Math::float3 intCamPos = Math::float3::lerp(oldCamPos, newCamPos, interpolationFraction);
-
-                const Math::float3 &oldLookAt = m_CameraSettings.thirdPersonCameraSettings.currentLookAt;
-                m_CameraSettings.thirdPersonCameraSettings.currentLookAt = Math::float3::lerp(oldLookAt, newLookAt,
-                                                                                              interpolationFraction);
-
-                m_ViewMatrix = Math::Matrix::CreateLookAt(intCamPos,
-                                                          m_CameraSettings.thirdPersonCameraSettings.currentLookAt,
-                                                          up);
-
-                setEntityTransform(m_ViewMatrix.Invert());
-            }
-        }
+            updateThirdPersonCamera(deltaTime);
             break;
-
-        case ECameraMode::FirstPerson: {
-            VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_World,
-                                                                    m_World.getScriptEngine().getPlayerEntity());
-
-            if (player.isValid()) {
-                auto &settings = m_CameraSettings.firstPersonCameraSettings;
-                Math::Matrix pTrans = player.playerController->getEntityTransform();
-                // TODO find position of player's head
-                m_ViewMatrix = pTrans.RotatedAroundLine(pTrans.Translation(), pTrans.Right(), settings.pitch);
-                setEntityTransform(m_ViewMatrix);
-            }
-        }
+        case ECameraMode::FirstPerson:
+            updateFirstPersonCamera();
             break;
-
-        case ECameraMode::Free: {
-            auto &settings = m_CameraSettings.floatingCameraSettings;
-
-            // Get forward/right vector
-            std::tie(settings.forward, settings.right) = getDirectionVectors(settings.yaw, settings.pitch);
-            settings.up = settings.right.cross(settings.forward);
-
-            settings.forward *= deltaTime * 100.0f;
-            settings.right *= deltaTime * 100.0f;
-
-            m_ViewMatrix = Math::Matrix::CreateView(settings.position,
-                                                    settings.yaw,
-                                                    settings.pitch);
-
-            setEntityTransform(m_ViewMatrix.Invert());
-        }
+        case ECameraMode::Free:
+            updateFreeCamera(deltaTime);
             break;
-
-        case ECameraMode::Viewer: {
-            auto &settings = m_CameraSettings.viewerCameraSettings;
-
-            // getDirectionVectors only returns 2 of 3 direction vectors
-            std::tie(settings.in, settings.right) = getDirectionVectors(settings.yaw, settings.pitch);
-            settings.up = settings.right.cross(settings.in);
-
-            m_ViewMatrix = Math::Matrix::CreateLookAt(
-                    settings.lookAt + settings.zoom * settings.in, settings.lookAt, settings.up);
-            setEntityTransform(m_ViewMatrix.Invert());
-        }
+        case ECameraMode::Viewer:
+            updateViewerCamera();
             break;
-
-        case ECameraMode::KeyedAnimation: {
-            if (!m_Keyframes.empty() && m_KeyframeActive != -1.0f) {
-                std::pair<Math::float3, Math::float3> poslookat = updateKeyframedPlay(deltaTime);
-                m_ViewMatrix = Math::Matrix::CreateLookAt(
-                        poslookat.first, poslookat.first + poslookat.second, Math::float3(0, 1, 0));
-                setEntityTransform(m_ViewMatrix.Invert());
-            }
-        }
+        case ECameraMode::KeyedAnimation:
+            updateKeyedAnimationCamera(deltaTime);
             break;
-
-        case ECameraMode::Static: {
+        case ECameraMode::Static:
             //TODO add handling there?
-        }
             break;
     }
+    setEntityTransform(m_ViewMatrix);
 }
 
 std::pair<Math::float3, Math::float3> Logic::CameraController::getDirectionVectors(float yaw, float pitch)

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -269,25 +269,23 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
                 mirror_modifier = 1.0;
             }
 
-            m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0);
-
             // This is (roughly) the same as the full shot from the original
             switch(m_ShotType)
             {
                 case EDialogueShotType::Full:
                 {
-
                     // TODO make camera LOOK-AT target character
-                    m_ViewMatrix *= Math::Matrix::CreateTranslation(2.0 * mirror_modifier,0.5,-1.0); // right, up, back
-                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), -0.75);
+                    m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0);
+                    m_ViewMatrix *= Math::Matrix::CreateTranslation(1.5 * mirror_modifier,0.5,-0.3); // right, up, back
+                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), -1.0 * mirror_modifier);
                 }
                 break;
                 case EDialogueShotType ::OverTheShoulder:
                 {
                     // TODO make camera LOOK-AT target character
+                    m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0.15);
                     m_ViewMatrix *= Math::Matrix::CreateTranslation(0.5 * mirror_modifier,0.65,-0.5);
-                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), -0.45 * mirror_modifier);
-                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Right(), 0.15);
+                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), targetTrans.Up(), -0.45 * mirror_modifier);
                 }
                 break;
                 case EDialogueShotType ::CloseUp:

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -277,7 +277,7 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
                     // TODO Pull further back based on distance between characters
                 }
                 break;
-                case EDialogueShotType ::OverTheShoulder:
+                case EDialogueShotType::OverTheShoulder:
                 {
                     m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0.2);
                     m_ViewMatrix *= Math::Matrix::CreateTranslation(0.5 * reverseShotModifier,0.8,-0.6);
@@ -285,10 +285,16 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
                     m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), targetTrans.Up(), -0.55 * reverseShotModifier);
                 }
                 break;
-                case EDialogueShotType ::CloseUp:
+                case EDialogueShotType::Neutral:
+                {
+                    m_ViewMatrix = npcTrans.RotatedAroundLine(npcTrans.Translation(), npcTrans.Up(), Math::PI/2);
+                    m_ViewMatrix *= Math::Matrix::CreateTranslation(-0.8/*in the middle of them*/,0.5,-2.0/*pull back until both characters are in frame*/); // right, up, front
+                }
+                break;
+                case EDialogueShotType::CloseUp:
                 {
                     m_ViewMatrix = otherTrans.RotatedAroundLine(otherTrans.Translation(), otherTrans.Up(), Math::PI);
-                    m_ViewMatrix *= Math::Matrix::CreateTranslation(-0.2 * reverseShotModifier, 0.8, -1.5);
+                    m_ViewMatrix *= Math::Matrix::CreateTranslation(-0.3 * reverseShotModifier, 0.8, -1.5);
                     m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0.2);
                     m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), targetTrans.Up(), 0.2 * reverseShotModifier);
                 }

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -272,24 +272,31 @@ void Logic::CameraController::onUpdateExplicit(float deltaTime)
             m_ViewMatrix = targetTrans.RotatedAroundLine(targetTrans.Translation(), targetTrans.Right(), 0);
 
             // This is (roughly) the same as the full shot from the original
-            if (false)
+            switch(m_ShotType)
             {
-                // TODO make camera LOOK-AT target character
-                m_ViewMatrix *= Math::Matrix::CreateTranslation(2.0 * mirror_modifier,0.5,-1.0); // right, up, back
-                m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), -0.75);
-            }
+                case EDialogueShotType::Full:
+                {
 
-            // This is (roughly) the same as the over-the-shoulder shot from the original
-            if (false)
-            {
-                // TODO make camera LOOK-AT target character
-                m_ViewMatrix *= Math::Matrix::CreateTranslation(0.5 * mirror_modifier,0.65,-0.5);
-                m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), -0.45 * mirror_modifier);
-                m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Right(), 0.15);
+                    // TODO make camera LOOK-AT target character
+                    m_ViewMatrix *= Math::Matrix::CreateTranslation(2.0 * mirror_modifier,0.5,-1.0); // right, up, back
+                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), -0.75);
+                }
+                break;
+                case EDialogueShotType ::OverTheShoulder:
+                {
+                    // TODO make camera LOOK-AT target character
+                    m_ViewMatrix *= Math::Matrix::CreateTranslation(0.5 * mirror_modifier,0.65,-0.5);
+                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Up(), -0.45 * mirror_modifier);
+                    m_ViewMatrix = m_ViewMatrix.RotatedAroundLine(m_ViewMatrix.Translation(), m_ViewMatrix.Right(), 0.15);
+                }
+                break;
+                case EDialogueShotType ::CloseUp:
+                {
+                    m_ViewMatrix = otherTrans.RotatedAroundLine(otherTrans.Translation(), otherTrans.Up(), Math::PI);
+                    m_ViewMatrix *= Math::Matrix::CreateTranslation(0.0, 0.5, -1.0);
+                }
+                break;
             }
-
-            m_ViewMatrix = otherTrans.RotatedAroundLine(otherTrans.Translation(), otherTrans.Up(), Math::PI);
-            m_ViewMatrix *= Math::Matrix::CreateTranslation(0.0, 0.5, -1.0);
 
             // Set camera transform to new position
             setEntityTransform(m_ViewMatrix);
@@ -482,6 +489,7 @@ void Logic::CameraController::setCameraMode(Logic::CameraController::ECameraMode
             Engine::Input::setMouseLock(true);
             break;
         case ECameraMode::Dialogue:
+            newDialogShot();
             Engine::Input::setMouseLock(true);
             break;
         case ECameraMode::KeyedAnimation:

--- a/src/logic/CameraController.cpp
+++ b/src/logic/CameraController.cpp
@@ -245,7 +245,7 @@ void Logic::CameraController::nextDialogueShot() {
     VobTypes::NpcVobInformation player = VobTypes::asNpcVob(m_World,
                                                             m_World.getScriptEngine().getPlayerEntity());
 
-    EDialogueShotType nextShot;
+    EDialogueShotType nextShot = m_DialogueShotType;
     bool playerTalking = m_dialogueTargetName == player.playerController->getScriptInstance().name[0];
 
     // Rule: Use close-up and neutral only after at least two fulls or shoulders

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -23,8 +23,8 @@ namespace Logic
         enum class EDialogueShotType
         {
             Full,
-            Neutral,
             OverTheShoulder,
+            Neutral,
             CloseUp,
         };
 
@@ -161,10 +161,7 @@ namespace Logic
         /**
          * Randomly chooses one of the dialogue shot types to cut to
          */
-        void nextDialogueShot()
-        {
-            m_DialogueShotType = (EDialogueShotType)(rand() % 4);
-        }
+        void nextDialogueShot();
 
         /**
          * @brief Sets whether this controller should read input

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -105,8 +105,11 @@ namespace Logic
 
             struct
             {
+                // Counter used for shot progression during dialog
                 int dialogueShotCounter;
+                // The counter limit after which more shot types can be used
                 int dialogueShotLimit;
+                // Likelihood of the camera staying on target NPC when PC_Hero speaks
                 int dontShowHeroChance;
             } dialogueCameraSettings;
         };
@@ -179,6 +182,36 @@ namespace Logic
          * @brief Sets whether this controller should read input
          */
         void setActive(bool active);
+
+        /**
+         * Updates the camera according to dialogue camera rules
+         */
+        void updateDialogueCamera();
+
+        /**
+         * Updates the camera according to third person camera rules
+         */
+        void updateThirdPersonCamera(float deltaTime);
+
+        /**
+         * Updates the camera according to first person camera rules
+         */
+        void updateFirstPersonCamera();
+
+        /**
+         * Updates the camera according to free camera rules
+         */
+        void updateFreeCamera(float deltaTime);
+        /**
+         * Updates the camera according to viewer camera rules
+         */
+
+        void updateViewerCamera();
+
+        /**
+         * Updates the camera according to keyed animation camera rules
+         */
+        void updateKeyedAnimationCamera(float deltaTime);
 
         /**
          * Sets the entity to follow in the first/third person camera modes

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -202,8 +202,6 @@ namespace Logic
          * Plays all stored keyframes
          */
         void playKeyframes(float duration = 1.0f);
-
-
     protected:
 
         /**
@@ -246,11 +244,11 @@ namespace Logic
          */
         void switchModeActions(ECameraMode mode);
 
-
         /**
          * Whether this controller should read player input
          */
         bool m_Active;
+
 
         /**
          * How the camera should behave regarding the followed entity

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -102,6 +102,13 @@ namespace Logic
                 Math::float3 up, right, in;
                 float yaw, pitch, zoom;
             } viewerCameraSettings;
+
+            struct
+            {
+                int dialogueShotCounter;
+                int dialogueShotLimit;
+                int dontShowHeroChance;
+            } dialogueCameraSettings;
         };
 
         /**
@@ -139,6 +146,11 @@ namespace Logic
         {
             setCameraMode(m_savedCameraMode);
         }
+
+        /**
+         * Reset m_neutralShotCounter to 0 in order to begin camera progression from start
+         */
+        void resetCameraProgression() {m_CameraSettings.dialogueCameraSettings.dialogueShotCounter = 0;}
 
         /**
          * Sets the name of the character that is speaking
@@ -265,15 +277,23 @@ namespace Logic
         ECameraMode m_CameraMode;
 
         /**
-         * What camera angle is used during dialog
+         * What camera angle is used during dialogue
          */
         EDialogueShotType  m_DialogueShotType;
 
         /**
-         * Remember camera mode (i.e. for dialog) to restore it later
+         * Tracks whether camera should show PC_hero when talking, or other character
+         */
+        bool m_dontShowHero;
+
+        /**
+         * Remember camera mode (i.e. for dialogue) to restore it later
          */
         ECameraMode m_savedCameraMode;
 
+        /**
+         * Name of NPC the dialogue camera should point at
+         */
         std::string m_dialogueTargetName;
 
         /**

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -23,6 +23,7 @@ namespace Logic
         enum class EDialogueShotType
         {
             Full,
+            Neutral,
             OverTheShoulder,
             CloseUp,
         };
@@ -162,7 +163,7 @@ namespace Logic
          */
         void nextDialogueShot()
         {
-            m_DialogueShotType = (EDialogueShotType)(rand() % 3);
+            m_DialogueShotType = (EDialogueShotType)(rand() % 4);
         }
 
         /**

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -139,16 +139,27 @@ namespace Logic
             setCameraMode(m_savedCameraMode);
         }
 
+        /**
+         * Sets the name of the character that is speaking
+         * @param target name of NPC
+         */
         void setDialogueTargetName(std::string &target)
         {
             m_dialogueTargetName = target;
         }
 
+        /**
+         * Sets the NPC handle of the character the player is talking to
+         * @param npc NPCHandle of NPC
+         */
         void setDialogueTargetNPCHandle(Daedalus::GameState::NpcHandle npc)
         {
             m_dialogueTargetNPCHandle = npc;
         }
 
+        /**
+         * Randomly chooses one of the dialogue shot types to cut to
+         */
         void nextDialogueShot()
         {
             m_DialogueShotType = (EDialogueShotType)(rand() % 3);

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -13,11 +13,18 @@ namespace Logic
         {
             ThirdPerson,
             FirstPerson,
-            Dialog,
+            Dialogue,
             Free,
             Viewer, // name is open to change
             Static,
             KeyedAnimation,
+        };
+
+        enum class EDialogueShotType
+        {
+            Full,
+            OverTheShoulder,
+            CloseUp,
         };
 
         struct CameraSettings

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -13,6 +13,7 @@ namespace Logic
         {
             ThirdPerson,
             FirstPerson,
+            Dialog,
             Free,
             Viewer, // name is open to change
             Static,
@@ -120,8 +121,17 @@ namespace Logic
          * @return ECameraMode camera mode
          */
         ECameraMode getCameraMode() {
-         return m_CameraMode;
+            return m_CameraMode;
         }
+
+        /**
+         * Sets camera mode to mode before last setCameraMode() call
+         */
+        void restoreCameraMode()
+        {
+            setCameraMode(m_savedCameraMode);
+        }
+
 
         /**
          * @brief Sets whether this controller should read input
@@ -171,6 +181,8 @@ namespace Logic
          * Plays all stored keyframes
          */
         void playKeyframes(float duration = 1.0f);
+
+
     protected:
 
         /**
@@ -213,16 +225,21 @@ namespace Logic
          */
         void switchModeActions(ECameraMode mode);
 
+
         /**
          * Whether this controller should read player input
          */
         bool m_Active;
 
-
         /**
          * How the camera should behave regarding the followed entity
          */
         ECameraMode m_CameraMode;
+
+        /**
+         * Remember camera mode (i.e. for dialog) to restore it later
+         */
+        ECameraMode m_savedCameraMode;
 
         /**
          * Entity this is attached to
@@ -268,9 +285,12 @@ namespace Logic
         float m_KeyframeActive;
         float m_KeyframeDuration;
 
-	/**
-         * Direction to use during locked camera while using mobs
-         */
+
+        Daedalus::GameState::NpcHandle m_DialogTarget;
+
+        /**
+             * Direction to use during locked camera while using mobs
+             */
         Math::float3 m_savedPdir;
     };
 }

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -139,19 +139,19 @@ namespace Logic
             setCameraMode(m_savedCameraMode);
         }
 
-        void setDialogTarget(std::string& target)
+        void setDialogueTargetName(std::string &target)
         {
-            m_dialogName = target;
+            m_dialogueTargetName = target;
         }
 
-        void setNPCTarget(Daedalus::GameState::NpcHandle npc)
+        void setDialogueTargetNPCHandle(Daedalus::GameState::NpcHandle npc)
         {
-            m_NPCTarget = npc;
+            m_dialogueTargetNPCHandle = npc;
         }
 
-        void newDialogShot()
+        void nextDialogueShot()
         {
-            m_ShotType = (EDialogueShotType)(rand() % 3);
+            m_DialogueShotType = (EDialogueShotType)(rand() % 3);
         }
 
         /**
@@ -260,14 +260,14 @@ namespace Logic
         /**
          * What camera angle is used during dialog
          */
-        EDialogueShotType  m_ShotType;
+        EDialogueShotType  m_DialogueShotType;
 
         /**
          * Remember camera mode (i.e. for dialog) to restore it later
          */
         ECameraMode m_savedCameraMode;
 
-        std::string m_dialogName;
+        std::string m_dialogueTargetName;
 
         /**
          * Entity this is attached to
@@ -314,7 +314,7 @@ namespace Logic
         float m_KeyframeDuration;
 
 
-        Daedalus::GameState::NpcHandle m_NPCTarget;
+        Daedalus::GameState::NpcHandle m_dialogueTargetNPCHandle;
 
         /**
              * Direction to use during locked camera while using mobs

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -132,6 +132,15 @@ namespace Logic
             setCameraMode(m_savedCameraMode);
         }
 
+        void setDialogTarget(std::string& target)
+        {
+            m_dialogName = target;
+        }
+
+        void setNPCTarget(Daedalus::GameState::NpcHandle npc)
+        {
+            m_NPCTarget = npc;
+        }
 
         /**
          * @brief Sets whether this controller should read input
@@ -241,6 +250,8 @@ namespace Logic
          */
         ECameraMode m_savedCameraMode;
 
+        std::string m_dialogName;
+
         /**
          * Entity this is attached to
          */
@@ -286,7 +297,7 @@ namespace Logic
         float m_KeyframeDuration;
 
 
-        Daedalus::GameState::NpcHandle m_DialogTarget;
+        Daedalus::GameState::NpcHandle m_NPCTarget;
 
         /**
              * Direction to use during locked camera while using mobs

--- a/src/logic/CameraController.h
+++ b/src/logic/CameraController.h
@@ -149,6 +149,11 @@ namespace Logic
             m_NPCTarget = npc;
         }
 
+        void newDialogShot()
+        {
+            m_ShotType = (EDialogueShotType)(rand() % 3);
+        }
+
         /**
          * @brief Sets whether this controller should read input
          */
@@ -251,6 +256,11 @@ namespace Logic
          * How the camera should behave regarding the followed entity
          */
         ECameraMode m_CameraMode;
+
+        /**
+         * What camera angle is used during dialog
+         */
+        EDialogueShotType  m_ShotType;
 
         /**
          * Remember camera mode (i.e. for dialog) to restore it later

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -523,6 +523,7 @@ void DialogManager::startDialog(NpcHandle npc, NpcHandle player)
     m_ProcessInfos = true;
     m_DialogActive = true;
     m_World.getCameraController()->setCameraMode(CameraController::ECameraMode::Dialog);
+    m_World.getCameraController()->setNPCTarget(npc);
     m_World.getEngine()->getHud().setGameplayHudVisible(false);
     updateChoices(npc);
 }

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "DialogManager.h"
+#include "CameraController.h"
 #include <components/VobClasses.h>
 #include <engine/BaseEngine.h>
 #include <engine/World.h>
@@ -325,6 +326,8 @@ void DialogManager::endDialog()
 
     if (targetVob.isValid())
         targetVob.playerController->getEM().onMessage(msg, playerVob.entity);
+
+    m_World.getCameraController()->restoreCameraMode();
 }
 
 bool DialogManager::init()
@@ -519,6 +522,7 @@ void DialogManager::startDialog(NpcHandle npc, NpcHandle player)
     m_Interaction.target = npc;
     m_ProcessInfos = true;
     m_DialogActive = true;
+    m_World.getCameraController()->setCameraMode(CameraController::ECameraMode::Dialog);
     m_World.getEngine()->getHud().setGameplayHudVisible(false);
     updateChoices(npc);
 }

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -273,7 +273,6 @@ void DialogManager::performChoice(size_t choice)
     {
         m_Interaction.currentInfo = infoHandle;
     }
-
 }
 
 void DialogManager::assessTalk(NpcHandle target)

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -234,10 +234,6 @@ void DialogManager::performChoice(size_t choice)
         // case: we are in a subdialog
         info.removeChoice(choice);
     }
-    else
-    {
-        m_World.getCameraController()->nextDialogueShot();
-    }
 
     // Set instances again, since they could have been changed across the frames
     // C_Info's callback needs global self/other

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -234,6 +234,10 @@ void DialogManager::performChoice(size_t choice)
         // case: we are in a subdialog
         info.removeChoice(choice);
     }
+    else
+    {
+        m_World.getCameraController()->nextDialogueShot();
+    }
 
     // Set instances again, since they could have been changed across the frames
     // C_Info's callback needs global self/other
@@ -269,6 +273,7 @@ void DialogManager::performChoice(size_t choice)
     {
         m_Interaction.currentInfo = infoHandle;
     }
+
 }
 
 void DialogManager::assessTalk(NpcHandle target)
@@ -524,7 +529,8 @@ void DialogManager::startDialog(NpcHandle npc, NpcHandle player)
     m_ProcessInfos = true;
     m_DialogActive = true;
     m_World.getCameraController()->setCameraMode(CameraController::ECameraMode::Dialogue);
-    m_World.getCameraController()->setNPCTarget(npc);
+    m_World.getCameraController()->setDialogueTargetNPCHandle(npc);
+    m_World.getCameraController()->nextDialogueShot();
     m_World.getEngine()->getHud().setGameplayHudVisible(false);
     m_World.getEngine()->getSession().enableActionBindings(false);
     updateChoices(npc);

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -522,7 +522,7 @@ void DialogManager::startDialog(NpcHandle npc, NpcHandle player)
     m_Interaction.target = npc;
     m_ProcessInfos = true;
     m_DialogActive = true;
-    m_World.getCameraController()->setCameraMode(CameraController::ECameraMode::Dialog);
+    m_World.getCameraController()->setCameraMode(CameraController::ECameraMode::Dialogue);
     m_World.getCameraController()->setNPCTarget(npc);
     m_World.getEngine()->getHud().setGameplayHudVisible(false);
     updateChoices(npc);

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -269,6 +269,8 @@ void DialogManager::performChoice(size_t choice)
     {
         m_Interaction.currentInfo = infoHandle;
     }
+
+    m_World.getCameraController()->resetCameraProgression();
 }
 
 void DialogManager::assessTalk(NpcHandle target)

--- a/src/logic/DialogManager.cpp
+++ b/src/logic/DialogManager.cpp
@@ -328,6 +328,7 @@ void DialogManager::endDialog()
         targetVob.playerController->getEM().onMessage(msg, playerVob.entity);
 
     m_World.getCameraController()->restoreCameraMode();
+    m_World.getEngine()->getSession().enableActionBindings(true);
 }
 
 bool DialogManager::init()
@@ -525,5 +526,6 @@ void DialogManager::startDialog(NpcHandle npc, NpcHandle player)
     m_World.getCameraController()->setCameraMode(CameraController::ECameraMode::Dialogue);
     m_World.getCameraController()->setNPCTarget(npc);
     m_World.getEngine()->getHud().setGameplayHudVisible(false);
+    m_World.getEngine()->getSession().enableActionBindings(false);
     updateChoices(npc);
 }

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -8,6 +8,7 @@
 #include <json.hpp>
 #include <stdlib.h>
 #include "visuals/ModelVisual.h"
+#include "CameraController.h"
 #include <audio/AudioEngine.h>
 #include <components/Entities.h>
 #include <components/Vob.h>
@@ -1008,6 +1009,7 @@ bool PlayerController::EV_Conversation(std::shared_ptr<EventMessages::Conversati
                 {
                     m_World.getDialogManager().setCurrentMessage(sharedMessage);
                     m_World.getDialogManager().displaySubtitle(message.text, getScriptInstance().name[0]);
+                    m_World.getCameraController()->setDialogTarget(getScriptInstance().name[0]); //TODO refactor so that name[0] only gets accessed once
                     subtitleBox.setScaling(0.0);
                     subtitleBox.setGrowDirection(+1.0f);
                 }

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1001,19 +1001,21 @@ bool PlayerController::EV_Conversation(std::shared_ptr<EventMessages::Conversati
             {
                 message.status = ConversationMessage::Status::PLAYING;
 
-                // Play the random dialog gesture
-                startDialogAnimation();
-                // Play sound of this conv-message
-                message.soundTicket = m_World.getAudioWorld().playSound(message.name, getEntityTransform().Translation(), DEFAULT_CHARACTER_SOUND_RANGE);
                 if (!isMonolog)
                 {
                     m_World.getDialogManager().setCurrentMessage(sharedMessage);
                     std::string characterName = getScriptInstance().name[0];
                     m_World.getDialogManager().displaySubtitle(message.text, characterName);
                     m_World.getCameraController()->setDialogueTargetName(characterName);
+                    m_World.getCameraController()->nextDialogueShot();
                     subtitleBox.setScaling(0.0);
                     subtitleBox.setGrowDirection(+1.0f);
                 }
+
+                // Play the random dialog gesture
+                startDialogAnimation();
+                // Play sound of this conv-message
+                message.soundTicket = m_World.getAudioWorld().playSound(message.name, getEntityTransform().Translation(), DEFAULT_CHARACTER_SOUND_RANGE);
             }
 
             if (message.status == ConversationMessage::Status::PLAYING)

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1008,8 +1008,10 @@ bool PlayerController::EV_Conversation(std::shared_ptr<EventMessages::Conversati
                 if (!isMonolog)
                 {
                     m_World.getDialogManager().setCurrentMessage(sharedMessage);
-                    m_World.getDialogManager().displaySubtitle(message.text, getScriptInstance().name[0]);
-                    m_World.getCameraController()->setDialogTarget(getScriptInstance().name[0]); //TODO refactor so that name[0] only gets accessed once
+                    std::string characterName = getScriptInstance().name[0];
+                    m_World.getDialogManager().displaySubtitle(message.text, characterName);
+                    m_World.getCameraController()->setDialogTarget(characterName);
+                    m_World.getCameraController()->newDialogShot();
                     subtitleBox.setScaling(0.0);
                     subtitleBox.setGrowDirection(+1.0f);
                 }

--- a/src/logic/PlayerController.cpp
+++ b/src/logic/PlayerController.cpp
@@ -1010,8 +1010,7 @@ bool PlayerController::EV_Conversation(std::shared_ptr<EventMessages::Conversati
                     m_World.getDialogManager().setCurrentMessage(sharedMessage);
                     std::string characterName = getScriptInstance().name[0];
                     m_World.getDialogManager().displaySubtitle(message.text, characterName);
-                    m_World.getCameraController()->setDialogTarget(characterName);
-                    m_World.getCameraController()->newDialogShot();
+                    m_World.getCameraController()->setDialogueTargetName(characterName);
                     subtitleBox.setScaling(0.0);
                     subtitleBox.setGrowDirection(+1.0f);
                 }

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -257,7 +257,7 @@ void UI::Hud::onInputAction(Engine::ActionType action)
 {
     using Engine::ActionType;
 
-    if (!m_pLoadingScreen->isHidden())
+    if (!m_pLoadingScreen->isHidden() || !m_pIntroduceChapterView->isHidden())
         return;
 
     if (!m_pIntroduceChapterView->isHidden() && action == ActionType::UI_ToggleMainMenu)

--- a/src/ui/Hud.cpp
+++ b/src/ui/Hud.cpp
@@ -257,7 +257,7 @@ void UI::Hud::onInputAction(Engine::ActionType action)
 {
     using Engine::ActionType;
 
-    if (!m_pLoadingScreen->isHidden() || !m_pIntroduceChapterView->isHidden())
+    if (!m_pLoadingScreen->isHidden())
         return;
 
     if (!m_pIntroduceChapterView->isHidden() && action == ActionType::UI_ToggleMainMenu)


### PR DESCRIPTION
Defined camera transformations (shot types) and a state machine to decide between them during dialogs with NPCs.

There are 4 shot types:
 - Full shot
 - Over the shoulder shot
 - Neutral shot
 - Close up shot

 In order to keep shot progression feeling natural, Full and Over the shoulder shots
 should be used a couple times before opening up the chance to move on to Neutral and Close Up
 shots. Furthermore, the camera should only push further in and not back out once it progressed
 to at least a Neutral shot.
 
 Dialog shot progression therefore respects the following rules:
 - Always start with either a Full or Over the shoulder shot
 - Close up and Neutral shot can only be used after Full or Over the shoulder have been used at least as often as m_CameraSettings.dialogueCameraSettings.dialogueShotLimit specifies
 - After a Neutral shot, the only possible next shot can be a Close up
 - A Close up can only be followed by a Close up

 Regarding the PC_Hero the following extra rules apply:
 - PC_Hero will only ever be shown via a Full or Over the shoulder shot
 - There is a chance that the camera does not cut to PC_Hero and stays on the target NPC

----------------------

On a more personal note: Unfortunately I had to bail from working on this wonderful project and can't tell when I might able to return. So I thought I should just create this pull request, since it works well despite being quite basic still.
I would have liked to figure out how to keep the camera from clipping through walls (even though that is a rare event anyway) and to emulate the original behaviour more closely (like, talking to Lord Hagen flips the camera depending on which side of his you are standing on when speaking to him).

-------------------
Feedback is still massively appreciated! I will read it all and still try to fix bugs and make reasonable improvements. Thank you for your time :smiley: 